### PR TITLE
feat: build single node binary

### DIFF
--- a/cmd/cartesi-node/full.go
+++ b/cmd/cartesi-node/full.go
@@ -1,0 +1,52 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"os/exec"
+
+	"github.com/spf13/cobra"
+)
+
+var full = &cobra.Command{
+	Use:   "full",
+	Short: "Starts the node in full mode with reader and validator capabilities",
+	Run:   runFullNode,
+}
+
+func runFullNode(cmd *cobra.Command, args []string) {
+	proc := exec.Command("cartesi-rollups-graphql-server")
+
+	stdoutPipe, err := proc.StdoutPipe()
+	if err != nil {
+		log.Fatal("Error creating stdout pipe:", err)
+	}
+
+	stderrPipe, err := proc.StderrPipe()
+	if err != nil {
+		log.Fatal("Error creating stderr pipe:", err)
+	}
+
+	if err := proc.Start(); err != nil {
+		log.Fatal("Error starting sub-process:", err)
+	}
+
+	// Create goroutines to display the sub-process's stdout and stderr.
+	go func() {
+		io.Copy(os.Stdout, stdoutPipe)
+	}()
+
+	go func() {
+		io.Copy(os.Stderr, stderrPipe)
+	}()
+
+	if err := proc.Wait(); err != nil {
+		log.Fatal("Error waiting for sub-process:", err)
+	}
+
+	log.Println("Sub-process finished")
+}

--- a/cmd/cartesi-node/main.go
+++ b/cmd/cartesi-node/main.go
@@ -1,0 +1,14 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/cartesi-node/no-backend.go
+++ b/cmd/cartesi-node/no-backend.go
@@ -1,0 +1,14 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import "github.com/spf13/cobra"
+
+var noBackend = &cobra.Command{
+	Use:   "no-backend",
+	Short: "Starts the node in no-backend mode",
+	Run: func(cmd *cobra.Command, args []string) {
+		println("TODO")
+	},
+}

--- a/cmd/cartesi-node/reader.go
+++ b/cmd/cartesi-node/reader.go
@@ -1,0 +1,14 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import "github.com/spf13/cobra"
+
+var reader = &cobra.Command{
+	Use:   "reader",
+	Short: "Starts the node in reader mode",
+	Run: func(cmd *cobra.Command, args []string) {
+		println("TODO")
+	},
+}

--- a/cmd/cartesi-node/root.go
+++ b/cmd/cartesi-node/root.go
@@ -1,0 +1,18 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import "github.com/spf13/cobra"
+
+var rootCmd = &cobra.Command{
+	Use: "cartesi-node [reader|validator|full|no-backend]",
+	Run: func(cmd *cobra.Command, args []string) { cmd.Usage() },
+}
+
+func init() {
+	rootCmd.AddCommand(reader)
+	rootCmd.AddCommand(validator)
+	rootCmd.AddCommand(full)
+	rootCmd.AddCommand(noBackend)
+}

--- a/cmd/cartesi-node/validator.go
+++ b/cmd/cartesi-node/validator.go
@@ -1,0 +1,14 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import "github.com/spf13/cobra"
+
+var validator = &cobra.Command{
+	Use:   "validator",
+	Short: "Starts the node in validator mode",
+	Run: func(cmd *cobra.Command, args []string) {
+		println("TODO")
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/cartesi/rollups-node
+
+go 1.21.1
+
+require github.com/spf13/cobra v1.7.0
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## 🧪 How to test

### Setup the database
The binary will start the `graphql-server` service and therefore needs a PostgreSQL instance to connect to. You should follow the instructions in the `data` crate [README](https://github.com/cartesi/rollups-node/blob/feature/single-binary/offchain/data/README.md) file to get a populated database you can interact with.

### Build `graphql-server`
The `cartesi-node` command assumes the executables (`graphql-server` in this case) are present in the PATH variable. So you'll first need to build it with cargo and then add it to your PATH. For example:

Inside `offchain/graphql-server`:
```sh
cargo build
```
and then:
```sh
PATH="{path to your workspace}/rollups-node/offchain/target/debug:${PATH}" 
```
### Run the `cartesi-node` command
From the project's root, just run:
```sh
POSTGRES_PASSWORD=pw go run ./cmd/cartesi-node full
```
The server should have started and to verify it you can interact with it via the GraphQL Playground at `http://localhost:4000/graphql`

Closes #91 