### PR TITLE
chore: DELETE check changelog for 2.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
+      - next/2.0
 
 jobs:
   check-changelog:


### PR DESCRIPTION
Temporary change, which should removed before merging back to `main`