### PR TITLE
Remove configurable inspect path prefix + 🐢 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added authority claimer service to support reader mode
 - Added support to `POST` *inspect state* requests
 
+### Removed
+
+- Removed configurable inspect-server path prefix
+
 ## [1.0.1] 2023-09-06
 
 ### Fixed

--- a/offchain/inspect-server/src/server.rs
+++ b/offchain/inspect-server/src/server.rs
@@ -14,8 +14,8 @@ use crate::inspect::{
     CompletionStatus, InspectClient, InspectStateResponse, Report,
 };
 
-// (2^20 - 64) bytes, which is the length of the RX buffer minus metadata
-pub const CARTESI_MACHINE_RX_BUFFER_LIMIT: usize = 1_048_512;
+// 2^20 bytes, which is the length of the RX buffer
+pub const CARTESI_MACHINE_RX_BUFFER_LIMIT: usize = 1_048_576;
 
 pub fn create(
     config: &InspectServerConfig,

--- a/offchain/inspect-server/tests/common/mod.rs
+++ b/offchain/inspect-server/tests/common/mod.rs
@@ -86,7 +86,6 @@ impl InspectServerWrapper {
             server_manager_address: SERVER_MANAGER_ADDRESS.to_string(),
             session_id: SESSION_ID.to_string(),
             queue_size: QUEUE_SIZE,
-            inspect_path_prefix: String::from("/inspect"),
             healthcheck_port: 0,
         };
 


### PR DESCRIPTION
This also fixes the POST body length limit.

Closes #67