### PR TITLE
feat: hide internal services behind proxy

### DIFF
--- a/build/compose-node.yaml
+++ b/build/compose-node.yaml
@@ -10,8 +10,6 @@ services:
     image: "cartesi/rollups-node:devel"
     ports:
       - "10000:10000" # Supervisor
-      - "10004:10004" # GraphQL Server
-      - "10009:10009" # Inspect Server
     environment:
       CARTESI_LOG_LEVEL: "info"
       CARTESI_LOG_TIMESTAMP: "false"

--- a/cmd/cartesi-rollups-cli/root/increasetime/increasetime.go
+++ b/cmd/cartesi-rollups-cli/root/increasetime/increasetime.go
@@ -34,7 +34,7 @@ func init() {
 	Cmd.Flags().IntVar(&time, "time", defaultTime,
 		"The amount of time to increase in the evm, in seconds")
 
-	Cmd.Flags().StringVar(&anvilEndpoint, "anvil-endpoint", "http://0.0.0.0:8545",
+	Cmd.Flags().StringVar(&anvilEndpoint, "anvil-endpoint", "http://localhost:8545",
 		"anvil address used to send to the request")
 }
 

--- a/cmd/cartesi-rollups-cli/root/inspect/inspect.go
+++ b/cmd/cartesi-rollups-cli/root/inspect/inspect.go
@@ -35,7 +35,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("payload"))
 
-	Cmd.Flags().StringVar(&inspectEndpoint, "inspect-endpoint", "http://0.0.0.0:10009/",
+	Cmd.Flags().StringVar(&inspectEndpoint, "inspect-endpoint", "http://localhost:10000/",
 		"address used to connect to the inspect api")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/input/input.go
+++ b/cmd/cartesi-rollups-cli/root/read/input/input.go
@@ -33,7 +33,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("index"))
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/inputs/inputs.go
+++ b/cmd/cartesi-rollups-cli/root/read/inputs/inputs.go
@@ -27,7 +27,7 @@ var (
 )
 
 func init() {
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/notice/notice.go
+++ b/cmd/cartesi-rollups-cli/root/read/notice/notice.go
@@ -39,7 +39,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("input-index"))
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/notices/notices.go
+++ b/cmd/cartesi-rollups-cli/root/read/notices/notices.go
@@ -31,7 +31,7 @@ func init() {
 	Cmd.Flags().IntVar(&inputIndex, "input-index", -1,
 		"index of the input")
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/report/report.go
+++ b/cmd/cartesi-rollups-cli/root/read/report/report.go
@@ -39,7 +39,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("input-index"))
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/reports/reports.go
+++ b/cmd/cartesi-rollups-cli/root/read/reports/reports.go
@@ -31,7 +31,7 @@ func init() {
 	Cmd.Flags().IntVar(&inputIndex, "input-index", -1,
 		"index of the input")
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/voucher/voucher.go
+++ b/cmd/cartesi-rollups-cli/root/read/voucher/voucher.go
@@ -39,7 +39,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("input-index"))
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/read/vouchers/vouchers.go
+++ b/cmd/cartesi-rollups-cli/root/read/vouchers/vouchers.go
@@ -31,7 +31,7 @@ func init() {
 	Cmd.Flags().IntVar(&inputIndex, "input-index", -1,
 		"index of the input")
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:4000/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 }
 

--- a/cmd/cartesi-rollups-cli/root/validate/validate.go
+++ b/cmd/cartesi-rollups-cli/root/validate/validate.go
@@ -44,7 +44,7 @@ func init() {
 
 	cobra.CheckErr(Cmd.MarkFlagRequired("input-index"))
 
-	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://0.0.0.0:10004/graphql",
+	Cmd.Flags().StringVar(&graphqlEndpoint, "graphql-endpoint", "http://localhost:10000/graphql",
 		"address used to connect to graphql")
 
 	Cmd.Flags().StringVar(&ethEndpoint, "eth-endpoint", "http://localhost:8545",

--- a/cmd/cartesi-rollups-node/handlers.go
+++ b/cmd/cartesi-rollups-node/handlers.go
@@ -1,0 +1,68 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/cartesi/rollups-node/internal/config"
+)
+
+func newHttpServiceHandler() http.Handler {
+	handler := http.NewServeMux()
+	handler.Handle("/healthz", http.HandlerFunc(healthcheckHandler))
+
+	graphqlProxy, err := newReverseProxy(getPort(portOffsetGraphQLServer))
+	if err != nil {
+		config.ErrorLogger.Fatal(err)
+	}
+	handler.Handle("/graphql", graphqlProxy)
+
+	dispatcherProxy, err := newReverseProxy(getPort(portOffsetDispatcher))
+	if err != nil {
+		config.ErrorLogger.Fatal(err)
+	}
+	handler.Handle("/metrics", dispatcherProxy)
+
+	inspectProxy, err := newReverseProxy(getPort(portOffsetInspectServer))
+	if err != nil {
+		config.ErrorLogger.Fatal(err)
+	}
+	handler.Handle("/inspect", inspectProxy)
+	handler.Handle("/inspect/", inspectProxy)
+
+	if config.GetCartesiFeatureHostMode() {
+		hostProxy, err := newReverseProxy(getPort(portOffsetHostRunnerRollups))
+		if err != nil {
+			config.ErrorLogger.Fatal(err)
+		}
+		handler.Handle("/rollup/", http.StripPrefix("/rollup", hostProxy))
+	}
+	return handler
+}
+
+func healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	config.DebugLogger.Println("received healthcheck request")
+	w.WriteHeader(http.StatusOK)
+}
+
+func newReverseProxy(port int) (*httputil.ReverseProxy, error) {
+	urlStr := fmt.Sprintf(
+		"http://%v:%v/",
+		config.GetCartesiHttpAddress(),
+		port,
+	)
+
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(url)
+	proxy.ErrorLog = config.ErrorLogger
+	return proxy, nil
+}

--- a/cmd/cartesi-rollups-node/services.go
+++ b/cmd/cartesi-rollups-node/services.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 
 	"github.com/cartesi/rollups-node/internal/config"
@@ -32,6 +31,11 @@ const (
 	portOffsetStateServer
 )
 
+const (
+	localhost              = "127.0.0.1"
+	serverManagerSessionId = "default_session_id"
+)
+
 // Get the port of the given service.
 func getPort(offset portOffset) int {
 	return config.GetCartesiHttpPort() + int(offset)
@@ -42,11 +46,9 @@ func getRedisEndpoint() string {
 	if config.GetCartesiExperimentalSunodoValidatorEnabled() {
 		return config.GetCartesiExperimentalSunodoValidatorRedisEndpoint()
 	} else {
-		return fmt.Sprintf("redis://127.0.0.1:%v", getPort(portOffsetRedis))
+		return fmt.Sprintf("redis://%v:%v", localhost, getPort(portOffsetRedis))
 	}
 }
-
-const serverManagerSessionId = "default_session_id"
 
 // Create the RUST_LOG variable using the config log level.
 // If the log level is set to debug, set tracing log for the given rust module.
@@ -74,7 +76,8 @@ func newAdvanceRunner() services.CommandService {
 	s.Env = append(s.Env, "LOG_ENABLE_COLOR=false")
 	s.Env = append(s.Env, getRustLog("advance_runner"))
 	s.Env = append(s.Env,
-		fmt.Sprintf("SERVER_MANAGER_ENDPOINT=http://127.0.0.1:%v",
+		fmt.Sprintf("SERVER_MANAGER_ENDPOINT=http://%v:%v",
+			localhost,
 			getPort(portOffsetServerManager)))
 	s.Env = append(s.Env,
 		fmt.Sprintf("SESSION_ID=%v", serverManagerSessionId))
@@ -156,7 +159,7 @@ func newDispatcher() services.CommandService {
 	s.Env = append(s.Env, "LOG_ENABLE_COLOR=false")
 	s.Env = append(s.Env, getRustLog("dispatcher"))
 	s.Env = append(s.Env,
-		fmt.Sprintf("SC_GRPC_ENDPOINT=http://127.0.0.1:%v", getPort(portOffsetStateServer)))
+		fmt.Sprintf("SC_GRPC_ENDPOINT=http://%v:%v", localhost, getPort(portOffsetStateServer)))
 	s.Env = append(s.Env,
 		fmt.Sprintf("SC_DEFAULT_CONFIRMATIONS=%v", config.GetCartesiBlockchainFinalityOffset()))
 	s.Env = append(s.Env,
@@ -192,7 +195,7 @@ func newGraphQLServer() services.CommandService {
 	s.Env = append(s.Env, getRustLog("graphql_server"))
 	s.Env = append(s.Env,
 		fmt.Sprintf("POSTGRES_ENDPOINT=%v", config.GetCartesiPostgresEndpoint()))
-	s.Env = append(s.Env, "GRAPHQL_HOST=0.0.0.0")
+	s.Env = append(s.Env, fmt.Sprintf("GRAPHQL_HOST=%v", localhost))
 	s.Env = append(s.Env,
 		fmt.Sprintf("GRAPHQL_PORT=%v", getPort(portOffsetGraphQLServer)))
 	s.Env = append(s.Env,
@@ -209,10 +212,10 @@ func newHostRunner() services.CommandService {
 	s.Env = append(s.Env, "LOG_ENABLE_TIMESTAMP=false")
 	s.Env = append(s.Env, "LOG_ENABLE_COLOR=false")
 	s.Env = append(s.Env, getRustLog("host_runner"))
-	s.Env = append(s.Env, "GRPC_SERVER_MANAGER_ADDRESS=127.0.0.1")
+	s.Env = append(s.Env, fmt.Sprintf("GRPC_SERVER_MANAGER_ADDRESS=%v", localhost))
 	s.Env = append(s.Env,
 		fmt.Sprintf("GRPC_SERVER_MANAGER_PORT=%v", getPort(portOffsetServerManager)))
-	s.Env = append(s.Env, "HTTP_ROLLUP_SERVER_ADDRESS=0.0.0.0")
+	s.Env = append(s.Env, fmt.Sprintf("HTTP_ROLLUP_SERVER_ADDRESS=%v", localhost))
 	s.Env = append(s.Env,
 		fmt.Sprintf("HTTP_ROLLUP_SERVER_PORT=%v", getPort(portOffsetHostRunnerRollups)))
 	s.Env = append(s.Env,
@@ -252,9 +255,9 @@ func newInspectServer() services.CommandService {
 	s.Env = append(s.Env, "LOG_ENABLE_COLOR=false")
 	s.Env = append(s.Env, getRustLog("inspect_server"))
 	s.Env = append(s.Env,
-		fmt.Sprintf("INSPECT_SERVER_ADDRESS=0.0.0.0:%v", getPort(portOffsetInspectServer)))
+		fmt.Sprintf("INSPECT_SERVER_ADDRESS=%v:%v", localhost, getPort(portOffsetInspectServer)))
 	s.Env = append(s.Env,
-		fmt.Sprintf("SERVER_MANAGER_ADDRESS=127.0.0.1:%v", getPort(portOffsetServerManager)))
+		fmt.Sprintf("SERVER_MANAGER_ADDRESS=%v:%v", localhost, getPort(portOffsetServerManager)))
 	s.Env = append(s.Env,
 		fmt.Sprintf("SESSION_ID=%v", serverManagerSessionId))
 	s.Env = append(s.Env,
@@ -282,7 +285,7 @@ func newServerManager() services.CommandService {
 	s.HealthcheckPort = getPort(portOffsetServerManager)
 	s.Path = "server-manager"
 	s.Args = append(s.Args,
-		fmt.Sprintf("--manager-address=127.0.0.1:%v", getPort(portOffsetServerManager)))
+		fmt.Sprintf("--manager-address=%v:%v", localhost, getPort(portOffsetServerManager)))
 	s.Env = append(s.Env, "REMOTE_CARTESI_MACHINE_LOG_LEVEL=info")
 	if config.GetCartesiLogLevel() == config.LogLevelDebug {
 		s.Env = append(s.Env, "SERVER_MANAGER_LOG_LEVEL=info")
@@ -314,7 +317,7 @@ func newStateServer() services.CommandService {
 	s.Env = append(s.Env,
 		fmt.Sprintf("BLOCKCHAIN_BLOCK_TIMEOUT=%v", config.GetCartesiBlockchainBlockTimeout()))
 	s.Env = append(s.Env,
-		fmt.Sprintf("SS_SERVER_ADDRESS=127.0.0.1:%v", getPort(portOffsetStateServer)))
+		fmt.Sprintf("SS_SERVER_ADDRESS=%v:%v", localhost, getPort(portOffsetStateServer)))
 	s.Env = append(s.Env, os.Environ()...)
 	return s
 }
@@ -327,16 +330,11 @@ func newSupervisorService(s []services.Service) services.SupervisorService {
 }
 
 func newHttpService() services.HttpService {
-	handler := http.NewServeMux()
-	handler.Handle("/healthz", http.HandlerFunc(healthcheckHandler))
+	addr := fmt.Sprintf("%v:%v", config.GetCartesiHttpAddress(), getPort(portOffsetProxy))
+	handler := newHttpServiceHandler()
 	return services.HttpService{
 		Name:    "http",
-		Address: fmt.Sprintf("%v:%v", config.GetCartesiHttpAddress(), getPort(portOffsetProxy)),
+		Address: addr,
 		Handler: handler,
 	}
-}
-
-func healthcheckHandler(w http.ResponseWriter, r *http.Request) {
-	config.DebugLogger.Println("received healthcheck request")
-	w.WriteHeader(http.StatusOK)
 }

--- a/docs/cartesi-rollups-cli_increase-time.md
+++ b/docs/cartesi-rollups-cli_increase-time.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli increase-time
 ### Options
 
 ```
-      --anvil-endpoint string   anvil address used to send to the request (default "http://0.0.0.0:8545")
+      --anvil-endpoint string   anvil address used to send to the request (default "http://localhost:8545")
   -h, --help                    help for increase-time
       --time int                The amount of time to increase in the evm, in seconds (default 86400)
 ```

--- a/docs/cartesi-rollups-cli_inspect.md
+++ b/docs/cartesi-rollups-cli_inspect.md
@@ -17,7 +17,7 @@ cartesi-rollups-cli inspect --payload 0x$(printf "hi" | xxd -p)
 
 ```
   -h, --help                      help for inspect
-      --inspect-endpoint string   address used to connect to the inspect api (default "http://0.0.0.0:10009/")
+      --inspect-endpoint string   address used to connect to the inspect api (default "http://localhost:10000/")
       --payload string            input payload hex-encoded starting with 0x
 ```
 

--- a/docs/cartesi-rollups-cli_read_input.md
+++ b/docs/cartesi-rollups-cli_read_input.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read input --index 5
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for input
       --index int                 index of the input
 ```

--- a/docs/cartesi-rollups-cli_read_inputs.md
+++ b/docs/cartesi-rollups-cli_read_inputs.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read inputs
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for inputs
 ```
 

--- a/docs/cartesi-rollups-cli_read_notice.md
+++ b/docs/cartesi-rollups-cli_read_notice.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read notice --notice-index 5 --input-index 6
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for notice
       --input-index int           index of the input
       --notice-index int          index of the notice

--- a/docs/cartesi-rollups-cli_read_notices.md
+++ b/docs/cartesi-rollups-cli_read_notices.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read notices
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for notices
       --input-index int           index of the input (default -1)
 ```

--- a/docs/cartesi-rollups-cli_read_report.md
+++ b/docs/cartesi-rollups-cli_read_report.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read report --report-index 5 --input-index 6
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for report
       --input-index int           index of the input
       --report-index int          index of the report

--- a/docs/cartesi-rollups-cli_read_reports.md
+++ b/docs/cartesi-rollups-cli_read_reports.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read reports
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for reports
       --input-index int           index of the input (default -1)
 ```

--- a/docs/cartesi-rollups-cli_read_voucher.md
+++ b/docs/cartesi-rollups-cli_read_voucher.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read voucher --voucher-index 5 --input-index 6
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for voucher
       --input-index int           index of the input
       --voucher-index int         index of the voucher

--- a/docs/cartesi-rollups-cli_read_vouchers.md
+++ b/docs/cartesi-rollups-cli_read_vouchers.md
@@ -16,7 +16,7 @@ cartesi-rollups-cli read vouchers
 ### Options
 
 ```
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:4000/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for vouchers
       --input-index int           index of the input (default -1)
 ```

--- a/docs/cartesi-rollups-cli_validate.md
+++ b/docs/cartesi-rollups-cli_validate.md
@@ -18,7 +18,7 @@ cartesi-rollups-cli validate --notice-index 5 --input-index 6
 ```
       --address-book string       if set, load the address book from the given file; else, use test addresses
       --eth-endpoint string       ethereum node JSON-RPC endpoint (default "http://localhost:8545")
-      --graphql-endpoint string   address used to connect to graphql (default "http://0.0.0.0:10004/graphql")
+      --graphql-endpoint string   address used to connect to graphql (default "http://localhost:10000/graphql")
   -h, --help                      help for validate
       --input-index int           index of the input
       --notice-index int          index of the notice

--- a/internal/services/http.go
+++ b/internal/services/http.go
@@ -24,8 +24,9 @@ func (s HttpService) String() string {
 
 func (s HttpService) Start(ctx context.Context, ready chan<- struct{}) error {
 	server := http.Server{
-		Addr:    s.Address,
-		Handler: s.Handler,
+		Addr:     s.Address,
+		Handler:  s.Handler,
+		ErrorLog: config.ErrorLogger,
 	}
 
 	listener, err := net.Listen("tcp", s.Address)


### PR DESCRIPTION
Modifies HttpService to act as a reverse proxy. Calls to /graphql, /inspect, /rollups, and /metrics endpoints are now received by it and forwarded to graphql-server, inspect-server, host-runner, and dispatcher respectively. The ports these services use needn't be exposed anymore, making HttpService the single access point to the node's APIs.

This is a step towards transforming these services into Golang modules.

Closes #241 