### PR TITLE
feat(repository): update validator methods

### DIFF
--- a/internal/evmreader/evmreader.go
+++ b/internal/evmreader/evmreader.go
@@ -36,7 +36,7 @@ type EvmReaderRepository interface {
 		inputs []Input,
 		blockNumber uint64,
 		appAddress common.Address,
-	) error
+	) ([]uint64, error)
 	GetAllRunningApplications(
 		ctx context.Context,
 	) ([]Application, error)
@@ -326,7 +326,7 @@ func (r *EvmReader) readInputs(
 				len(inputs),
 			)
 		}
-		err = r.repository.InsertInputsAndUpdateLastProcessedBlock(
+		_, err = r.repository.InsertInputsAndUpdateLastProcessedBlock(
 			ctx,
 			inputs,
 			endBlock,

--- a/internal/evmreader/evmreader_test.go
+++ b/internal/evmreader/evmreader_test.go
@@ -445,7 +445,7 @@ func (s *EvmReaderSuite) TestItReadsMultipleInputsFromSingleNewBlock() {
 		inputs, ok := obj.([]Input)
 		s.Require().True(ok)
 		s.Assert().Equal(2, len(inputs))
-	}).Return(nil)
+	}).Return([]uint64{}, nil)
 
 	// Start service
 	ready := make(chan struct{}, 1)
@@ -673,7 +673,7 @@ func newMockRepository() *MockRepository {
 		mock.Anything,
 		mock.Anything,
 		mock.Anything,
-		mock.Anything).Return(nil)
+		mock.Anything).Return([]uint64{}, nil)
 
 	repo.On("GetEpoch",
 		mock.Anything,
@@ -711,9 +711,9 @@ func (m *MockRepository) InsertInputsAndUpdateLastProcessedBlock(
 	inputs []Input,
 	blockNumber uint64,
 	appAddress common.Address,
-) error {
+) ([]uint64, error) {
 	args := m.Called(ctx, inputs, blockNumber)
-	return args.Error(0)
+	return args.Get(0).([]uint64), args.Error(1)
 }
 
 func (m *MockRepository) GetAllRunningApplications(

--- a/internal/repository/base_test.go
+++ b/internal/repository/base_test.go
@@ -95,7 +95,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		Id:              1,
 		Index:           0,
 		FirstBlock:      0,
-		LastBlock:       math.MaxUint64 / 2,
+		LastBlock:       200,
 		AppAddress:      app.ContractAddress,
 		ClaimHash:       nil,
 		TransactionHash: nil,
@@ -108,7 +108,7 @@ func (s *RepositorySuite) SetupDatabase() {
 	epoch2 := Epoch{
 		Id:              2,
 		Index:           1,
-		FirstBlock:      (math.MaxUint64 / 2) + 1,
+		FirstBlock:      201,
 		LastBlock:       math.MaxUint64,
 		AppAddress:      app.ContractAddress,
 		ClaimHash:       nil,
@@ -120,7 +120,6 @@ func (s *RepositorySuite) SetupDatabase() {
 	s.Require().Nil(err)
 
 	input1 := Input{
-		Id:               1,
 		Index:            1,
 		CompletionStatus: InputStatusAccepted,
 		RawData:          common.Hex2Bytes("deadbeef"),
@@ -131,11 +130,10 @@ func (s *RepositorySuite) SetupDatabase() {
 		EpochId:          1,
 	}
 
-	err = s.database.InsertInput(s.ctx, &input1)
+	input1.Id, err = s.database.InsertInput(s.ctx, &input1)
 	s.Require().Nil(err)
 
 	input2 := Input{
-		Id:               2,
 		Index:            2,
 		CompletionStatus: InputStatusNone,
 		RawData:          common.Hex2Bytes("deadbeef"),
@@ -146,11 +144,10 @@ func (s *RepositorySuite) SetupDatabase() {
 		EpochId:          1,
 	}
 
-	err = s.database.InsertInput(s.ctx, &input2)
+	input2.Id, err = s.database.InsertInput(s.ctx, &input2)
 	s.Require().Nil(err)
 
 	input3 := Input{
-		Id:               3,
 		Index:            3,
 		CompletionStatus: InputStatusAccepted,
 		RawData:          common.Hex2Bytes("deadbeef"),
@@ -161,7 +158,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		EpochId:          2,
 	}
 
-	err = s.database.InsertInput(s.ctx, &input3)
+	input3.Id, err = s.database.InsertInput(s.ctx, &input3)
 	s.Require().Nil(err)
 
 	var siblings []Hash
@@ -174,7 +171,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		OutputHashesSiblings: siblings,
 	}
 
-	err = s.database.InsertOutput(s.ctx, &output0)
+	output0.Id, err = s.database.InsertOutput(s.ctx, &output0)
 	s.Require().Nil(err)
 
 	output1 := Output{
@@ -184,7 +181,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		OutputHashesSiblings: siblings,
 	}
 
-	err = s.database.InsertOutput(s.ctx, &output1)
+	output1.Id, err = s.database.InsertOutput(s.ctx, &output1)
 	s.Require().Nil(err)
 
 	output2 := Output{
@@ -194,7 +191,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		OutputHashesSiblings: siblings,
 	}
 
-	err = s.database.InsertOutput(s.ctx, &output2)
+	output2.Id, err = s.database.InsertOutput(s.ctx, &output2)
 	s.Require().Nil(err)
 
 	output3 := Output{
@@ -204,7 +201,7 @@ func (s *RepositorySuite) SetupDatabase() {
 		OutputHashesSiblings: siblings,
 	}
 
-	err = s.database.InsertOutput(s.ctx, &output3)
+	output3.Id, err = s.database.InsertOutput(s.ctx, &output3)
 	s.Require().Nil(err)
 
 	report := Report{
@@ -295,7 +292,7 @@ func (s *RepositorySuite) TestInputFailsDuplicateRow() {
 		AppAddress:       common.HexToAddress("deadbeef"),
 	}
 
-	err := s.database.InsertInput(s.ctx, &input)
+	_, err := s.database.InsertInput(s.ctx, &input)
 	s.Require().ErrorContains(err, "duplicate key value")
 }
 
@@ -308,7 +305,7 @@ func (s *RepositorySuite) TestInputFailsApplicationDoesntExist() {
 		AppAddress:       common.HexToAddress("deadbeefaaa"),
 	}
 
-	err := s.database.InsertInput(s.ctx, &input)
+	_, err := s.database.InsertInput(s.ctx, &input)
 	s.Require().ErrorContains(err, "violates foreign key constraint")
 }
 
@@ -343,7 +340,7 @@ func (s *RepositorySuite) TestOutputFailsDuplicateRow() {
 		OutputHashesSiblings: nil,
 	}
 
-	err := s.database.InsertOutput(s.ctx, &output)
+	_, err := s.database.InsertOutput(s.ctx, &output)
 	s.Require().ErrorContains(err, "duplicate key value")
 }
 
@@ -355,7 +352,7 @@ func (s *RepositorySuite) TestOutputFailsInputDoesntExist() {
 		OutputHashesSiblings: nil,
 	}
 
-	err := s.database.InsertOutput(s.ctx, &output)
+	_, err := s.database.InsertOutput(s.ctx, &output)
 	s.Require().ErrorContains(err, "violates foreign key constraint")
 }
 
@@ -407,7 +404,7 @@ func (s *RepositorySuite) TestEpochExists() {
 		Status:          EpochStatusOpen,
 		Index:           0,
 		FirstBlock:      0,
-		LastBlock:       (math.MaxUint64 / 2),
+		LastBlock:       200,
 		TransactionHash: nil,
 		ClaimHash:       nil,
 		AppAddress:      common.HexToAddress("deadbeef"),

--- a/internal/repository/validator.go
+++ b/internal/repository/validator.go
@@ -7,77 +7,29 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
+	"log/slog"
 
 	. "github.com/cartesi/rollups-node/internal/node/model"
 	"github.com/jackc/pgx/v5"
 )
 
-const DefaultServiceTimeout = 5 * time.Minute
-
-func (pg *Database) GetLastProcessedBlock(
+// GetOutputsProducedInBlockRange returns outputs produced by inputs sent to the application
+// between start and end blocks, inclusive. Outputs are returned in ascending
+// order by index.
+func (pg *Database) GetOutputsProducedInBlockRange(
 	ctx context.Context,
-	appAddress Address,
-) (uint64, error) {
-	var block uint64
-
-	query := `
-	SELECT
-		last_processed_block
-	FROM
-		application
-	WHERE
-		contract_address=@address`
-
-	args := pgx.NamedArgs{
-		"address": appAddress,
-	}
-
-	err := pg.db.QueryRow(ctx, query, args).Scan(&block)
-	if err != nil {
-		return 0, fmt.Errorf("QueryRow failed: %v\n", err)
-	}
-
-	return block, nil
-}
-
-func (pg *Database) GetAllOutputsFromProcessedInputs(
-	ctx context.Context,
-	startBlock uint64,
-	endBlock uint64,
-	timeout *time.Duration,
-) ([]Output, error) {
-	ctxTimeout, cancel := context.WithTimeout(ctx, *timeout)
-	defer cancel()
-	for {
-		select {
-		case <-ctxTimeout.Done():
-			return nil, fmt.Errorf("GetAllOutputsFromProcessedInputs timeout") // timeout
-		default:
-			outputs, err := pg.getAllOutputsFromProcessedInputs(ctxTimeout, startBlock, endBlock)
-			if outputs != nil {
-				return outputs, nil
-			}
-
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-}
-
-func (pg *Database) getAllOutputsFromProcessedInputs(
-	ctx context.Context,
+	application Address,
 	startBlock uint64,
 	endBlock uint64,
 ) ([]Output, error) {
 	query := `
-	SELECT
+	SELECT 
 		o.id,
 		o.index,
 		o.raw_data,
-		o.input_id,
-		i.status
+		o.hash,
+		o.output_hashes_siblings,
+		o.input_id
 	FROM
 		output o
 	INNER JOIN
@@ -85,52 +37,235 @@ func (pg *Database) getAllOutputsFromProcessedInputs(
 	ON
 		o.input_id=i.id
 	WHERE
-		i.block_number BETWEEN @startBlock and @endBlock
+		i.block_number BETWEEN @startBlock AND @endBlock
+	AND
+		i.application_address=@appAddress
 	ORDER BY
-		o.index asc`
+		o.index ASC
+	`
+
+	args := pgx.NamedArgs{"startBlock": startBlock, "endBlock": endBlock, "appAddress": application}
+	rows, err := pg.db.Query(ctx, query, args)
+	if err != nil {
+		return nil, fmt.Errorf("GetOutputs failed: %w", err)
+	}
+
+	var (
+		id, index, inputId   uint64
+		rawData              []byte
+		hash                 *Hash
+		outputHashesSiblings []Hash
+		outputs              []Output
+	)
+	scans := []any{&id, &index, &rawData, &hash, &outputHashesSiblings, &inputId}
+	_, err = pgx.ForEachRow(rows, scans, func() error {
+		output := Output{
+			Id:                   id,
+			Index:                index,
+			RawData:              rawData,
+			Hash:                 hash,
+			OutputHashesSiblings: outputHashesSiblings,
+			InputId:              inputId,
+		}
+		outputs = append(outputs, output)
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("GetOutputs failed: %w", err)
+	}
+	return outputs, nil
+}
+
+// GetProcessedEpochs returns epochs from the application which had all
+// its inputs processed. Epochs are returned in ascending order by index.
+func (pg *Database) GetProcessedEpochs(ctx context.Context, application Address) ([]Epoch, error) {
+	query := `
+	SELECT
+		id,
+		application_address,
+		index,
+		first_block,
+		last_block,
+		claim_hash,
+		transaction_hash,
+		status
+	FROM 
+		epoch
+	WHERE 
+		application_address=@appAddress AND status=@status
+	ORDER BY
+		index ASC`
 
 	args := pgx.NamedArgs{
-		"startBlock": startBlock,
-		"endBlock":   endBlock,
+		"appAddress": application,
+		"status":     EpochStatusProcessedAllInputs,
 	}
 
 	rows, err := pg.db.Query(ctx, query, args)
 	if err != nil {
-		return nil, fmt.Errorf("Query failed: %v\n", err)
+		return nil, fmt.Errorf("GetProcessedEpochs failed: %w", err)
 	}
 
-	var id, input_id, index uint64
-	var rawData []byte
-	var status string
-	var results []Output
+	var (
+		id, index, firstBlock, lastBlock uint64
+		appAddress                       Address
+		claimHash, transactionHash       *Hash
+		status                           string
+		results                          []Epoch
+	)
 
-	rowCount := 0
-
-	_, err = pgx.ForEachRow(rows, []any{&id, &index, &rawData, &input_id, &status},
-		func() error {
-			rowCount++
-			if status != string(InputStatusNone) {
-				output := Output{
-					Id:      id,
-					Index:   index,
-					RawData: rawData,
-					InputId: input_id,
-				}
-				results = append(results, output)
-			}
-			return nil
-		})
+	scans := []any{
+		&id, &appAddress, &index, &firstBlock, &lastBlock, &claimHash, &transactionHash, &status,
+	}
+	_, err = pgx.ForEachRow(rows, scans, func() error {
+		epoch := Epoch{
+			Id:              id,
+			Index:           index,
+			AppAddress:      appAddress,
+			FirstBlock:      firstBlock,
+			LastBlock:       lastBlock,
+			ClaimHash:       claimHash,
+			TransactionHash: transactionHash,
+			Status:          EpochStatus(status),
+		}
+		results = append(results, epoch)
+		return nil
+	})
 	if err != nil {
-		return nil, fmt.Errorf("ForEachRow failed: %w\n", err)
+		return nil, fmt.Errorf("GetProcessedEpochs failed: %w", err)
 	}
-
-	if len(results) == rowCount {
-		return results, nil
-	}
-
-	return nil, nil
+	return results, nil
 }
 
+// GetLastInputOutputHash returns the outputs Merkle tree hash calculated
+// by the Cartesi Machine after it processed the last input in the provided
+// epoch.
+func (pg *Database) GetLastInputOutputHash(
+	ctx context.Context,
+	epochIndex uint64,
+	appAddress Address,
+) (*Hash, error) {
+	//Get Epoch from Database
+	epoch, err := pg.GetEpoch(ctx, epochIndex, appAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	//Check Epoch Status
+	switch epoch.Status { //nolint:exhaustive
+	case EpochStatusOpen, EpochStatusClosed:
+		err := fmt.Errorf(
+			"epoch '%d' of app '%v' is still being processed",
+			epoch.Index, epoch.AppAddress,
+		)
+		return nil, err
+	default:
+		break
+	}
+
+	//Get epoch last input
+	query := `
+	SELECT
+		outputs_hash
+	FROM 
+		input
+	WHERE
+		epoch_id = @id
+	ORDER BY
+		index DESC
+	LIMIT 1
+	`
+
+	args := pgx.NamedArgs{"id": epoch.Id}
+	var outputHash Hash
+
+	err = pg.db.QueryRow(ctx, query, args).Scan(&outputHash)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			slog.Warn(
+				"no inputs",
+				"service", "repository",
+				"epoch", epoch.Index,
+				"app", epoch.AppAddress,
+			)
+			return nil, nil
+		}
+		return nil, fmt.Errorf("GetLastInputOutputHash failed: %w", err)
+	}
+	return &outputHash, nil
+}
+
+// GetPreviousEpoch returns the epoch that ended one block before the start
+// of the current epoch
+func (pg *Database) GetPreviousEpoch(ctx context.Context, currentEpoch Epoch) (*Epoch, error) {
+	if currentEpoch.FirstBlock == 0 {
+		// if this is the first epoch, there is nothing to return
+		return nil, nil
+	}
+
+	query := `
+	SELECT
+		id,
+		application_address,
+		index,
+		first_block,
+		last_block,
+		claim_hash,
+		transaction_hash,
+		status
+	FROM
+		epoch
+	WHERE
+		application_address=@appAddress AND last_block=@lastBlock
+	ORDER BY
+		index DESC
+	LIMIT 1
+	`
+
+	args := pgx.NamedArgs{
+		"appAddress": currentEpoch.AppAddress,
+		"lastBlock":  currentEpoch.FirstBlock - 1,
+	}
+
+	var (
+		id, index, firstBlock, lastBlock uint64
+		appAddress                       Address
+		claimHash, transactionHash       *Hash
+		status                           EpochStatus
+	)
+
+	err := pg.db.QueryRow(ctx, query, args).Scan(
+		&id,
+		&appAddress,
+		&index,
+		&firstBlock,
+		&lastBlock,
+		&transactionHash,
+		&claimHash,
+		&status,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GetPreviousEpoch failed: %w", err)
+	}
+
+	return &Epoch{
+		Id:              id,
+		Index:           index,
+		FirstBlock:      firstBlock,
+		LastBlock:       lastBlock,
+		TransactionHash: transactionHash,
+		ClaimHash:       claimHash,
+		Status:          status,
+		AppAddress:      appAddress,
+	}, nil
+}
+
+// SetEpochClaimAndInsertProofsTransaction performs a database transaction
+// containing two operations:
+//
+// 1. Updates an epoch, adding its claim and modifying its status.
+//
+// 2. Updates several outputs with their Keccak256 hash and proof.
 func (pg *Database) SetEpochClaimAndInsertProofsTransaction(
 	ctx context.Context,
 	epoch Epoch,
@@ -141,64 +276,61 @@ func (pg *Database) SetEpochClaimAndInsertProofsTransaction(
 	SET
 		claim_hash=@claimHash,
 		status=@status
-	WHERE
-	 id=@id`
+	WHERE 
+		id = @id
+	`
 
 	args := pgx.NamedArgs{
-		"id":        epoch.Id,
 		"claimHash": epoch.ClaimHash,
 		"status":    EpochStatusClaimComputed,
+		"id":        epoch.Id,
 	}
 
 	tx, err := pg.db.Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to set claim. epoch: '%d' ,error: %w\n", epoch.Index, err)
+		return fmt.Errorf("SetEpochClaimAndInsertProofsTransaction failed: %w", err)
 	}
 	tag, err := tx.Exec(ctx, query1, args)
 	if err != nil {
 		return errors.Join(
-			fmt.Errorf("unable to set claim. epoch '%d' ,error: %w\n", epoch.Index, err),
+			fmt.Errorf("SetEpochClaimAndInsertProofsTransaction failed: %w", err),
 			tx.Rollback(ctx),
 		)
 	}
 	if tag.RowsAffected() != 1 {
 		return errors.Join(
-			fmt.Errorf(
-				"unable to set claim. epoch '%d' , error: no rows affected ",
-				epoch.Index,
-			),
+			fmt.Errorf("failed to update epoch %d: no rows affected", epoch.Index),
 			tx.Rollback(ctx),
 		)
 	}
 
 	query2 := `
-	UPDATE output
-	SET
-		output_hashes_siblings=@outputHashesSiblings
-	WHERE
-		id=@id`
+	UPDATE 	
+		output
+	SET 	
+		hash = @hash,
+		output_hashes_siblings = @outputHashesSiblings
+	WHERE	
+	id = @id
+	`
 
 	for _, output := range outputs {
 		outputArgs := pgx.NamedArgs{
+			"hash":                 output.Hash,
 			"outputHashesSiblings": output.OutputHashesSiblings,
 			"id":                   output.Id,
 		}
 		tag, err := tx.Exec(ctx, query2, outputArgs)
 		if err != nil {
 			return errors.Join(
-				fmt.Errorf(
-					`unable to set claim. epoch '%d'
-					, error: unable to insert proof for output '%d' %w\n`,
-					epoch.Index, output.Index, err),
+				fmt.Errorf("failed to insert proof for output '%d'. %w", output.Index, err),
 				tx.Rollback(ctx),
 			)
 		}
-		if tag.RowsAffected() != 1 {
+		if tag.RowsAffected() == 0 {
 			return errors.Join(
 				fmt.Errorf(
-					`unable to set claim. epoch '%d'
-					, error: no rows affected on output '%d' update`,
-					epoch.Index,
+					"failed to insert proof for output '%d'. No rows affected",
 					output.Index,
 				),
 				tx.Rollback(ctx),
@@ -209,12 +341,9 @@ func (pg *Database) SetEpochClaimAndInsertProofsTransaction(
 	err = tx.Commit(ctx)
 	if err != nil {
 		return errors.Join(
-			fmt.Errorf("unable to set claim. epoch '%d', error: %w\n",
-				epoch.Index,
-				err),
+			fmt.Errorf("SetEpochClaimAndInsertProofsTransaction failed: %w", err),
 			tx.Rollback(ctx),
 		)
 	}
-
 	return nil
 }

--- a/internal/repository/validator_test.go
+++ b/internal/repository/validator_test.go
@@ -4,125 +4,371 @@
 package repository
 
 import (
-	"time"
-
 	. "github.com/cartesi/rollups-node/internal/node/model"
 	"github.com/ethereum/go-ethereum/common"
 )
 
-func (s *RepositorySuite) TestGetMostRecentBlock() {
-	var block uint64 = 1
+func (s *RepositorySuite) TestGetOutputs() {
+	// get outputs from the existing app
+	outputs, err := s.database.GetOutputsProducedInBlockRange(
+		s.ctx,
+		common.HexToAddress("deadbeef"),
+		1, 3,
+	)
+	s.Require().Nil(err)
+	s.Require().Len(outputs, 3)
 
-	response, err := s.database.GetLastProcessedBlock(s.ctx, common.HexToAddress("deadbeef"))
+	// add an output from another app
+	app := Application{
+		ContractAddress: common.HexToAddress("deadbeee"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
+	}
+	err = s.database.InsertApplication(s.ctx, &app)
 	s.Require().Nil(err)
 
-	s.Require().Equal(block, response)
-}
-
-func (s *RepositorySuite) TestGetAllOutputsFromProcessedInputs() {
-	output0 := Output{
-		Id:                   1,
-		Index:                1,
-		InputId:              1,
-		RawData:              common.Hex2Bytes("deadbeef"),
-		OutputHashesSiblings: nil,
+	epoch := Epoch{
+		Index:      0,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusProcessedAllInputs,
 	}
-
-	output1 := Output{
-		Id:                   2,
-		Index:                2,
-		InputId:              1,
-		RawData:              common.Hex2Bytes("deadbeef"),
-		OutputHashesSiblings: nil,
-	}
-
-	timeout := 5 * time.Second
-
-	response, err := s.database.GetAllOutputsFromProcessedInputs(s.ctx, 1, 2, &timeout)
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
 	s.Require().Nil(err)
-	s.Require().Equal(output0, response[0])
-	s.Require().Equal(output1, response[1])
+
+	expectedHash := common.BytesToHash([]byte("outputs hash"))
+	input := Input{
+		Index:            0,
+		CompletionStatus: InputStatusAccepted,
+		BlockNumber:      1,
+		OutputsHash:      &expectedHash,
+		RawData:          []byte("data"),
+		AppAddress:       app.ContractAddress,
+		EpochId:          epoch.Id,
+	}
+	input.Id, err = s.database.InsertInput(s.ctx, &input)
+	s.Require().Nil(err)
+
+	newOutput := &Output{
+		Index:   0,
+		RawData: []byte("data"),
+		InputId: input.Id,
+	}
+	newOutput.Id, err = s.database.InsertOutput(s.ctx, newOutput)
+	s.Require().Nil(err)
+
+	// the output from the other application is not considered
+	outputs, err = s.database.GetOutputsProducedInBlockRange(
+		s.ctx,
+		common.HexToAddress("deadbeef"),
+		1, 3,
+	)
+	s.Require().Nil(err)
+	s.Require().Len(outputs, 3)
+	for _, output := range outputs {
+		s.NotEqual(newOutput.Id, output.Id)
+	}
 }
 
-func (s *RepositorySuite) TestGetAllOutputsFromProcessedInputsTimeout() {
-	timeout := 5 * time.Second
+func (s *RepositorySuite) TestGetProcessedEpochs() {
+	app := Application{
+		ContractAddress: common.HexToAddress("deadbeed"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
+	}
+	err := s.database.InsertApplication(s.ctx, &app)
+	s.Require().Nil(err)
 
-	_, err := s.database.GetAllOutputsFromProcessedInputs(s.ctx, 2, 3, &timeout)
-	s.Require().ErrorContains(err, "timeout")
+	// no epochs, should return nothing
+	epochs, err := s.database.GetProcessedEpochs(s.ctx, app.ContractAddress)
+	s.Require().Nil(err)
+	s.Len(epochs, 0)
+
+	epoch := Epoch{
+		AppAddress: app.ContractAddress,
+		Index:      0,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusOpen,
+	}
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
+	s.Require().Nil(err)
+
+	// a single non-processed epoch, should return nothing
+	epochs, err = s.database.GetProcessedEpochs(s.ctx, app.ContractAddress)
+	s.Require().Nil(err)
+	s.Len(epochs, 0)
+
+	epoch2 := Epoch{
+		AppAddress: app.ContractAddress,
+		Index:      1,
+		FirstBlock: 100,
+		LastBlock:  199,
+		Status:     EpochStatusProcessedAllInputs,
+	}
+	epoch2.Id, err = s.database.InsertEpoch(s.ctx, &epoch2)
+	s.Require().Nil(err)
+
+	// should return the processed epoch
+	epochs, err = s.database.GetProcessedEpochs(s.ctx, app.ContractAddress)
+	s.Require().Nil(err)
+	s.Len(epochs, 1)
+	s.Contains(epochs, epoch2)
+}
+
+func (s *RepositorySuite) TestGetLastInputOutputHash() {
+	app := Application{
+		ContractAddress: common.HexToAddress("deadbeec"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
+	}
+	err := s.database.InsertApplication(s.ctx, &app)
+	s.Require().Nil(err)
+
+	epoch := Epoch{
+		Index:      0,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusOpen,
+	}
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
+	s.Require().Nil(err)
+
+	// should fail
+	hash, err := s.database.GetLastInputOutputHash(s.ctx, epoch.Index, epoch.AppAddress)
+	s.Require().NotNil(err)
+	s.Nil(hash)
+	s.ErrorContains(err, "still being processed")
+
+	epoch2 := Epoch{
+		Index:      1,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 100,
+		LastBlock:  199,
+		Status:     EpochStatusClosed,
+	}
+	epoch2.Id, err = s.database.InsertEpoch(s.ctx, &epoch2)
+	s.Require().Nil(err)
+
+	// should fail
+	hash, err = s.database.GetLastInputOutputHash(s.ctx, epoch2.Index, epoch2.AppAddress)
+	s.Require().NotNil(err)
+	s.Nil(hash)
+	s.ErrorContains(err, "still being processed")
+
+	epoch3 := Epoch{
+		Index:      2,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 200,
+		LastBlock:  299,
+		Status:     EpochStatusProcessedAllInputs,
+	}
+	epoch3.Id, err = s.database.InsertEpoch(s.ctx, &epoch3)
+	s.Require().Nil(err)
+
+	expectedHash := common.BytesToHash([]byte("outputs hash"))
+	input := &Input{
+		Index:            0,
+		CompletionStatus: InputStatusAccepted,
+		BlockNumber:      1,
+		OutputsHash:      &expectedHash,
+		RawData:          []byte("data"),
+		AppAddress:       app.ContractAddress,
+		EpochId:          epoch3.Id,
+	}
+	input.Id, err = s.database.InsertInput(s.ctx, input)
+	s.Require().Nil(err)
+
+	hash, err = s.database.GetLastInputOutputHash(s.ctx, epoch3.Index, epoch3.AppAddress)
+	s.Require().Nil(err)
+	s.Require().NotNil(hash)
+	s.Equal(expectedHash, *hash)
+}
+
+func (s *RepositorySuite) TestGetPreviousEpoch() {
+	app := &Application{
+		ContractAddress: common.HexToAddress("deadbeeb"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
+	}
+	err := s.database.InsertApplication(s.ctx, app)
+	s.Require().Nil(err)
+
+	epoch := Epoch{
+		Index:      0,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusClaimAccepted,
+	}
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
+	s.Require().Nil(err)
+
+	// first epoch, should return nil
+	previousEpoch, err := s.database.GetPreviousEpoch(s.ctx, epoch)
+	s.Require().Nil(previousEpoch)
+	s.Require().Nil(err)
+
+	epoch2 := Epoch{
+		Index:      1,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 100,
+		LastBlock:  199,
+		Status:     EpochStatusClaimAccepted,
+	}
+	epoch2.Id, err = s.database.InsertEpoch(s.ctx, &epoch2)
+	s.Require().Nil(err)
+
+	// second epoch, should return first
+	previousEpoch, err = s.database.GetPreviousEpoch(s.ctx, epoch2)
+	s.Require().Nil(err)
+	s.Require().NotNil(previousEpoch)
+	s.Require().Equal(*previousEpoch, epoch)
 }
 
 func (s *RepositorySuite) TestSetEpochClaimAndInsertProofsTransaction() {
-	var siblings []Hash
-	siblings = append(siblings, common.HexToHash("deadbeef"))
-
-	output := Output{
-		Id:                   1,
-		Index:                1,
-		InputId:              1,
-		RawData:              common.Hex2Bytes("deadbeef"),
-		OutputHashesSiblings: siblings,
+	app := Application{
+		ContractAddress: common.HexToAddress("deadbeea"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
 	}
-
-	hash := common.HexToHash("deadbeef")
-
-	expectedEpoch, err := s.database.GetEpoch(s.ctx, 0, common.HexToAddress("deadbeef"))
+	err := s.database.InsertApplication(s.ctx, &app)
 	s.Require().Nil(err)
 
-	expectedEpoch.ClaimHash = &hash
-	expectedEpoch.Status = EpochStatusClaimComputed
-
-	epoch, err := s.database.GetEpoch(s.ctx, 0, common.HexToAddress("deadbeef"))
+	epoch := Epoch{
+		Index:      0,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusProcessedAllInputs,
+	}
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
 	s.Require().Nil(err)
 
-	epoch.ClaimHash = &hash
+	input := Input{
+		Index:            0,
+		CompletionStatus: InputStatusAccepted,
+		BlockNumber:      1,
+		RawData:          []byte("data"),
+		AppAddress:       app.ContractAddress,
+		EpochId:          epoch.Id,
+	}
+	input.Id, err = s.database.InsertInput(s.ctx, &input)
+	s.Require().Nil(err)
+
+	output1 := Output{
+		Index:   100,
+		RawData: []byte("data"),
+		InputId: input.Id,
+	}
+	output1.Id, err = s.database.InsertOutput(s.ctx, &output1)
+	s.Require().Nil(err)
+
+	output2 := Output{
+		Index:   101,
+		RawData: []byte("data"),
+		InputId: input.Id,
+	}
+	output2.Id, err = s.database.InsertOutput(s.ctx, &output2)
+	s.Require().Nil(err)
+
+	expectedClaim := common.BytesToHash([]byte("claim"))
+	epoch.ClaimHash = &expectedClaim
 	epoch.Status = EpochStatusClaimComputed
+	expectedSiblings1 := []Hash{{}, {}}
+	expectedHash1 := common.BytesToHash([]byte("output"))
+	output1.Hash = &expectedHash1
+	output1.OutputHashesSiblings = expectedSiblings1
+	expectedHash2 := common.BytesToHash([]byte("output"))
+	expectedSiblings2 := []Hash{{}, {}, {}}
+	output2.Hash = &expectedHash2
+	output2.OutputHashesSiblings = expectedSiblings2
 
-	var outputs []Output
-	outputs = append(outputs, output)
-
-	err = s.database.SetEpochClaimAndInsertProofsTransaction(s.ctx, *epoch, outputs)
+	err = s.database.SetEpochClaimAndInsertProofsTransaction(
+		s.ctx,
+		epoch,
+		[]Output{output1, output2},
+	)
 	s.Require().Nil(err)
 
-	actualEpoch, err := s.database.GetEpoch(s.ctx, epoch.Index, common.HexToAddress("deadbeef"))
+	updatedClaim, err := s.database.GetEpoch(s.ctx, 0, epoch.AppAddress)
 	s.Require().Nil(err)
-	s.Require().Equal(expectedEpoch, actualEpoch)
+	s.Require().NotNil(updatedClaim)
+	s.Require().NotNil(updatedClaim.ClaimHash)
+	s.Equal(expectedClaim, *updatedClaim.ClaimHash)
+	s.Equal(EpochStatusClaimComputed, updatedClaim.Status)
 
-	actualOutput, err := s.database.GetOutput(s.ctx, output.Index, common.HexToAddress("deadbeef"))
+	updatedOutput1, err := s.database.GetOutput(s.ctx, 100, input.AppAddress)
 	s.Require().Nil(err)
-	s.Require().Equal(output, *actualOutput)
+	s.Require().NotNil(updatedOutput1)
+	s.Require().NotNil(updatedOutput1.Hash)
+	s.Equal(expectedHash1, *updatedOutput1.Hash)
+	s.Equal(expectedSiblings1, updatedOutput1.OutputHashesSiblings)
+
+	updatedOutput2, err := s.database.GetOutput(s.ctx, 101, input.AppAddress)
+	s.Require().Nil(err)
+	s.Require().NotNil(updatedOutput2)
+	s.Require().NotNil(updatedOutput2.Hash)
+	s.Equal(expectedHash2, *updatedOutput2.Hash)
+	s.Equal(expectedSiblings2, updatedOutput2.OutputHashesSiblings)
 }
 
 func (s *RepositorySuite) TestSetEpochClaimAndInsertProofsTransactionRollback() {
-	var siblings []Hash
-	siblings = append(siblings, common.HexToHash("deadbeef"))
-
-	output := Output{
-		Id:                   5,
-		Index:                4,
-		InputId:              1,
-		RawData:              common.Hex2Bytes("deadbeef"),
-		OutputHashesSiblings: siblings,
+	app := Application{
+		ContractAddress: common.HexToAddress("deadbeff"),
+		TemplateHash:    common.BytesToHash([]byte("template")),
+		Status:          ApplicationStatusRunning,
 	}
-
-	hash := common.HexToHash("deadbeef")
-
-	epoch, err := s.database.GetEpoch(s.ctx, 1, common.HexToAddress("deadbeef"))
+	err := s.database.InsertApplication(s.ctx, &app)
 	s.Require().Nil(err)
 
-	epoch.ClaimHash = &hash
+	epoch := Epoch{
+		Index:      0,
+		AppAddress: app.ContractAddress,
+		FirstBlock: 0,
+		LastBlock:  99,
+		Status:     EpochStatusProcessedAllInputs,
+	}
+	epoch.Id, err = s.database.InsertEpoch(s.ctx, &epoch)
+	s.Require().Nil(err)
+
+	input := Input{
+		Index:            0,
+		CompletionStatus: InputStatusAccepted,
+		BlockNumber:      1,
+		RawData:          []byte("data"),
+		AppAddress:       app.ContractAddress,
+		EpochId:          epoch.Id,
+	}
+	input.Id, err = s.database.InsertInput(s.ctx, &input)
+	s.Require().Nil(err)
+
+	output1 := Output{
+		Index:   102,
+		RawData: []byte("data"),
+		InputId: input.Id,
+	}
+	output1.Id, err = s.database.InsertOutput(s.ctx, &output1)
+	s.Require().Nil(err)
+
+	output1.Id = 978233982398 // non-existing id
+	claim := common.BytesToHash([]byte("claim"))
+	epoch.ClaimHash = &claim
 	epoch.Status = EpochStatusClaimComputed
 
-	expectedEpoch, err := s.database.GetEpoch(s.ctx, epoch.Index, common.HexToAddress("deadbeef"))
+	err = s.database.SetEpochClaimAndInsertProofsTransaction(
+		s.ctx,
+		epoch,
+		[]Output{output1},
+	)
+	s.Require().NotNil(err)
+	s.ErrorContains(err, "No rows affected")
+
+	nonUpdatedEpoch, err := s.database.GetEpoch(s.ctx, epoch.Index, epoch.AppAddress)
 	s.Require().Nil(err)
-
-	var outputs []Output
-	outputs = append(outputs, output)
-
-	err = s.database.SetEpochClaimAndInsertProofsTransaction(s.ctx, *epoch, outputs)
-	s.Require().ErrorContains(err, "unable to set claim")
-
-	actualEpoch, err := s.database.GetEpoch(s.ctx, expectedEpoch.Index, expectedEpoch.AppAddress)
-	s.Require().Nil(err)
-	s.Require().NotNil(actualEpoch)
-	s.Require().Equal(expectedEpoch, actualEpoch)
+	s.Require().NotNil(nonUpdatedEpoch)
+	s.Nil(nonUpdatedEpoch.ClaimHash)
+	s.Equal(EpochStatusProcessedAllInputs, nonUpdatedEpoch.Status)
 }


### PR DESCRIPTION
I've returned the ID for newly inserted inputs and outputs to make my life easier, before realizing we're not enforcing their index uniqueness by app yet. I left it here since we will do it for all insert functions sometime soon.

Closes https://github.com/cartesi/rollups-node/issues/549.