### PR TITLE
ci: adjust dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "dependabot"
+      prefix: "ci"
     pull-request-branch-name:
       separator: "/"
+    labels:
+      - "no changelog"

--- a/.github/workflows/rust-code-quality.yml
+++ b/.github/workflows/rust-code-quality.yml
@@ -4,8 +4,8 @@ name: Assess Rust code quality
 on:
   push:
     paths:
-      - '.github/workflows/rust-code-quality.yml'
-      - 'offchain/**'
+      - ".github/workflows/rust-code-quality.yml"
+      - "offchain/**"
 
 jobs:
   assess-rust-code-quality:
@@ -33,9 +33,6 @@ jobs:
       - name: Install protoc
         run: sudo apt update && sudo apt install -y protobuf-compiler libprotobuf-dev
 
-      - name: Update rust
-        run: rustup update
-
       - name: Install cargo-machete
         run: cargo install cargo-machete
         continue-on-error: true
@@ -43,8 +40,14 @@ jobs:
       - name: Analyze dependencies
         run: cargo machete .
 
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
       - name: Check code format
         run: cargo fmt --all -- --check
+
+      - name: Install clippy
+        run: rustup component add clippy
 
       - name: Run linter
         run: cargo clippy -- -A clippy::module_inception

--- a/offchain/rust-toolchain.toml
+++ b/offchain/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.72"


### PR DESCRIPTION
Modifies dependabot settings so its PRs pass the CI checks automatically. They are currently failing the commit format and changelog checks.