### PR TITLE
Adjust code to avoid some clippy warnings

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -44,8 +44,8 @@ jobs:
         run: cargo machete .
         continue-on-error: true
 
-      - name: Check format
+      - name: Check code format
         run: cargo fmt --all -- --check
 
       - name: Run linter
-        run: cargo clippy -- -A clippy::module_inception -A clippy::new_ret_no_self
+        run: cargo clippy -- -A clippy::module_inception

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,6 +38,7 @@ jobs:
 
       - name: Install cargo-machete
         run: cargo install cargo-machete
+        continue-on-error: true
 
       - name: Analyze dependencies
         run: cargo machete .

--- a/offchain/dispatcher/src/auth.rs
+++ b/offchain/dispatcher/src/auth.rs
@@ -58,14 +58,13 @@ pub struct AuthEnvCLIConfig {
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::upper_case_acronyms)]
 pub enum AuthConfig {
     Mnemonic {
         mnemonic: String,
         account_index: Option<u32>,
     },
 
-    AWS {
+    Aws {
         key_id: String,
         region: Region,
     },
@@ -95,7 +94,7 @@ impl AuthConfig {
                 (Some(key_id), Some(region)) => {
                     let region = Region::from_str(&region)
                         .context(InvalidRegionSnafu)?;
-                    Ok(AuthConfig::AWS { key_id, region })
+                    Ok(AuthConfig::Aws { key_id, region })
                 }
             }
         }

--- a/offchain/dispatcher/src/signer/signer.rs
+++ b/offchain/dispatcher/src/signer/signer.rs
@@ -58,7 +58,7 @@ impl ConditionalSigner {
                     .with_chain_id(chain_id);
                 Ok(ConditionalSigner::LocalWallet(wallet))
             }
-            AuthConfig::AWS { key_id, region } => {
+            AuthConfig::Aws { key_id, region } => {
                 AwsSigner::new(key_id, chain_id, region)
                     .await
                     .map(ConditionalSigner::AwsSigner)


### PR DESCRIPTION
This obsoletes cartesi/rollups#211

- Remaining warnings to be tackled at #46
- includes 🐢 for removing `cargo-machete` install from CI

Closes #37