### PR TITLE
chore: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The Cartesi Node depends on the following components:
 
 | Component | Version |
 |---|---|
-| Cartesi Machine SDK | [v0.16.2](https://github.com/cartesi/machine-emulator/releases/tag/v0.16.2) |
+| Cartesi Machine SDK | [v0.16.2](https://github.com/cartesi/machine-emulator-sdk/releases/tag/v0.16.2) |
 | Cartesi OpenAPI Interfaces | [v0.6.0](https://github.com/cartesi/openapi-interfaces/releases/tag/v0.6.0) |
 | Cartesi Rollups Contracts | [v1.0.2](https://github.com/cartesi/rollups/releases/tag/v1.0.2) |
 | Cartesi Server Manager | [v0.8.2](https://github.com/cartesi/server-manager/releases/tag/v0.8.2) |


### PR DESCRIPTION
The dependency for the Cartesi Machine SDK was pointing to the wrong repo.