### PR TITLE
[1.4.x] remove dead code from claimer

### DIFF
--- a/offchain/authority-claimer/src/listener.rs
+++ b/offchain/authority-claimer/src/listener.rs
@@ -84,18 +84,10 @@ mod tests {
         BrokerConfig, BrokerEndpoint, BrokerError, RedactedUrl, RollupsClaim,
         Url,
     };
-    use snafu::Snafu;
 
     // ------------------------------------------------------------------------------------------------
     // Broker Mock
     // ------------------------------------------------------------------------------------------------
-
-    #[derive(Clone, Debug, Snafu)]
-    pub enum MockError {
-        EndError,
-        InternalError,
-        MockError,
-    }
 
     pub async fn setup_broker(
         docker: &Cli,


### PR DESCRIPTION
Similar to #438, it's going to cover the CI checks for #407