### PR TITLE
ci: check if PR updated changelog

### DIFF
--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,18 @@
+name: Check Changelog
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+
+jobs:
+  check-changelog:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGELOG.md
+
+          


### PR DESCRIPTION
Add a new CI workflow that checks whether a PR targeting the main branch modified the CHANGELOG.md file. This can be disabled by using the "no changelog" tag when opening the PR.

To test this you can remove the tag from this PR. The workflow should run again and fail.