### PR TITLE
fix: multi-line logs in Go supervisor

### DIFF
--- a/internal/services/command.go
+++ b/internal/services/command.go
@@ -42,8 +42,8 @@ type CommandService struct {
 func (s CommandService) Start(ctx context.Context, ready chan<- struct{}) error {
 	cmd := exec.CommandContext(ctx, s.Path, s.Args...)
 	cmd.Env = s.Env
-	cmd.Stderr = commandLogger{s.Name}
-	cmd.Stdout = commandLogger{s.Name}
+	cmd.Stderr = newLineWriter(commandLogger{s.Name})
+	cmd.Stdout = newLineWriter(commandLogger{s.Name})
 	cmd.Cancel = func() error {
 		err := cmd.Process.Signal(syscall.SIGTERM)
 		if err != nil {

--- a/internal/services/linewriter.go
+++ b/internal/services/linewriter.go
@@ -1,0 +1,48 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package services
+
+import (
+	"bytes"
+	"io"
+)
+
+// lineWriter accumulates the received data in a buffer and writes it to the inner writer when it
+// encounters a new line, ignoring empty lines in the process.
+// lineWriter assumes the inner writer does not returns an error.
+type lineWriter struct {
+	inner  io.Writer
+	buffer bytes.Buffer
+}
+
+func newLineWriter(inner io.Writer) *lineWriter {
+	return &lineWriter{
+		inner: inner,
+	}
+}
+
+func (w *lineWriter) Write(data []byte) (int, error) {
+	_, err := w.buffer.Write(data)
+	if err != nil {
+		// Not possible given bytes.Buffer spec
+		panic(err)
+	}
+	for {
+		if !bytes.ContainsRune(w.buffer.Bytes(), '\n') {
+			break
+		}
+		line, err := w.buffer.ReadBytes('\n')
+		if err != nil {
+			// Not possible because we looked for the \n rune
+			panic(err)
+		}
+		if len(line) > 1 {
+			if _, err := w.inner.Write(line); err != nil {
+				// Assume the writer doesn't return an error
+				panic(err)
+			}
+		}
+	}
+	return len(data), nil
+}

--- a/internal/services/linewriter_test.go
+++ b/internal/services/linewriter_test.go
@@ -1,0 +1,133 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package services
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type mockWriter struct {
+	mock.Mock
+}
+
+func (w *mockWriter) Write(p []byte) (int, error) {
+	args := w.Called(p)
+	return args.Int(0), args.Error(1)
+}
+
+type LineWriterSuite struct {
+	suite.Suite
+	mock   *mockWriter
+	writer *lineWriter
+}
+
+func TestLineWriterSuite(t *testing.T) {
+	suite.Run(t, &LineWriterSuite{})
+}
+
+func (s *LineWriterSuite) SetupTest() {
+	s.mock = &mockWriter{}
+	s.writer = newLineWriter(s.mock)
+}
+
+func (s *LineWriterSuite) TestItWritesLines() {
+	s.mock.On("Write", mock.Anything).Return(0, nil)
+	lines := [][]byte{
+		[]byte("hello\n"),
+		[]byte("world\n"),
+		[]byte("nugget\n"),
+	}
+	for _, line := range lines {
+		n, err := s.writer.Write(line)
+		s.Equal(n, len(line))
+		s.Nil(err)
+	}
+	for _, line := range lines {
+		s.mock.AssertCalled(s.T(), "Write", line)
+	}
+}
+
+func (s *LineWriterSuite) TestItSplitMultipleLines() {
+	s.mock.On("Write", mock.Anything).Return(0, nil)
+	lines := [][]byte{
+		[]byte("hello\n"),
+		[]byte("world\n"),
+		[]byte("nugget\n"),
+	}
+	data := bytes.Join(lines, nil)
+	n, err := s.writer.Write(data)
+	s.Equal(n, len(data))
+	s.Nil(err)
+	for _, line := range lines {
+		s.mock.AssertCalled(s.T(), "Write", line)
+	}
+}
+
+func (s *LineWriterSuite) TestItIgnoresEmptyLines() {
+	s.mock.On("Write", mock.Anything).Return(0, nil)
+	lines := [][]byte{
+		[]byte("hello\n"),
+		[]byte("world\n"),
+		[]byte("nugget\n"),
+	}
+	parts := [][]byte{
+		{'\n'},
+		{'\n'},
+		lines[0],
+		{'\n'},
+		{'\n'},
+		lines[1],
+		{'\n'},
+		{'\n'},
+		lines[2],
+		{'\n'},
+		{'\n'},
+	}
+	for _, part := range parts {
+		n, err := s.writer.Write(part)
+		s.Equal(n, len(part))
+		s.Nil(err)
+	}
+	for _, line := range lines {
+		s.mock.AssertCalled(s.T(), "Write", line)
+	}
+}
+
+func (s *LineWriterSuite) TestItDoesNotWriteStringWithoutNewLine() {
+	s.mock.On("Write", mock.Anything).Return(0, nil)
+	data := []byte("hello nugget")
+	n, err := s.writer.Write(data)
+	s.Equal(n, len(data))
+	s.Nil(err)
+	s.mock.AssertNotCalled(s.T(), "Write")
+}
+
+func (s *LineWriterSuite) TestItJoinsStringsIntoSingleLine() {
+	s.mock.On("Write", mock.Anything).Return(0, nil)
+	parts := [][]byte{
+		[]byte("hello "),
+		[]byte("world "),
+		[]byte("nugget"),
+		[]byte("\n"),
+	}
+	line := bytes.Join(parts, nil)
+	for _, part := range parts {
+		n, err := s.writer.Write(part)
+		s.Equal(n, len(part))
+		s.Nil(err)
+	}
+	s.mock.AssertCalled(s.T(), "Write", line)
+}
+
+func (s *LineWriterSuite) TestItPanicsIfWriterReturnsError() {
+	s.mock.On("Write", mock.Anything).Return(0, errors.New("test error"))
+	s.PanicsWithError("test error", func() {
+		_, _ = s.writer.Write([]byte("hello nugget\n"))
+	})
+}


### PR DESCRIPTION
Close #211 