### PR TITLE
fix: fix Rust version at 1.77.0

### DIFF
--- a/cmd/authority-claimer/rust-toolchain.toml
+++ b/cmd/authority-claimer/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.77.0"


### PR DESCRIPTION
Fix rust version at 1.77.0 to prevent unwanted issues. Rust version should be updated alongside Node Docker image generation