### PR TITLE
Pin Rust to version 1.72.x

### DIFF
--- a/.github/workflows/rust-code-quality.yml
+++ b/.github/workflows/rust-code-quality.yml
@@ -4,8 +4,8 @@ name: Assess Rust code quality
 on:
   push:
     paths:
-      - '.github/workflows/rust-code-quality.yml'
-      - 'offchain/**'
+      - ".github/workflows/rust-code-quality.yml"
+      - "offchain/**"
 
 jobs:
   assess-rust-code-quality:
@@ -33,9 +33,6 @@ jobs:
       - name: Install protoc
         run: sudo apt update && sudo apt install -y protobuf-compiler libprotobuf-dev
 
-      - name: Update rust
-        run: rustup update
-
       - name: Install cargo-machete
         run: cargo install cargo-machete
         continue-on-error: true
@@ -43,8 +40,14 @@ jobs:
       - name: Analyze dependencies
         run: cargo machete .
 
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
       - name: Check code format
         run: cargo fmt --all -- --check
+
+      - name: Install clippy
+        run: rustup component add clippy
 
       - name: Run linter
         run: cargo clippy -- -A clippy::module_inception

--- a/offchain/rust-toolchain.toml
+++ b/offchain/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.72"


### PR DESCRIPTION
The default Rust version in the `ubuntu-22.04` image used in our Github Action workflows [was upgraded](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md) to Rust 1.73.0. This new version introduced [new warnings](https://github.com/cartesi/rollups-node/actions/runs/6631070210/job/18015601341), and made some `dispatcher` tests [start failing](https://github.com/cartesi/rollups-node/actions/runs/6632161387/job/18017235554?pr=127). 

As we're in the process of migrating from Rust to Go, fixing this is not high on our priority list. Pining the Rust version will allow the CI to continue working and postpone the need to deal with these problems.