### PR TITLE
Create runtime dir for container image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -294,7 +294,7 @@ COPY --from=go-builder ${GO_BUILD_PATH}/cartesi-rollups-node /usr/bin
 # Setup runtime dir.
 ARG RUNTIME_DIR=/usr/share/rollups-node
 WORKDIR ${RUNTIME_DIR}
-RUN chown cartesi:cartesi ${RUNTIME_DIR}
+RUN mkdir -p ${RUNTIME_DIR} && chown cartesi:cartesi ${RUNTIME_DIR}
 
 # Set user to low-privilege.
 USER cartesi


### PR DESCRIPTION
This PR will create the RUNTIME_DIR that wasn't being created before the permissions were being given with `chown`.

This will allow sunodo to deprecate the usage/maintenance of its own rollups-node container image.

Related to: https://github.com/sunodo/sunodo/pull/413