### PR TITLE
Support specification of private key to claimer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added verification to ensure CARTESI_BLOCKCHAIN_ID matches the id returned from the Ethereum node
-- Added support for CARTESI_AUTH_PRIVATE_KEY
+- Added support for CARTESI_AUTH_PRIVATE_KEY and CARTESI_AUTH_PRIVATE_KEY_FILE
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added verification to ensure CARTESI_BLOCKCHAIN_ID matches the id returned from the Ethereum node
+- Added support for CARTESI_AUTH_PRIVATE_KEY
 
 ## Changed
 

--- a/cmd/cartesi-rollups-node/services.go
+++ b/cmd/cartesi-rollups-node/services.go
@@ -133,6 +133,9 @@ func newAuthorityClaimer() services.CommandService {
 	s.Env = append(s.Env,
 		fmt.Sprintf("AUTHORITY_CLAIMER_HTTP_SERVER_PORT=%v", getPort(portOffsetAuthorityClaimer)))
 	switch auth := config.GetAuth().(type) {
+	case config.AuthPrivateKey:
+		s.Env = append(s.Env,
+			fmt.Sprintf("TX_SIGNING_PRIVATE_KEY=%v", auth.PrivateKey))
 	case config.AuthMnemonic:
 		s.Env = append(s.Env,
 			fmt.Sprintf("TX_SIGNING_MNEMONIC=%v", auth.Mnemonic))

--- a/docs/config.md
+++ b/docs/config.md
@@ -53,6 +53,14 @@ Overrides `CARTESI_AUTH_AWS_KMS_*`.
 
 * **Type:** `string`
 
+## `CARTESI_AUTH_PRIVATE_KEY`
+
+The node will use this private key to sign transactions.
+
+Overrides `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`.
+
+* **Type:** `string`
+
 ## `CARTESI_BLOCKCHAIN_BLOCK_TIMEOUT`
 
 Block subscription timeout in seconds.

--- a/docs/config.md
+++ b/docs/config.md
@@ -57,6 +57,14 @@ Overrides `CARTESI_AUTH_AWS_KMS_*`.
 
 The node will use this private key to sign transactions.
 
+Overrides `CARTESI_AUTH_PRIVATE_KEY_FILE`, `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`.
+
+* **Type:** `string`
+
+## `CARTESI_AUTH_PRIVATE_KEY_FILE`
+
+The node will use the private key contained in this file to sign transactions.
+
 Overrides `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`.
 
 * **Type:** `string`

--- a/internal/config/auth.go
+++ b/internal/config/auth.go
@@ -6,6 +6,11 @@ package config
 // Auth objects are used to sign transactions.
 type Auth any
 
+// Allows signing through private keys.
+type AuthPrivateKey struct {
+	PrivateKey string
+}
+
 // Allows signing through mnemonics.
 type AuthMnemonic struct {
 	Mnemonic     string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,11 @@ var (
 // ------------------------------------------------------------------------------------------------
 
 func GetAuth() Auth {
+	// if private key is coming from an environment variable
+	if privateKey, ok := getCartesiAuthPrivateKey(); ok {
+		return AuthPrivateKey{PrivateKey: privateKey}
+	}
+
 	// getting the (optional) account index
 	index, _ := getCartesiAuthMnemonicAccountIndex()
 

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -170,6 +170,15 @@ description = """
 When using mnemonics to sign transactions,
 the node will use this account index to generate the private key."""
 
+[auth.CARTESI_AUTH_PRIVATE_KEY]
+go-type = "string"
+export = false
+redact = true
+description = """
+The node will use this private key to sign transactions.
+
+Overrides `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`."""
+
 [auth.CARTESI_AUTH_AWS_KMS_KEY_ID]
 go-type = "string"
 export = false

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -177,6 +177,15 @@ redact = true
 description = """
 The node will use this private key to sign transactions.
 
+Overrides `CARTESI_AUTH_PRIVATE_KEY_FILE`, `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`."""
+
+[auth.CARTESI_AUTH_PRIVATE_KEY_FILE]
+go-type = "string"
+export = false
+redact = true
+description = """
+The node will use the private key contained in this file to sign transactions.
+
 Overrides `CARTESI_AUTH_MNEMONIC`, `CARTESI_AUTH_MNEMONIC_FILE` and `CARTESI_AUTH_AWS_KMS_*`."""
 
 [auth.CARTESI_AUTH_AWS_KMS_KEY_ID]

--- a/internal/config/get.go
+++ b/internal/config/get.go
@@ -44,6 +44,11 @@ func getCartesiAuthPrivateKey() (string, bool) {
 	return v, ok
 }
 
+func getCartesiAuthPrivateKeyFile() (string, bool) {
+	v, ok := getOptional("CARTESI_AUTH_PRIVATE_KEY_FILE", "", false, true, toString)
+	return v, ok
+}
+
 func GetCartesiBlockchainBlockTimeout() int {
 	v := get("CARTESI_BLOCKCHAIN_BLOCK_TIMEOUT", "60", true, false, toInt)
 	return v

--- a/internal/config/get.go
+++ b/internal/config/get.go
@@ -39,6 +39,11 @@ func getCartesiAuthMnemonicFile() (string, bool) {
 	return v, ok
 }
 
+func getCartesiAuthPrivateKey() (string, bool) {
+	v, ok := getOptional("CARTESI_AUTH_PRIVATE_KEY", "", false, true, toString)
+	return v, ok
+}
+
 func GetCartesiBlockchainBlockTimeout() int {
 	v := get("CARTESI_BLOCKCHAIN_BLOCK_TIMEOUT", "60", true, false, toInt)
 	return v

--- a/offchain/authority-claimer/src/config/cli.rs
+++ b/offchain/authority-claimer/src/config/cli.rs
@@ -91,6 +91,10 @@ impl TryFrom<AuthorityClaimerCLI> for AuthorityClaimerConfig {
 #[derive(Debug, Parser)]
 #[command(name = "tx_signing_config")]
 pub(crate) struct TxSigningCLIConfig {
+    /// Signer private key, overrides `tx_signing_mnemonic` , `tx_signing_mnemonic_file` and `tx_signing_aws_kms_*`
+    #[arg(long, env)]
+    tx_signing_private_key: Option<String>,
+
     /// Signer mnemonic, overrides `tx_signing_mnemonic_file` and `tx_signing_aws_kms_*`
     #[arg(long, env)]
     tx_signing_mnemonic: Option<String>,
@@ -117,7 +121,11 @@ impl TryFrom<TxSigningCLIConfig> for TxSigningConfig {
 
     fn try_from(cli: TxSigningCLIConfig) -> Result<Self, Self::Error> {
         let account_index = cli.tx_signing_mnemonic_account_index;
-        if let Some(mnemonic) = cli.tx_signing_mnemonic {
+        if let Some(private_key) = cli.tx_signing_private_key {
+            Ok(TxSigningConfig::PrivateKey {
+                private_key: Redacted::new(private_key),
+            })
+        } else if let Some(mnemonic) = cli.tx_signing_mnemonic {
             Ok(TxSigningConfig::Mnemonic {
                 mnemonic: Redacted::new(mnemonic),
                 account_index,

--- a/offchain/authority-claimer/src/config/mod.rs
+++ b/offchain/authority-claimer/src/config/mod.rs
@@ -35,6 +35,10 @@ pub struct AuthorityClaimerConfig {
 
 #[derive(Debug, Clone)]
 pub enum TxSigningConfig {
+    PrivateKey {
+        private_key: Redacted<String>,
+    },
+
     Mnemonic {
         mnemonic: Redacted<String>,
         account_index: Option<u32>,


### PR DESCRIPTION
This PR adds the option to specify CARTESI_AUTH_PRIVATE_KEY to pass to the authority-claimer in case the user have a simple private key in hand, and not a mnemonic.

The value of the private key must be a hex string of 32 bytes, without the traditional starting `0x`.
i.e.: `59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d`

closes #344 