### PR TITLE
feat: add files to support manual tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 .env
 .DS_Store
+build/deployments
 **/.idea/

--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -1,0 +1,177 @@
+version: "3.9"
+
+name: rollups-node
+services:
+  rollups-node:
+    build:
+      context: ..
+      dockerfile: build/Dockerfile
+      tags:
+        - "cartesi/rollups-node:devel"
+    entrypoint: ["cartesi-rollups-node", "validator"]
+    ports:
+      - "4000:4000"
+    depends_on:
+      hardhat:
+        condition: service_healthy
+      deployer:
+        condition: service_completed_successfully
+      hardhat_set_interval:
+        condition: service_completed_successfully
+      server_manager:
+        condition: service_healthy
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      RUST_LOG: info
+      CARTESI_LOG_LEVEL: info
+      POSTGRES_ENDPOINT: postgres://postgres:password@database:5432/postgres
+
+      #GraphQL Server
+      GRAPHQL_HEALTHCHECK_PORT: 8082
+      GRAPHQL_HOST: "0.0.0.0"
+      GRAPHQL_PORT: "4000"
+
+      #Indexer
+      INDEXER_HEALTHCHECK_PORT: 8083
+      DAPP_CONTRACT_ADDRESS_FILE: /deployments/localhost/dapp.json
+      REDIS_ENDPOINT: redis://redis:6379
+      CHAIN_ID: 31337
+
+    volumes:
+      - machine:/var/opt/cartesi/machine-snapshots
+      - blockchain-data:/opt/cartesi/share/deployments:ro
+      - ./deployments:/deployments:ro
+
+  hardhat:
+    image: cartesi/rollups-hardhat:1.0.0
+    command:
+      [
+        "node",
+        "--network",
+        "hardhat",
+        "--export",
+        "/opt/cartesi/share/deployments/localhost.json",
+      ]
+    init: true
+    ports:
+      - "8545:8545"
+    healthcheck:
+      test:
+        ["CMD", "test", "-f", "/opt/cartesi/share/deployments/localhost.json"]
+      interval: 30s
+      timeout: 30s
+      retries: 5
+    volumes:
+      - blockchain-data:/opt/cartesi/share/deployments
+      - ./deployments:/app/rollups/deployments
+
+  deployer:
+    image: cartesi/rollups-cli:1.0.0
+    restart: on-failure
+    depends_on:
+      hardhat:
+        condition: service_healthy
+      server_manager:
+        condition: service_healthy
+    command:
+      [
+        "create",
+        "--rpc",
+        "http://hardhat:8545",
+        "--deploymentFile",
+        "/opt/cartesi/share/deployments/localhost.json",
+        "--mnemonic",
+        "test test test test test test test test test test test junk",
+        "--templateHashFile",
+        "/var/opt/cartesi/machine-snapshots/0_0/hash",
+        "--outputFile",
+        "/deployments/localhost/dapp.json",
+      ]
+    volumes:
+      - blockchain-data:/opt/cartesi/share/deployments:ro
+      - machine:/var/opt/cartesi/machine-snapshots:ro
+      - ./deployments:/deployments
+
+  hardhat_stop_automine:
+    image: curlimages/curl:7.84.0
+    restart: on-failure
+    depends_on:
+      hardhat:
+        condition: service_healthy
+      deployer:
+        condition: service_completed_successfully
+    command:
+      [
+        "--data",
+        '{"id":1337,"jsonrpc":"2.0","method":"evm_setAutomine","params":[false]}',
+        "http://hardhat:8545",
+      ]
+
+  hardhat_set_interval:
+    image: curlimages/curl:7.84.0
+    restart: on-failure
+    depends_on:
+      hardhat:
+        condition: service_healthy
+      hardhat_stop_automine:
+        condition: service_completed_successfully
+    command:
+      [
+        "--data",
+        '{"id":1337,"jsonrpc":"2.0","method":"evm_setIntervalMining","params":[5000]}',
+        "http://hardhat:8545",
+      ]
+
+  server_manager:
+    build:
+      context: ..
+      dockerfile: build/machine.Dockerfile
+    restart: always
+    ports:
+      - "5001:5001"
+    healthcheck:
+      test: ["CMD-SHELL", 'bash -c ''echo "" > /dev/tcp/127.0.0.1/5001;''']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - machine:/var/opt/cartesi/machine-snapshots
+    environment:
+      - SERVER_MANAGER_LOG_LEVEL=warning
+      - REMOTE_CARTESI_MACHINE_LOG_LEVEL=info
+
+  database:
+    image: postgres:13-alpine
+    ports:
+      - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      - POSTGRES_PASSWORD=password
+    volumes:
+      - database-data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:6-alpine
+    ports:
+      - 6379:6379
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redis-data:/data
+
+volumes:
+  blockchain-data: {}
+  machine: {}
+  database-data: {}
+  redis-data: {}

--- a/build/machine.Dockerfile
+++ b/build/machine.Dockerfile
@@ -1,0 +1,30 @@
+# (c) Cartesi and individual authors (see AUTHORS)
+# SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+FROM cartesi/server-manager:0.8.2 as build-server-stage
+
+USER root
+
+# Install system dependencies
+RUN apt update && \
+    apt install -y wget
+
+# Download rootfs, linux and rom
+ENV IMAGES_PATH /usr/share/cartesi-machine/images
+RUN wget -O ${IMAGES_PATH}/rootfs.ext2 https://github.com/cartesi/image-rootfs/releases/download/v0.18.0/rootfs-v0.18.0.ext2 && \
+    wget -O ${IMAGES_PATH}/linux.bin https://github.com/cartesi/image-kernel/releases/download/v0.17.0/linux-5.15.63-ctsi-2-v0.17.0.bin && \
+    wget -O ${IMAGES_PATH}/rom.bin https://github.com/cartesi/machine-emulator-rom/releases/download/v0.17.0/rom-v0.17.0.bin
+
+# Generate machine with echo and store it
+ENV SNAPSHOT_DIR=/tmp/dapp-bin
+RUN cartesi-machine \
+    --ram-length=128Mi \
+    --rollup \
+    --store=$SNAPSHOT_DIR \
+    -- "ioctl-echo-loop --vouchers=1 --notices=1 --reports=1 --verbose=1"
+
+FROM cartesi/server-manager:0.8.2 as server-stage
+
+WORKDIR /opt/cartesi/bin
+COPY --from=build-server-stage --chown=cartesi:cartesi /tmp/dapp-bin /var/opt/cartesi/machine-snapshots/0_0
+RUN ln -s /var/opt/cartesi/machine-snapshots/0_0 /var/opt/cartesi/machine-snapshots/latest


### PR DESCRIPTION
As `cartesi-rollups-node` gets built and new services are added, it becomes increasingly cumbersome to set up an environment to test it. The added docker-compose file is meant to simplify the process of manual testing for the time being.

Obs: the `server_manager` service will later be removed from the docker-compose to be managed by the `cartesi-rollups-node` binary itself.

Closes #97