### PR TITLE
fix: service reachability

### DIFF
--- a/build/node-compose.yml
+++ b/build/node-compose.yml
@@ -5,8 +5,8 @@ services:
   node:
     image: "cartesi/rollups-node:devel"
     ports:
-      - "10003:4000"
-      - "10007:5005"
+      - "10004:10004" # GraphQL Server
+      - "10009:10009" # Inspect Server
     restart: always
     depends_on:
       devnet:

--- a/cmd/cartesi-rollups-node/services.go
+++ b/cmd/cartesi-rollups-node/services.go
@@ -187,7 +187,7 @@ func newGraphQLServer() services.Service {
 	s.Env = append(s.Env, getRustLog("graphql_server"))
 	s.Env = append(s.Env,
 		fmt.Sprintf("POSTGRES_ENDPOINT=%v", config.GetPostgresEndpoint()))
-	s.Env = append(s.Env, "GRAPHQL_HOST=127.0.0.1")
+	s.Env = append(s.Env, "GRAPHQL_HOST=0.0.0.0")
 	s.Env = append(s.Env,
 		fmt.Sprintf("GRAPHQL_PORT=%v", getPort(portOffsetGraphQLServer)))
 	s.Env = append(s.Env,
@@ -207,7 +207,7 @@ func newHostRunner() services.Service {
 	s.Env = append(s.Env, "GRPC_SERVER_MANAGER_ADDRESS=127.0.0.1")
 	s.Env = append(s.Env,
 		fmt.Sprintf("GRPC_SERVER_MANAGER_PORT=%v", getPort(portOffsetServerManager)))
-	s.Env = append(s.Env, "HTTP_ROLLUP_SERVER_ADDRESS=127.0.0.1")
+	s.Env = append(s.Env, "HTTP_ROLLUP_SERVER_ADDRESS=0.0.0.0")
 	s.Env = append(s.Env,
 		fmt.Sprintf("HTTP_ROLLUP_SERVER_PORT=%v", getPort(portOffsetHostRunnerRollups)))
 	s.Env = append(s.Env,
@@ -247,7 +247,7 @@ func newInspectServer() services.Service {
 	s.Env = append(s.Env, "LOG_ENABLE_COLOR=false")
 	s.Env = append(s.Env, getRustLog("inspect_server"))
 	s.Env = append(s.Env,
-		fmt.Sprintf("INSPECT_SERVER_ADDRESS=127.0.0.1:%v", getPort(portOffsetInspectServer)))
+		fmt.Sprintf("INSPECT_SERVER_ADDRESS=0.0.0.0:%v", getPort(portOffsetInspectServer)))
 	s.Env = append(s.Env,
 		fmt.Sprintf("SERVER_MANAGER_ADDRESS=127.0.0.1:%v", getPort(portOffsetServerManager)))
 	s.Env = append(s.Env,


### PR DESCRIPTION
When executing the cartesi-rollups-node in a docker container, using the address 127.0.0.1 blocks services from receiving connections from interfaces outside the container. This prevents users from interacting with the Host Runner or querying the GraphQL and Inspect servers.

This commit also fixes the port mapping for GraphQL and Inspect servers in the node-compose.yml file

---
**Obs:** I've only changed the IP addresses of the services that need to receive connections from outside the container. I'm unsure of what is best: to make the difference apparent or to standardize it all.

@GMKrieger thank you for the help in understanding what was going on.