### PR TITLE
feat(advance-runner): get off-chain machine hash

### DIFF
--- a/offchain/advance-runner/src/runner.rs
+++ b/offchain/advance-runner/src/runner.rs
@@ -52,6 +52,9 @@ pub enum RunnerError<SnapError: snafu::Error + 'static> {
         got
     ))]
     ParentIdMismatchError { expected: String, got: String },
+
+    #[snafu(display("failed to get hash from snapshot "))]
+    GetSnapshotHashError { source: SnapError },
 }
 
 type Result<T, SnapError> = std::result::Result<T, RunnerError<SnapError>>;
@@ -117,6 +120,13 @@ impl<Snap: SnapshotManager + std::fmt::Debug + 'static> Runner<Snap> {
             .await
             .context(GetLatestSnapshotSnafu)?;
         tracing::info!(?snapshot, "got latest snapshot");
+
+        let offchain_hash = self
+            .snapshot_manager
+            .get_template_hash(&snapshot)
+            .await
+            .context(GetSnapshotHashSnafu)?;
+        tracing::trace!(?offchain_hash, "got snapshot hash");
 
         let event_id = self
             .broker

--- a/offchain/advance-runner/src/snapshot/disabled.rs
+++ b/offchain/advance-runner/src/snapshot/disabled.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 use super::{Snapshot, SnapshotManager};
+use rollups_events::Hash;
 
 #[derive(Debug)]
 pub struct SnapshotDisabled {}
@@ -40,5 +41,13 @@ impl SnapshotManager for SnapshotDisabled {
     ) -> Result<(), SnapshotDisabledError> {
         tracing::trace!("snapshots disabled; ignoring");
         Ok(())
+    }
+
+    async fn get_template_hash(
+        &self,
+        _: &Snapshot,
+    ) -> Result<Hash, SnapshotDisabledError> {
+        tracing::trace!("snapshots disabled; returning default");
+        Ok(Hash::default())
     }
 }

--- a/offchain/advance-runner/src/snapshot/mod.rs
+++ b/offchain/advance-runner/src/snapshot/mod.rs
@@ -1,14 +1,15 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
+use rollups_events::Hash;
 use std::path::PathBuf;
 
 pub mod config;
 pub mod disabled;
 pub mod fs_manager;
 
-/// Cartesi Machine snapshot description
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// A path to a Cartesi Machine snapshot and its metadata
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct Snapshot {
     pub path: PathBuf,
     pub epoch: u64,
@@ -31,4 +32,10 @@ pub trait SnapshotManager {
 
     /// Set the most recent snapshot
     async fn set_latest(&self, snapshot: Snapshot) -> Result<(), Self::Error>;
+
+    /// Get the snapshot's template hash
+    async fn get_template_hash(
+        &self,
+        snapshot: &Snapshot,
+    ) -> Result<Hash, Self::Error>;
 }


### PR DESCRIPTION
This PR is the halfway implementation of #36. Currently, there's no check, we're just logging the hash obtained from the Cartesi Machine snapshot. A second PR will follow with the on-chain hash and the actual comparison.