### PR TITLE
feat(advance-runner)!: validate snapshot hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added authority claimer service to support reader mode
 - Added support to `POST` *inspect state* requests
+- Added snapshot validation. The node will now check whether the snapshot's template hash matches the one stored in the blockchain
 
 ### Changed
 

--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -247,7 +247,9 @@ dependencies = [
  "async-trait",
  "backoff",
  "clap",
+ "contracts",
  "env_logger",
+ "ethers",
  "grpc-interfaces",
  "hex",
  "http-health-check",
@@ -264,6 +266,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid 1.4.1",
 ]
 

--- a/offchain/advance-runner/Cargo.toml
+++ b/offchain/advance-runner/Cargo.toml
@@ -9,6 +9,7 @@ name = "cartesi-rollups-advance-runner"
 path = "src/main.rs"
 
 [dependencies]
+contracts = { path = "../contracts" }
 grpc-interfaces = { path = "../grpc-interfaces" }
 http-health-check = { path = "../http-health-check" }
 log = { path = "../log" }
@@ -17,13 +18,15 @@ rollups-events = { path = "../rollups-events" }
 async-trait.workspace = true
 backoff = { workspace = true, features = ["tokio"] }
 clap = { workspace = true, features = ["derive", "env"] }
+ethers.workspace = true
 hex.workspace = true
 sha3 = { workspace = true, features = ["std"] }
 snafu.workspace = true
 tokio = { workspace = true, features = ["macros", "time", "rt-multi-thread"] }
 tonic.workspace = true
-tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
+tracing.workspace = true
+url.workspace = true
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]
@@ -32,5 +35,5 @@ test-fixtures = { path = "../test-fixtures" }
 env_logger.workspace = true
 rand.workspace = true
 tempfile.workspace = true
-testcontainers.workspace = true
 test-log = { workspace = true, features = ["trace"] }
+testcontainers.workspace = true

--- a/offchain/advance-runner/src/config.rs
+++ b/offchain/advance-runner/src/config.rs
@@ -29,12 +29,15 @@ impl AdvanceRunnerConfig {
     pub fn parse() -> Result<Self, ConfigError> {
         let cli_config = CLIConfig::parse();
         let broker_config = cli_config.broker_cli_config.into();
-        let dapp_metadata = cli_config.dapp_metadata_cli_config.into();
+        let dapp_metadata: DAppMetadata =
+            cli_config.dapp_metadata_cli_config.into();
         let server_manager_config =
             ServerManagerConfig::parse_from_cli(cli_config.sm_cli_config);
-        let snapshot_config =
-            SnapshotConfig::parse_from_cli(cli_config.snapshot_cli_config)
-                .context(SnapshotConfigSnafu)?;
+        let snapshot_config = SnapshotConfig::new(
+            cli_config.snapshot_cli_config,
+            dapp_metadata.dapp_address.clone(),
+        )
+        .context(SnapshotConfigSnafu)?;
         let backoff_max_elapsed_duration =
             Duration::from_millis(cli_config.backoff_max_elapsed_duration);
         let healthcheck_port = cli_config.healthcheck_port;

--- a/offchain/advance-runner/src/dapp_contract.rs
+++ b/offchain/advance-runner/src/dapp_contract.rs
@@ -1,0 +1,44 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+use contracts::cartesi_dapp::CartesiDApp;
+use ethers::{
+    prelude::ContractError,
+    providers::{Http, HttpRateLimitRetryPolicy, Provider, RetryClient},
+};
+use rollups_events::{Address, Hash};
+use snafu::{ResultExt, Snafu};
+use std::sync::Arc;
+use url::Url;
+
+const MAX_RETRIES: u32 = 10;
+const INITIAL_BACKOFF: u64 = 1000;
+
+#[derive(Debug, Snafu)]
+#[snafu(display("failed to obtain hash from dapp contract"))]
+pub struct DappContractError {
+    source: ContractError<Provider<RetryClient<Http>>>,
+}
+
+pub async fn get_template_hash(
+    dapp_address: &Address,
+    provider_http_endpoint: Url,
+) -> Result<Hash, DappContractError> {
+    let provider = Provider::new(RetryClient::new(
+        Http::new(provider_http_endpoint),
+        Box::new(HttpRateLimitRetryPolicy),
+        MAX_RETRIES,
+        INITIAL_BACKOFF,
+    ));
+
+    let cartesi_dapp =
+        CartesiDApp::new(dapp_address.inner(), Arc::new(provider));
+
+    let template_hash = cartesi_dapp
+        .get_template_hash()
+        .call()
+        .await
+        .context(DappContractSnafu)?;
+
+    Ok(Hash::new(template_hash))
+}

--- a/offchain/advance-runner/src/lib.rs
+++ b/offchain/advance-runner/src/lib.rs
@@ -16,6 +16,7 @@ pub use error::AdvanceRunnerError;
 
 mod broker;
 pub mod config;
+mod dapp_contract;
 mod error;
 pub mod runner;
 mod server_manager;

--- a/offchain/advance-runner/src/runner.rs
+++ b/offchain/advance-runner/src/runner.rs
@@ -53,8 +53,8 @@ pub enum RunnerError<SnapError: snafu::Error + 'static> {
     ))]
     ParentIdMismatchError { expected: String, got: String },
 
-    #[snafu(display("failed to get hash from snapshot "))]
-    GetSnapshotHashError { source: SnapError },
+    #[snafu(display("failed to validate snapshot"))]
+    ValidateSnapshotError { source: SnapError },
 }
 
 type Result<T, SnapError> = std::result::Result<T, RunnerError<SnapError>>;
@@ -121,12 +121,13 @@ impl<Snap: SnapshotManager + std::fmt::Debug + 'static> Runner<Snap> {
             .context(GetLatestSnapshotSnafu)?;
         tracing::info!(?snapshot, "got latest snapshot");
 
-        let offchain_hash = self
-            .snapshot_manager
-            .get_template_hash(&snapshot)
-            .await
-            .context(GetSnapshotHashSnafu)?;
-        tracing::trace!(?offchain_hash, "got snapshot hash");
+        if snapshot.is_template() {
+            self.snapshot_manager
+                .validate(&snapshot)
+                .await
+                .context(ValidateSnapshotSnafu)?;
+            tracing::info!("template snapshot is valid");
+        }
 
         let event_id = self
             .broker

--- a/offchain/advance-runner/src/snapshot/disabled.rs
+++ b/offchain/advance-runner/src/snapshot/disabled.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 use super::{Snapshot, SnapshotManager};
-use rollups_events::Hash;
 
 #[derive(Debug)]
 pub struct SnapshotDisabled {}
@@ -17,7 +16,7 @@ impl SnapshotManager for SnapshotDisabled {
 
     /// Get the most recent snapshot
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_latest(&self) -> Result<Snapshot, SnapshotDisabledError> {
+    async fn get_latest(&self) -> Result<Snapshot, Self::Error> {
         tracing::trace!("snapshots disabled; returning default");
         Ok(Default::default())
     }
@@ -28,26 +27,21 @@ impl SnapshotManager for SnapshotDisabled {
         &self,
         _: u64,
         _: u64,
-    ) -> Result<Snapshot, SnapshotDisabledError> {
+    ) -> Result<Snapshot, Self::Error> {
         tracing::trace!("snapshots disabled; returning default");
         Ok(Default::default())
     }
 
     /// Set the most recent snapshot
     #[tracing::instrument(level = "trace", skip_all)]
-    async fn set_latest(
-        &self,
-        _: Snapshot,
-    ) -> Result<(), SnapshotDisabledError> {
+    async fn set_latest(&self, _: Snapshot) -> Result<(), Self::Error> {
         tracing::trace!("snapshots disabled; ignoring");
         Ok(())
     }
 
-    async fn get_template_hash(
-        &self,
-        _: &Snapshot,
-    ) -> Result<Hash, SnapshotDisabledError> {
-        tracing::trace!("snapshots disabled; returning default");
-        Ok(Hash::default())
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn validate(&self, _: &Snapshot) -> Result<(), Self::Error> {
+        tracing::trace!("snapshots disabled; ignoring");
+        Ok(())
     }
 }

--- a/offchain/advance-runner/src/snapshot/mod.rs
+++ b/offchain/advance-runner/src/snapshot/mod.rs
@@ -1,7 +1,6 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-use rollups_events::Hash;
 use std::path::PathBuf;
 
 pub mod config;
@@ -14,6 +13,15 @@ pub struct Snapshot {
     pub path: PathBuf,
     pub epoch: u64,
     pub processed_input_count: u64,
+}
+
+impl Snapshot {
+    /// Verifies if this is the template snapshot. The template snapshot is a
+    /// Cartesi Machine snapshot taken right after its creation and before it
+    /// processes any inputs
+    pub fn is_template(&self) -> bool {
+        self.epoch == 0 && self.processed_input_count == 0
+    }
 }
 
 #[async_trait::async_trait]
@@ -33,9 +41,7 @@ pub trait SnapshotManager {
     /// Set the most recent snapshot
     async fn set_latest(&self, snapshot: Snapshot) -> Result<(), Self::Error>;
 
-    /// Get the snapshot's template hash
-    async fn get_template_hash(
-        &self,
-        snapshot: &Snapshot,
-    ) -> Result<Hash, Self::Error>;
+    /// Compares `Snapshot`'s hash with the template hash stored on-chain,
+    /// failing if they don't match
+    async fn validate(&self, snapshot: &Snapshot) -> Result<(), Self::Error>;
 }

--- a/offchain/advance-runner/tests/fixtures/mod.rs
+++ b/offchain/advance-runner/tests/fixtures/mod.rs
@@ -68,7 +68,7 @@ impl AdvanceRunnerFixture {
 
         let dapp_metadata = DAppMetadata {
             chain_id,
-            dapp_address,
+            dapp_address: dapp_address.clone(),
         };
 
         let broker_config = BrokerConfig {
@@ -85,6 +85,9 @@ impl AdvanceRunnerFixture {
                 snapshot_latest: snapshot_dir
                     .expect("Should have a Path")
                     .join("latest"),
+                validation_enabled: false,
+                provider_http_endpoint: None,
+                dapp_address,
             })
         } else {
             SnapshotConfig::Disabled

--- a/offchain/contracts/build.rs
+++ b/offchain/contracts/build.rs
@@ -17,12 +17,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     let tempdir = tempfile::tempdir()?;
     let tarball = tempdir.path().join("rollups.tgz");
     download_contracts(&tarball)?;
-    unzip_contracts(&tarball, &tempdir.path())?;
+    unzip_contracts(&tarball, tempdir.path())?;
 
     let contracts = vec![
         ("inputs", "InputBox", "input_box.rs"),
         ("consensus/authority", "Authority", "authority.rs"),
         ("history", "History", "history.rs"),
+        ("dapp", "CartesiDApp", "cartesi_dapp.rs"),
     ];
     for (contract_path, contract_name, bindings_file_name) in contracts {
         let source_path = path(tempdir.path(), contract_path, contract_name);

--- a/offchain/contracts/src/lib.rs
+++ b/offchain/contracts/src/lib.rs
@@ -18,3 +18,4 @@ macro_rules! contract {
 contract!(input_box);
 contract!(authority);
 contract!(history);
+contract!(cartesi_dapp);


### PR DESCRIPTION
The snapshot's template hash gets compared with its counterpart in the blockchain, causing the advance-runner to stop if it does not match.

BREAKING CHANGE: adds the PROVIDER_HTTP_ENDPOINT parameter, which is required to validate snapshots. Validation is enabled by default, but can be disabled by setting SNAPSHOT_VALIDATION_ENABLED to false

Closes #36 