### PR TITLE
Support POST requests at the inspect-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+### Added
 
 - Added authority claimer service to support reader mode
+- Added support to `POST` *inspect state* requests
 
 ## [1.0.0] 2023-08-22
 

--- a/offchain/inspect-server/tests/payload.rs
+++ b/offchain/inspect-server/tests/payload.rs
@@ -3,6 +3,7 @@
 
 mod common;
 use crate::common::*;
+use inspect_server::server::CARTESI_MACHINE_RX_BUFFER_LIMIT;
 
 struct EchoInspect {}
 
@@ -17,9 +18,9 @@ impl MockInspect for EchoInspect {
     }
 }
 
-async fn test_payload(sent_payload: &str, expected_payload: &str) {
+async fn test_get_payload(sent_payload: &str, expected_payload: &str) {
     let test_state = TestState::setup(EchoInspect {}).await;
-    let response = send_request(sent_payload)
+    let response = send_get_request(sent_payload)
         .await
         .expect("failed to obtain response");
     assert_eq!(response.status, "Accepted");
@@ -32,32 +33,32 @@ async fn test_payload(sent_payload: &str, expected_payload: &str) {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_simple_payload() {
-    test_payload("hello", "hello").await;
+async fn test_get_simple_payload() {
+    test_get_payload("hello", "hello").await;
 }
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_payload_with_spaces() {
-    test_payload("hello world", "hello world").await;
+async fn test_get_payload_with_spaces() {
+    test_get_payload("hello world", "hello world").await;
 }
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_url_encoded_payload() {
-    test_payload("hello%20world", "hello world").await;
+async fn test_get_url_encoded_payload() {
+    test_get_payload("hello%20world", "hello world").await;
 }
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_payload_with_slashes() {
-    test_payload("user/123/name", "user/123/name").await;
+async fn test_get_payload_with_slashes() {
+    test_get_payload("user/123/name", "user/123/name").await;
 }
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_payload_with_path_and_query() {
-    test_payload(
+async fn test_get_payload_with_path_and_query() {
+    test_get_payload(
         "user/data?key=value&key2=value2",
         "user/data?key=value&key2=value2",
     )
@@ -66,8 +67,8 @@ async fn test_payload_with_path_and_query() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_raw_json_payload() {
-    test_payload(
+async fn test_get_raw_json_payload() {
+    test_get_payload(
         r#"{"key": ["value1", "value2"]}"#,
         r#"{"key": ["value1", "value2"]}"#,
     )
@@ -76,6 +77,59 @@ async fn test_raw_json_payload() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_payload_with_empty_payload() {
-    test_payload("", "").await;
+async fn test_get_empty_payload() {
+    test_get_payload("", "").await;
+}
+
+async fn test_post_payload(sent_payload: &str, expected_payload: &str) {
+    let test_state = TestState::setup(EchoInspect {}).await;
+    let response = send_post_request(sent_payload)
+        .await
+        .expect("failed to obtain response");
+    assert_eq!(response.status, "Accepted");
+    assert_eq!(response.exception_payload, None);
+    assert_eq!(response.reports.len(), 1);
+    let expected_payload = String::from("0x") + &hex::encode(expected_payload);
+    assert_eq!(response.reports[0].payload, expected_payload);
+    test_state.teardown().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_empty_payload() {
+    test_post_payload("", "").await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_simple_payload() {
+    test_post_payload("hello", "hello").await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_raw_json_payload() {
+    test_post_payload(
+        r#"{"key": ["value1", "value2"]}"#,
+        r#"{"key": ["value1", "value2"]}"#,
+    )
+    .await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_payload_on_limit() {
+    let payload = "0".repeat(CARTESI_MACHINE_RX_BUFFER_LIMIT);
+    test_post_payload(&payload.clone(), &payload.clone()).await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_fails_when_payload_over_limit() {
+    let payload = "0".repeat(CARTESI_MACHINE_RX_BUFFER_LIMIT + 1);
+    let test_state = TestState::setup(EchoInspect {}).await;
+    send_post_request(&payload)
+        .await
+        .expect_err("Payload reached size limit");
+    test_state.teardown().await;
 }

--- a/offchain/inspect-server/tests/queue.rs
+++ b/offchain/inspect-server/tests/queue.rs
@@ -31,9 +31,9 @@ impl SyncInspect {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_error_when_server_manager_is_down() {
+async fn test_get_error_when_server_manager_is_down() {
     let inspect_server = InspectServerWrapper::start().await;
-    let (status, message) = send_request("hello")
+    let (status, message) = send_get_request("hello")
         .await
         .expect_err("failed to obtain response");
     assert_eq!(status, StatusCode::BAD_GATEWAY);
@@ -46,9 +46,9 @@ async fn test_error_when_server_manager_is_down() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_it_succeeds_after_server_manager_starts() {
+async fn test_get_succeeds_after_server_manager_starts() {
     let inspect_server = InspectServerWrapper::start().await;
-    let (status, _) = send_request("hello")
+    let (status, _) = send_get_request("hello")
         .await
         .expect_err("failed to obtain response");
     assert_eq!(status, StatusCode::BAD_GATEWAY);
@@ -59,7 +59,7 @@ async fn test_it_succeeds_after_server_manager_starts() {
         .send(MockInspectResponse::default())
         .await
         .expect("failed to send response");
-    send_request("hello")
+    send_get_request("hello")
         .await
         .expect("failed to obtain response");
     server_manager.stop().await;
@@ -68,14 +68,14 @@ async fn test_it_succeeds_after_server_manager_starts() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_it_handle_concurrent_inspect_requests() {
+async fn test_get_it_handle_concurrent_inspect_requests() {
     let (mock, response_tx) = SyncInspect::setup();
     let state = TestState::setup(mock).await;
     // Send multiple concurrent requests
     let handlers: Vec<_> = (0..QUEUE_SIZE)
         .map(|_| {
             tokio::spawn(async {
-                send_request("hello")
+                send_get_request("hello")
                     .await
                     .expect("failed to obtain response");
             })
@@ -99,7 +99,7 @@ async fn test_it_handle_concurrent_inspect_requests() {
 
 #[tokio::test]
 #[serial_test::serial]
-async fn test_it_returns_error_when_queue_is_full() {
+async fn test_get_it_returns_error_when_queue_is_full() {
     let (mock, response_tx) = SyncInspect::setup();
     let state = TestState::setup(mock).await;
     // Send concurrent requests to overflow the queue.
@@ -107,7 +107,113 @@ async fn test_it_returns_error_when_queue_is_full() {
     // imediatelly consumed and removed from the queue.
     let mut handlers = FuturesUnordered::new();
     for _ in 0..(QUEUE_SIZE + 2) {
-        handlers.push(tokio::spawn(send_request("hello")));
+        handlers.push(tokio::spawn(send_get_request("hello")));
+    }
+    // Poll the handlers to find the overflow error
+    let (status, message) = handlers
+        .next()
+        .await
+        .expect("failed to poll")
+        .expect("failed to join handler")
+        .expect_err("failed to receive error");
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        message,
+        String::from("Failed to inspect state: no available capacity")
+    );
+    // Add the responses to the queue
+    for _ in 0..(QUEUE_SIZE + 1) {
+        response_tx
+            .send(MockInspectResponse::default())
+            .await
+            .expect("failed to send response");
+    }
+    // Wait for responses so we don't have zombie threads
+    while let Some(handler) = handlers.next().await {
+        let _ = handler.expect("failed to join handler");
+    }
+    state.teardown().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_error_when_server_manager_is_down() {
+    let inspect_server = InspectServerWrapper::start().await;
+    let (status, message) = send_get_request("hello")
+        .await
+        .expect_err("failed to obtain response");
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    assert_eq!(
+        &message,
+        "Failed to connect to server manager: transport error"
+    );
+    inspect_server.stop().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_succeeds_after_server_manager_starts() {
+    let inspect_server = InspectServerWrapper::start().await;
+    let (status, _) = send_post_request("hello")
+        .await
+        .expect_err("failed to obtain response");
+    assert_eq!(status, StatusCode::BAD_GATEWAY);
+    let (mock, response_tx) = SyncInspect::setup();
+    let server_manager = MockServerManagerWrapper::start(mock).await;
+    // Add response to queue before sending request
+    response_tx
+        .send(MockInspectResponse::default())
+        .await
+        .expect("failed to send response");
+    send_post_request("hello")
+        .await
+        .expect("failed to obtain response");
+    server_manager.stop().await;
+    inspect_server.stop().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_it_handle_concurrent_inspect_requests() {
+    let (mock, response_tx) = SyncInspect::setup();
+    let state = TestState::setup(mock).await;
+    // Send multiple concurrent requests
+    let handlers: Vec<_> = (0..QUEUE_SIZE)
+        .map(|_| {
+            tokio::spawn(async {
+                send_post_request("hello")
+                    .await
+                    .expect("failed to obtain response");
+            })
+        })
+        .collect();
+    // Wait until the requests arrive in the inspect-server
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    // Add the responses to the queue
+    for _ in 0..QUEUE_SIZE {
+        response_tx
+            .send(MockInspectResponse::default())
+            .await
+            .expect("failed to send response");
+    }
+    // Check the responses
+    for handler in handlers {
+        handler.await.expect("failed to wait handler");
+    }
+    state.teardown().await;
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_post_it_returns_error_when_queue_is_full() {
+    let (mock, response_tx) = SyncInspect::setup();
+    let state = TestState::setup(mock).await;
+    // Send concurrent requests to overflow the queue.
+    // We need to 2 extra requests to overflow the queue because the first message will be
+    // imediatelly consumed and removed from the queue.
+    let mut handlers = FuturesUnordered::new();
+    for _ in 0..(QUEUE_SIZE + 2) {
+        handlers.push(tokio::spawn(send_post_request("hello")));
     }
     // Poll the handlers to find the overflow error
     let (status, message) = handlers


### PR DESCRIPTION
- [x] Added support for POST requests
- [x] Replicated most of the existing tests to also cover POST requests
- [x] Updated API at companion PR cartesi/openapi-interfaces#2

Closes #27

