### PR TITLE
build: use compose build configuration

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,3 +5,15 @@ To build the Rollups Node Docker image, run the following command in the build d
 ```
 docker buildx bake --load
 ```
+
+Alternatively, you can build the image using the following command.
+
+```
+docker compose -f node-compose.yml build
+```
+
+And then run the following command to start the node with its dependecies.
+
+```
+docker compose -f node-compose.yml -f deps-compose.yml up
+```

--- a/build/deps-compose.yml
+++ b/build/deps-compose.yml
@@ -28,6 +28,17 @@ services:
     environment:
       - POSTGRES_PASSWORD=password
 
+  node:
+    depends_on:
+      devnet:
+        condition: service_healthy
+      machine_snapshot_setup:
+        condition: service_completed_successfully
+      database:
+        condition: service_healthy
+    volumes:
+      - machine:/var/opt/cartesi/machine-snapshots
+
 volumes:
   blockchain-data: {}
   machine: {}

--- a/build/node-compose.yml
+++ b/build/node-compose.yml
@@ -3,7 +3,10 @@ version: "3.9"
 name: rollups-node
 services:
   node:
-    image: "cartesi/rollups-node:devel"
+    build:
+      context: ../
+      dockerfile: ./build/Dockerfile
+      target: rollups-node
     ports:
       - "10004:10004" # GraphQL Server
       - "10009:10009" # Inspect Server

--- a/build/node-compose.yml
+++ b/build/node-compose.yml
@@ -11,13 +11,6 @@ services:
       - "10004:10004" # GraphQL Server
       - "10009:10009" # Inspect Server
     restart: always
-    depends_on:
-      devnet:
-        condition: service_healthy
-      machine_snapshot_setup:
-        condition: service_completed_successfully
-      database:
-        condition: service_healthy
     environment:
       CARTESI_LOG_LEVEL: "info"
       CARTESI_LOG_TIMESTAMP: "true"
@@ -38,5 +31,3 @@ services:
       CARTESI_SNAPSHOT_DIR: "/var/opt/cartesi/machine-snapshots"
       CARTESI_AUTH_MNEMONIC: "test test test test test test test test test test test junk"
       CARTESI_POSTGRES_ENDPOINT: "postgres://postgres:password@database:5432/postgres"
-    volumes:
-      - machine:/var/opt/cartesi/machine-snapshots


### PR DESCRIPTION
This PR has no much impact, but I think it's more natural when using `docker compose` to run `build` and then `up`.

But that's me! :)