### PR TITLE
Lint markdown files on CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -33,5 +33,12 @@ jobs:
         with:
           version: v1.54.2
 
+      - name: Lint Markdown docs
+      - uses: DavidAnson/markdownlint-cli2-action@v15
+        with:
+          globs: |
+            *.md
+            docs/*.md
+
       - name: Check auto generated files
         run: make check-generate

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,2 @@
+# Global configuration for markdownlint
+MD013: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD013 -->
 <!-- markdownlint-disable MD024 -->
 # Changelog
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -74,3 +75,4 @@ available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.ht
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
+<!-- markdownlint-enable -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 # Contributing to Cartesi
 
 Thank you for your interest in Cartesi!
@@ -165,3 +166,4 @@ We are happy to automate this for you via DocuSign upon request in the Google Fo
 
 When contributing in a deeper manner to this repository, please first discuss the change you wish to make via our 
 [Discord channel here](https://discord.gg/Pt2NrnS), or contact us at info@cartesi.io email before working on the change.
+<!-- markdownlint-enable -->

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,12 @@ lint: ## Run the linter
 	@echo "Running the linter"
 	@golangci-lint run
 
+.PHONY: md-lint
+md-lint: ## Lint Markdown docs. Each dir has its own .markdownlint.yaml.
+	@echo "Running markdownlint-cli"
+	@docker run -v $$PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
+	@docker run -v $$PWD/docs:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "*.md"
+
 .PHONY: generate
 generate: ## Generate the file that are commited to the repo
 	@echo "Generating Go files"
@@ -27,7 +33,7 @@ graphql-schema: ## Generate the graphql schema file
 	@mv offchain/schema.graphql api/graphql/reader.graphql
 
 .PHONY: check-generate
-check-generate: generate graphql-schema ## Check whether the generated files are in sync 
+check-generate: generate graphql-schema ## Check whether the generated files are in sync
 	@echo "Checking differences on the repository..."
 	@if git diff --exit-code; then \
 		echo "No differences found."; \

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable MD013 -->
 # Cartesi Node Reference Implementation
 
 The [Cartesi Node](https://docs.cartesi.io/cartesi-rollups/main-concepts/#cartesi-nodes) is the part of the [Cartesi Rollups Framework](https://docs.cartesi.io/cartesi-rollups/overview/) that is responsible for handling the communication between the on-chain smart contracts and the [Cartesi Machine](https://docs.cartesi.io/machine/intro/).

--- a/docs/.markdownlint.yaml
+++ b/docs/.markdownlint.yaml
@@ -1,0 +1,7 @@
+# Configuration related to docs generated automatically
+# by https://pkg.go.dev/github.com/spf13/cobra/doc.
+MD010: false
+MD012: false
+MD013: false
+MD040: false
+MD041: false


### PR DESCRIPTION
- Add [markdownlint ](https://github.com/DavidAnson/markdownlint-cli2-action) to the CI
- Lint docs
- Fix linter issues
- Disable issues related to https://pkg.go.dev/github.com/spf13/cobra/doc, which would require a custom doc generator to be fixed (see https://github.com/spf13/cobra/blob/bcfcff729ecdeb4072ef6f2a9c0b5e4ca1853206/doc/md_docs.go#L57)
- Add make recipe

Closes #268 