### PR TITLE
feat: allow server-manager to bypass log config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added `CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG` env var to allow `server-manager` output to bypass all log configuration
+
 ## [1.3.0] 2024-02-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG` env var to allow `server-manager` output to bypass all log configuration
+- Added `CARTESI_EXPERIMENTAL_DISABLE_CONFIG_LOG` env var to disable log entries related to the node's configuration
 
 ## [1.3.0] 2024-02-09
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -131,6 +131,13 @@ Address of the InputBox contract.
 
 * **Type:** `string`
 
+## `CARTESI_EXPERIMENTAL_DISABLE_CONFIG_LOG`
+
+Disables all log entries related to the node's configuration
+
+* **Type:** `bool`
+* **Default:** `"false"`
+
 ## `CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG`
 
 When enabled, prints server-manager output to stdout and stderr directly.

--- a/docs/config.md
+++ b/docs/config.md
@@ -131,6 +131,14 @@ Address of the InputBox contract.
 
 * **Type:** `string`
 
+## `CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG`
+
+When enabled, prints server-manager output to stdout and stderr directly.
+All other log configurations are ignored.
+
+* **Type:** `bool`
+* **Default:** `"false"`
+
 ## `CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED`
 
 When enabled, the node does not start the authority-claimer service and the Redis server.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ package config
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strconv"
@@ -93,6 +94,9 @@ var configLogger = log.New(os.Stdout, "CONFIG ", log.LstdFlags)
 
 func init() {
 	cache.values = make(map[string]string)
+	if GetCartesiExperimentalDisableConfigLog() {
+		configLogger.SetOutput(io.Discard)
+	}
 }
 
 // Reads the value of an environment variable (loads from a cached value when possible).

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -244,3 +244,10 @@ go-type = "bool"
 description = """
 When enabled, prints server-manager output to stdout and stderr directly.
 All other log configurations are ignored."""
+
+[experimental.CARTESI_EXPERIMENTAL_DISABLE_CONFIG_LOG]
+default = "false"
+go-type = "bool"
+redact = true
+description = """
+Disables all log entries related to the node's configuration"""

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -238,3 +238,9 @@ go-type = "string"
 description = """
 External Redis endpoint for the node when running in the experimental sunodo validator mode."""
 
+[experimental.CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG]
+default = "false"
+go-type = "bool"
+description = """
+When enabled, prints server-manager output to stdout and stderr directly.
+All other log configurations are ignored."""

--- a/internal/config/get.go
+++ b/internal/config/get.go
@@ -99,6 +99,11 @@ func GetCartesiContractsInputBoxAddress() string {
 	return v
 }
 
+func GetCartesiExperimentalDisableConfigLog() bool {
+	v := get("CARTESI_EXPERIMENTAL_DISABLE_CONFIG_LOG", "false", true, true, toBool)
+	return v
+}
+
 func GetCartesiExperimentalServerManagerBypassLog() bool {
 	v := get("CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG", "false", true, false, toBool)
 	return v

--- a/internal/config/get.go
+++ b/internal/config/get.go
@@ -99,6 +99,11 @@ func GetCartesiContractsInputBoxAddress() string {
 	return v
 }
 
+func GetCartesiExperimentalServerManagerBypassLog() bool {
+	v := get("CARTESI_EXPERIMENTAL_SERVER_MANAGER_BYPASS_LOG", "false", true, false, toBool)
+	return v
+}
+
 func GetCartesiExperimentalSunodoValidatorEnabled() bool {
 	v := get("CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED", "false", true, false, toBool)
 	return v

--- a/internal/services/server-manager.go
+++ b/internal/services/server-manager.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -41,8 +42,13 @@ const waitDelay = 200 * time.Millisecond
 func (s ServerManager) Start(ctx context.Context, ready chan<- struct{}) error {
 	cmd := exec.CommandContext(ctx, s.Path, s.Args...)
 	cmd.Env = s.Env
-	cmd.Stderr = newLineWriter(commandLogger{s.Name})
-	cmd.Stdout = newLineWriter(commandLogger{s.Name})
+	if config.GetCartesiExperimentalServerManagerBypassLog() {
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+	} else {
+		cmd.Stderr = newLineWriter(commandLogger{s.Name})
+		cmd.Stdout = newLineWriter(commandLogger{s.Name})
+	}
 	// Without a delay, cmd.Wait() will block forever waiting for the I/O pipes
 	// to be closed
 	cmd.WaitDelay = waitDelay


### PR DESCRIPTION
A workaround so Sunodo can display only the application output on its log. Closes #345 