### PR TITLE
Port mine command to 1.x

### DIFF
--- a/cmd/cartesi-rollups-cli/root/deps/deps.go
+++ b/cmd/cartesi-rollups-cli/root/deps/deps.go
@@ -51,8 +51,12 @@ func init() {
 		"Devnet local listening port number")
 
 	Cmd.Flags().StringVar(&depsConfig.Devnet.BlockTime, "devnet-block-time",
-		deps.DefaultBlockTime,
+		deps.DefaultDevnetBlockTime,
 		"Devnet mining block time")
+
+	Cmd.Flags().BoolVar(&depsConfig.Devnet.NoMining, "devnet-no-mining",
+		deps.DefaultDevnetNoMining,
+		"Devnet disable mining")
 
 	Cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "verbose logs")
 }

--- a/cmd/cartesi-rollups-cli/root/mine/mine.go
+++ b/cmd/cartesi-rollups-cli/root/mine/mine.go
@@ -1,0 +1,41 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package mine
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:     "mine",
+	Short:   "Mine a new block",
+	Example: examples,
+	Run:     run,
+}
+
+const examples = `# Mine a new block:
+cartesi-rollups-cli mine`
+
+var (
+	anvilEndpoint string
+)
+
+func init() {
+
+	Cmd.Flags().StringVar(&anvilEndpoint, "anvil-endpoint", "http://localhost:8545",
+		"address of anvil endpoint to be used to send the mining request")
+}
+
+func run(cmd *cobra.Command, args []string) {
+
+	blockNumber, err := ethutil.MineNewBlock(context.Background(), anvilEndpoint)
+
+	cobra.CheckErr(err)
+
+	slog.Info("Ok", "block number", blockNumber)
+}

--- a/cmd/cartesi-rollups-cli/root/mine/mine.go
+++ b/cmd/cartesi-rollups-cli/root/mine/mine.go
@@ -12,30 +12,40 @@ import (
 )
 
 var Cmd = &cobra.Command{
-	Use:     "mine",
-	Short:   "Mine a new block",
-	Example: examples,
-	Run:     run,
+	Use:   "mine",
+	Short: "Mine blocks",
+	Run:   run,
+	Example: `# Mine 10 blocks with a 5-second interval between them:
+cartesi-rollups-cli mine --number-of-blocks 10 --block-interval 5`,
 }
 
-const examples = `# Mine a new block:
-cartesi-rollups-cli mine`
-
 var (
-	anvilEndpoint string
+	ethEndpoint   string
+	numBlocks     int
+	blockInterval int
 )
 
 func init() {
-
-	Cmd.Flags().StringVar(&anvilEndpoint, "anvil-endpoint", "http://localhost:8545",
-		"address of anvil endpoint to be used to send the mining request")
+	Cmd.Flags().StringVar(&ethEndpoint, "eth-endpoint", "http://localhost:8545",
+		"ethereum node JSON-RPC endpoint")
+	Cmd.Flags().IntVar(&numBlocks, "number-of-blocks", 1,
+		"number of blocks to mine")
+	Cmd.Flags().IntVar(&blockInterval, "block-interval", 1,
+		"interval, in seconds, between the timestamps of each block")
 }
 
 func run(cmd *cobra.Command, args []string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	blockNumber, err := ethutil.MineNewBlock(context.Background(), anvilEndpoint)
-
+	slog.Debug("mining blocks",
+		"numBlocks", numBlocks,
+		"blockInterval", blockInterval)
+	blockNumber, err := ethutil.MineBlocks(ctx,
+		ethEndpoint,
+		uint64(numBlocks),
+		uint64(blockInterval))
 	cobra.CheckErr(err)
 
-	slog.Info("Ok", "block number", blockNumber)
+	slog.Info("done", "last block number", blockNumber)
 }

--- a/cmd/cartesi-rollups-cli/root/root.go
+++ b/cmd/cartesi-rollups-cli/root/root.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/execute"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/increasetime"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/inspect"
+	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/mine"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/read"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/savesnapshot"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/send"
@@ -31,5 +32,6 @@ func init() {
 	Cmd.AddCommand(validate.Cmd)
 	Cmd.AddCommand(deps.Cmd)
 	Cmd.AddCommand(execute.Cmd)
+	Cmd.AddCommand(mine.Cmd)
 	Cmd.DisableAutoGenTag = true
 }

--- a/docs/cli/cartesi-rollups-cli.md
+++ b/docs/cli/cartesi-rollups-cli.md
@@ -18,6 +18,7 @@ Cartesi Rollups node.
 * [cartesi-rollups-cli execute](cartesi-rollups-cli_execute.md)	 - Executes a voucher
 * [cartesi-rollups-cli increase-time](cartesi-rollups-cli_increase-time.md)	 - Increases evm time of the current machine
 * [cartesi-rollups-cli inspect](cartesi-rollups-cli_inspect.md)	 - Calls inspect API
+* [cartesi-rollups-cli mine](cartesi-rollups-cli_mine.md)	 - Mine a new block
 * [cartesi-rollups-cli read](cartesi-rollups-cli_read.md)	 - Read the node state from the GraphQL API
 * [cartesi-rollups-cli run-deps](cartesi-rollups-cli_run-deps.md)	 - Run node dependencies with Docker
 * [cartesi-rollups-cli save-snapshot](cartesi-rollups-cli_save-snapshot.md)	 - Saves the testing Cartesi machine snapshot to the designated folder

--- a/docs/cli/cartesi-rollups-cli.md
+++ b/docs/cli/cartesi-rollups-cli.md
@@ -18,7 +18,7 @@ Cartesi Rollups node.
 * [cartesi-rollups-cli execute](cartesi-rollups-cli_execute.md)	 - Executes a voucher
 * [cartesi-rollups-cli increase-time](cartesi-rollups-cli_increase-time.md)	 - Increases evm time of the current machine
 * [cartesi-rollups-cli inspect](cartesi-rollups-cli_inspect.md)	 - Calls inspect API
-* [cartesi-rollups-cli mine](cartesi-rollups-cli_mine.md)	 - Mine a new block
+* [cartesi-rollups-cli mine](cartesi-rollups-cli_mine.md)	 - Mine blocks
 * [cartesi-rollups-cli read](cartesi-rollups-cli_read.md)	 - Read the node state from the GraphQL API
 * [cartesi-rollups-cli run-deps](cartesi-rollups-cli_run-deps.md)	 - Run node dependencies with Docker
 * [cartesi-rollups-cli save-snapshot](cartesi-rollups-cli_save-snapshot.md)	 - Saves the testing Cartesi machine snapshot to the designated folder

--- a/docs/cli/cartesi-rollups-cli_mine.md
+++ b/docs/cli/cartesi-rollups-cli_mine.md
@@ -1,0 +1,26 @@
+## cartesi-rollups-cli mine
+
+Mine a new block
+
+```
+cartesi-rollups-cli mine [flags]
+```
+
+### Examples
+
+```
+# Mine a new block:
+cartesi-rollups-cli mine
+```
+
+### Options
+
+```
+      --anvil-endpoint string   address of anvil endpoint to be used to send the mining request (default "http://localhost:8545")
+  -h, --help                    help for mine
+```
+
+### SEE ALSO
+
+* [cartesi-rollups-cli](cartesi-rollups-cli.md)	 - Command line interface for Cartesi Rollups
+

--- a/docs/cli/cartesi-rollups-cli_mine.md
+++ b/docs/cli/cartesi-rollups-cli_mine.md
@@ -1,6 +1,6 @@
 ## cartesi-rollups-cli mine
 
-Mine a new block
+Mine blocks
 
 ```
 cartesi-rollups-cli mine [flags]
@@ -9,15 +9,17 @@ cartesi-rollups-cli mine [flags]
 ### Examples
 
 ```
-# Mine a new block:
-cartesi-rollups-cli mine
+# Mine 10 blocks with a 5-second interval between them:
+cartesi-rollups-cli mine --number-of-blocks 10 --block-interval 5
 ```
 
 ### Options
 
 ```
-      --anvil-endpoint string   address of anvil endpoint to be used to send the mining request (default "http://localhost:8545")
-  -h, --help                    help for mine
+      --block-interval int     interval, in seconds, between the timestamps of each block (default 1)
+      --eth-endpoint string    ethereum node JSON-RPC endpoint (default "http://localhost:8545")
+  -h, --help                   help for mine
+      --number-of-blocks int   number of blocks to mine (default 1)
 ```
 
 ### SEE ALSO

--- a/docs/cli/cartesi-rollups-cli_run-deps.md
+++ b/docs/cli/cartesi-rollups-cli_run-deps.md
@@ -19,6 +19,7 @@ cartesi-rollups-cli run-deps
       --devnet-block-time string       Devnet mining block time (default "1")
       --devnet-docker-image string     Devnet docker image name (default "cartesi/rollups-node-devnet:devel")
       --devnet-mapped-port string      Devnet local listening port number (default "8545")
+      --devnet-no-mining               Devnet disable mining
   -h, --help                           help for run-deps
       --postgres-docker-image string   Postgress docker image name (default "postgres:16-alpine")
       --postgres-mapped-port string    Postgres local listening port number (default "5432")

--- a/internal/node/machinehash_test.go
+++ b/internal/node/machinehash_test.go
@@ -138,8 +138,8 @@ func startDevnet() (*deps.DepsContainers, error) {
 	container, err := deps.Run(context.Background(), deps.DepsConfig{
 		Devnet: &deps.DevnetConfig{
 			DockerImage:             deps.DefaultDevnetDockerImage,
-			BlockTime:               deps.DefaultBlockTime,
-			BlockToWaitForOnStartup: deps.DefaultBlockToWaitForOnStartup,
+			BlockTime:               deps.DefaultDevnetBlockTime,
+			BlockToWaitForOnStartup: deps.DefaultDevnetBlockToWaitForOnStartup,
 			Port:                    testutil.GetCartesiTestDepsPortRange(),
 		},
 	})

--- a/pkg/ethutil/ethutil.go
+++ b/pkg/ethutil/ethutil.go
@@ -219,17 +219,23 @@ func SetNextDevnetBlockTimestamp(
 	return client.CallContext(ctx, nil, "evm_setNextBlockTimestamp", timestamp)
 }
 
-// Mines a new block
-func MineNewBlock(
+// Mine blocks.
+// Assumes the HTTP provider is anvil as the `rpc_modules` method cannot be
+// be relied upon to discover what modules are supported and decide what mine
+// method to use
+func MineBlocks(
 	ctx context.Context,
 	blockchainHttpEndpoint string,
+	numBlocks uint64,
+	blockInterval uint64,
 ) (uint64, error) {
 	client, err := rpc.DialContext(ctx, blockchainHttpEndpoint)
 	if err != nil {
 		return 0, err
 	}
 	defer client.Close()
-	err = client.CallContext(ctx, nil, "evm_mine")
+
+	err = client.CallContext(ctx, nil, "anvil_mine", numBlocks, blockInterval)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/ethutil/ethutil.go
+++ b/pkg/ethutil/ethutil.go
@@ -207,14 +207,36 @@ func AdvanceDevnetTime(ctx context.Context,
 // Sets the timestamp for the next block at Devnet
 func SetNextDevnetBlockTimestamp(
 	ctx context.Context,
-	blockchainHttpEnpoint string,
+	blockchainHttpEndpoint string,
 	timestamp int64,
 ) error {
 
-	client, err := rpc.DialContext(ctx, blockchainHttpEnpoint)
+	client, err := rpc.DialContext(ctx, blockchainHttpEndpoint)
 	if err != nil {
 		return err
 	}
 	defer client.Close()
 	return client.CallContext(ctx, nil, "evm_setNextBlockTimestamp", timestamp)
+}
+
+// Mines a new block
+func MineNewBlock(
+	ctx context.Context,
+	blockchainHttpEndpoint string,
+) (uint64, error) {
+	client, err := rpc.DialContext(ctx, blockchainHttpEndpoint)
+	if err != nil {
+		return 0, err
+	}
+	defer client.Close()
+	err = client.CallContext(ctx, nil, "evm_mine")
+	if err != nil {
+		return 0, err
+	}
+	ethClient, err := ethclient.DialContext(ctx, blockchainHttpEndpoint)
+	if err != nil {
+		return 0, err
+	}
+	defer ethClient.Close()
+	return ethClient.BlockNumber(ctx)
 }

--- a/pkg/ethutil/ethutil_test.go
+++ b/pkg/ethutil/ethutil_test.go
@@ -19,8 +19,8 @@ import (
 
 const testTimeout = 300 * time.Second
 
-// This suite sets up a container running a devnet Ethereum node, and connects to it using
-// go-ethereum's client.
+// This suite sets up a container running a devnet Ethereum node
+// and connects to it using go-ethereum's client.
 type EthUtilSuite struct {
 	suite.Suite
 	ctx      context.Context
@@ -75,11 +75,22 @@ func (s *EthUtilSuite) TestAddInput() {
 	s.Require().Equal(payload, event.Input)
 }
 
-func (s *EthUtilSuite) TestMineNewBlock() {
-	blockNumber, err := MineNewBlock(s.ctx, s.endpoint)
-	s.Require().Nil(err)
-	s.Require().Equal(uint64(22), blockNumber)
+func (s *EthUtilSuite) TestMineOneBlock() {
+	s.mineBlocks(1)
+}
 
+func (s *EthUtilSuite) TestMineAHundredBlocks() {
+	s.mineBlocks(100)
+}
+
+func (s *EthUtilSuite) mineBlocks(numBlocks uint64) {
+	lastBlockNumber, err := s.client.BlockNumber(s.ctx)
+	s.Require().Nil(err)
+	expectedBlockNumber := lastBlockNumber + numBlocks
+
+	blockNumber, err := MineBlocks(s.ctx, s.endpoint, numBlocks, 1)
+	s.Require().Nil(err)
+	s.Require().Equal(expectedBlockNumber, blockNumber)
 }
 
 // Log the output of the given container

--- a/test/echo_test.go
+++ b/test/echo_test.go
@@ -71,7 +71,7 @@ func (s *EchoInputTestSuite) SetupTest() {
 			DockerImage:             deps.DefaultDevnetDockerImage,
 			Port:                    testutil.GetCartesiTestDepsPortRange(),
 			BlockTime:               devNetMiningBlockTimeInSeconds,
-			BlockToWaitForOnStartup: deps.DefaultBlockToWaitForOnStartup,
+			BlockToWaitForOnStartup: deps.DefaultDevnetBlockToWaitForOnStartup,
 		},
 	}
 


### PR DESCRIPTION
- Cherry-picks command and devnet changes made at c7193114c7ef6fe254453d96b735a8b4de351a89 for next/2.0.
- Also extends the command to allow for mining multiple blocks at a time. 

As the cli is solely used for _devnet_, it assumes the provider is foundry/anvil in order to perform that instead of relying on method `rpc_modules` to discover if `amvil_mine` can be used instead of a loop of `evm_mine` calls to achieve the same result.