### PR TITLE
feat(devnet): add verbose logging argument

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -196,7 +196,7 @@ ARG SNAPSHOT_BUILD_PATH
 COPY --from=snapshot-builder ${SNAPSHOT_BUILD_PATH}/hash hash.bin
 
 # Generate anvil state
-RUN go run ./cmd/gen-devnet --template-hash-file hash.bin
+RUN go run ./cmd/gen-devnet --verbose --template-hash-file hash.bin
 
 # STAGE: rollups-node-devnet
 #

--- a/cmd/gen-devnet/deployer.go
+++ b/cmd/gen-devnet/deployer.go
@@ -112,9 +112,11 @@ func createContracts(ctx context.Context,
 	if err != nil {
 		return contractAddresses, "", fmt.Errorf("command failed %v: %v", castSend.Args, err)
 	}
-	fmt.Printf("deployer: command: %s\n", castSend.Args)
-	fmt.Printf("deployer: output: %s\n", outStrBuilder.String())
 
+	if VerboseLog {
+		fmt.Printf("deployer: command: %s\n", castSend.Args)
+		fmt.Printf("deployer: output: %s\n", outStrBuilder.String())
+	}
 	// Extract blockNumber from JSON output
 	jsonMap := make(map[string](any))
 	err = json.Unmarshal([]byte([]byte(outStrBuilder.String())), &jsonMap)

--- a/cmd/gen-devnet/main.go
+++ b/cmd/gen-devnet/main.go
@@ -35,6 +35,7 @@ Set CARTESI_LOG_LEVEL to debug for extensive logging.`,
 }
 
 var (
+	VerboseLog           bool
 	anvilStatePath       string
 	deploymentInfoPath   string
 	hashFile             string
@@ -67,6 +68,12 @@ func init() {
 		"d",
 		"./deployment.json",
 		"path for saving the deployment information")
+
+	Cmd.Flags().BoolVarP(&VerboseLog,
+		"verbose",
+		"v",
+		false,
+		"enable verbose logging")
 }
 
 func main() {
@@ -116,6 +123,18 @@ func run(cmd *cobra.Command, args []string) {
 			if err != nil {
 				fmt.Printf("%s: deployment failed. %v\n", CMD_NAME, err)
 				return
+			}
+
+			anvilStatePath, err := filepath.Abs(anvilStatePath)
+			if err != nil {
+				fmt.Printf("%s: unable to get path for %s: %v\n",
+					CMD_NAME,
+					anvilStatePath,
+					err)
+			} else {
+				fmt.Printf("%s: anvil state saved to %s\n",
+					CMD_NAME,
+					anvilStatePath)
 			}
 
 			jsonInfo, err := json.MarshalIndent(depInfo, "", "\t")

--- a/cmd/gen-devnet/rollups.go
+++ b/cmd/gen-devnet/rollups.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-
-	"github.com/cartesi/rollups-node/internal/config"
 )
 
 const (
@@ -67,7 +65,7 @@ func deployContracts(ctx context.Context, execDir string) error {
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, "RPC_URL="+RPC_URL)
 	cmd.Dir = cmdDir
-	if config.GetCartesiLogLevel() == config.LogLevelDebug {
+	if VerboseLog {
 		cmd.Stdout = os.Stdout
 	}
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
As a follow-up to #289:

- This removes an unnecessary dependency from internal/config. 
- 🐢 While here, also log anvil_state.json location.