### PR TITLE
fix(ci): always run Rust workflow

### DIFF
--- a/.github/workflows/rust-code-quality.yml
+++ b/.github/workflows/rust-code-quality.yml
@@ -1,11 +1,7 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: Assess Rust code quality
 
-on:
-  push:
-    paths:
-      - '.github/workflows/rust-code-quality.yml'
-      - 'offchain/**.rs'
+on: push
 
 jobs:
   assess-rust-code-quality:


### PR DESCRIPTION
![Screenshot from 2024-01-30 15-52-11](https://github.com/cartesi/rollups-node/assets/8294320/4bbc0880-043e-4416-9621-1f96e6d53517)
This fixes the issues where some PRs are getting stuck because the access-rust-code-quality doesn't run.