### PR TITLE
feat(database)!: simplify postgres config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Standardized log libraries and configuration
 - Moved GraphQL schema generation to the CI. Now it is distributed as a Github artifact
+- Replace `POSTGRES_*` environment variables with `POSTGRES_ENDPOINT`
 
 ### Removed
 

--- a/offchain/Cargo.lock
+++ b/offchain/Cargo.lock
@@ -4174,12 +4174,12 @@ dependencies = [
  "redacted",
  "serial_test",
  "snafu",
+ "tempfile",
  "test-fixtures",
  "test-log",
  "testcontainers",
  "tracing",
  "tracing-subscriber",
- "urlencoding",
 ]
 
 [[package]]
@@ -5665,12 +5665,6 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "users"

--- a/offchain/Cargo.toml
+++ b/offchain/Cargo.toml
@@ -88,7 +88,6 @@ tracing-actix-web = "0.7"
 tracing-subscriber = "0.3"
 tracing-test = "0.2"
 url = "2"
-urlencoding = "2.1"
 users = "0.11"
 uuid = "1.4"
 

--- a/offchain/data/Cargo.toml
+++ b/offchain/data/Cargo.toml
@@ -14,13 +14,13 @@ diesel_migrations.workspace = true
 diesel = { workspace = true, features = ["postgres", "r2d2"]}
 snafu.workspace = true
 tracing.workspace = true
-urlencoding.workspace = true
 
 [dev-dependencies]
 test-fixtures = { path = "../test-fixtures" }
 
 serial_test.workspace = true
 env_logger.workspace = true
+tempfile.workspace = true
 testcontainers.workspace = true
 test-log = { workspace = true, features = ["trace"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/offchain/data/src/lib.rs
+++ b/offchain/data/src/lib.rs
@@ -9,7 +9,7 @@ mod repository;
 mod schema;
 mod types;
 
-pub use config::{Redacted, RepositoryCLIConfig, RepositoryConfig};
+pub use config::{RedactedUrl, RepositoryCLIConfig, RepositoryConfig, Url};
 pub use error::Error;
 pub use migrations::{run_migrations, MigrationError};
 pub use pagination::{Connection, Cursor, Edge, PageInfo};

--- a/offchain/data/src/repository.rs
+++ b/offchain/data/src/repository.rs
@@ -34,7 +34,7 @@ impl Repository {
             Pool::builder()
                 .max_size(POOL_CONNECTION_SIZE)
                 .build(ConnectionManager::<PgConnection>::new(
-                    config.endpoint().into_inner(),
+                    config.endpoint(),
                 ))
                 .map_err(backoff::Error::transient)
         })

--- a/offchain/indexer/src/indexer.rs
+++ b/offchain/indexer/src/indexer.rs
@@ -25,8 +25,7 @@ impl Indexer {
     pub async fn start(config: IndexerConfig) -> Result<(), IndexerError> {
         tracing::info!("running database migrations");
         let endpoint = config.repository_config.endpoint();
-        rollups_data::run_migrations(&endpoint.into_inner())
-            .context(MigrationsSnafu)?;
+        rollups_data::run_migrations(&endpoint).context(MigrationsSnafu)?;
 
         tracing::info!("runned migrations; connecting to DB");
         let repository = tokio::task::spawn_blocking(|| {

--- a/offchain/test-fixtures/src/repository.rs
+++ b/offchain/test-fixtures/src/repository.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
 use backoff::ExponentialBackoffBuilder;
-use rollups_data::{Redacted, Repository, RepositoryConfig};
+use rollups_data::{RedactedUrl, Repository, RepositoryConfig, Url};
 use std::time::Duration;
 use testcontainers::clients::Cli;
 
@@ -68,12 +68,19 @@ impl RepositoryFixture<'_> {
 
 fn create_repository_config(postgres_port: u16) -> RepositoryConfig {
     use crate::data::*;
+    let redacted_endpoint = Some(RedactedUrl::new(
+        Url::parse(&format!(
+            "postgres://{}:{}@{}:{}/{}",
+            POSTGRES_USER,
+            POSTGRES_PASSWORD,
+            POSTGRES_HOST,
+            postgres_port,
+            POSTGRES_DB,
+        ))
+        .expect("failed to generate Postgres endpoint"),
+    ));
     RepositoryConfig {
-        user: POSTGRES_USER.to_owned(),
-        password: Redacted::new(POSTGRES_PASSWORD.to_owned()),
-        hostname: POSTGRES_HOST.to_owned(),
-        port: postgres_port,
-        db: POSTGRES_DB.to_owned(),
+        redacted_endpoint,
         connection_pool_size: 1,
         backoff: Default::default(),
     }


### PR DESCRIPTION
Receive a single environment variable to setup the postgres connection. It is now possible to omit the password and let the Pg driver load it from its own passfile.

Close #55 