### PR TITLE
Add reader mode and revert unnecessary changes to sunodo validator mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Disabled the `authority-claimer` when `CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED` is set to `true`.
 - Redacted the contents of `CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_REDIS_ENDPOINT`.
 
 ## [1.5.0] 2024-07-22

--- a/docs/config.md
+++ b/docs/config.md
@@ -151,7 +151,8 @@ All other log configurations are ignored.
 
 ## `CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED`
 
-When enabled, the node does not start the authority-claimer service and the Redis server, thus not making claims.
+When enabled, the node does not start Redis.
+It must be configured with an external Redis endpoint.
 
 * **Type:** `bool`
 * **Default:** `"false"`
@@ -164,7 +165,7 @@ External Redis endpoint for the node when running in the experimental sunodo val
 
 ## `CARTESI_FEATURE_DISABLE_CLAIMER`
 
-If set to true, the node will not make claims.
+If set to true, the authority-claimer service is disabled.
 
 * **Type:** `bool`
 * **Default:** `"false"`

--- a/docs/config.md
+++ b/docs/config.md
@@ -187,6 +187,13 @@ You should only use host mode for development and debugging!
 * **Type:** `bool`
 * **Default:** `"false"`
 
+## `CARTESI_FEATURE_READER_MODE_ENABLED`
+
+If set to true, the node will not generate any claims.
+
+* **Type:** `bool`
+* **Default:** `"false"`
+
 ## `CARTESI_HTTP_ADDRESS`
 
 HTTP address for the node.

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -32,6 +32,7 @@ type NodeConfig struct {
 	HttpAddress                              string
 	HttpPort                                 int
 	FeatureHostMode                          bool
+	FeatureReaderModeEnabled                 bool
 	FeatureDisableClaimer                    bool
 	FeatureDisableMachineHashCheck           bool
 	ExperimentalServerManagerBypassLog       bool
@@ -96,6 +97,7 @@ func FromEnv() NodeConfig {
 	config.FeatureDisableMachineHashCheck = getFeatureDisableMachineHashCheck()
 	config.ExperimentalServerManagerBypassLog = getExperimentalServerManagerBypassLog()
 	config.FeatureDisableClaimer = getFeatureDisableClaimer()
+	config.FeatureReaderModeEnabled = getFeatureReaderModeEnabled()
 	config.ExperimentalSunodoValidatorEnabled = getExperimentalSunodoValidatorEnabled()
 	if config.ExperimentalSunodoValidatorEnabled {
 		config.ExperimentalSunodoValidatorRedisEndpoint =

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -102,7 +102,6 @@ func FromEnv() NodeConfig {
 	if config.ExperimentalSunodoValidatorEnabled {
 		config.ExperimentalSunodoValidatorRedisEndpoint =
 			Redacted[string]{getExperimentalSunodoValidatorRedisEndpoint()}
-		config.FeatureDisableClaimer = true
 	}
 	if !config.FeatureDisableClaimer && !getExperimentalSunodoValidatorEnabled() {
 		config.Auth = authFromEnv()

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -103,7 +103,8 @@ func FromEnv() NodeConfig {
 		config.ExperimentalSunodoValidatorRedisEndpoint =
 			Redacted[string]{getExperimentalSunodoValidatorRedisEndpoint()}
 	}
-	if !config.FeatureDisableClaimer && !getExperimentalSunodoValidatorEnabled() {
+	// Authentication is only available when the claimer is enabled
+	if !config.FeatureDisableClaimer {
 		config.Auth = authFromEnv()
 	}
 	return config

--- a/internal/node/config/config_test.go
+++ b/internal/node/config/config_test.go
@@ -31,13 +31,6 @@ func TestConfigTest(t *testing.T) {
 	suite.Run(t, new(ConfigTestSuite))
 }
 
-func (s *ConfigTestSuite) TestExperimentalSunodoValidatorModeDisablesClaimer() {
-	os.Setenv("CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED", "true")
-	os.Setenv("CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_REDIS_ENDPOINT", "redis://")
-	c := FromEnv()
-	assert.Equal(s.T(), true, c.FeatureDisableClaimer)
-}
-
 func (s *ConfigTestSuite) TestAuthIsNotSetWhenClaimerIsDisabled() {
 	os.Setenv("CARTESI_FEATURE_DISABLE_CLAIMER", "true")
 	c := FromEnv()
@@ -45,9 +38,13 @@ func (s *ConfigTestSuite) TestAuthIsNotSetWhenClaimerIsDisabled() {
 }
 
 func (s *ConfigTestSuite) TestExperimentalSunodoValidatorRedisEndpointIsRedacted() {
+	enableSunodoValidatorMode()
+	c := FromEnv()
+	assert.Equal(s.T(), "[REDACTED]", c.ExperimentalSunodoValidatorRedisEndpoint.String())
+}
+
+func enableSunodoValidatorMode() {
 	os.Setenv("CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_ENABLED", "true")
 	os.Setenv("CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_REDIS_ENDPOINT",
 		"redis://username:p@ssw0rd@hostname:9999")
-	c := FromEnv()
-	assert.Equal(s.T(), "[REDACTED]", c.ExperimentalSunodoValidatorRedisEndpoint.String())
 }

--- a/internal/node/config/generate/Config.toml
+++ b/internal/node/config/generate/Config.toml
@@ -28,6 +28,12 @@ If set to true, the node will run in host mode.
 In host mode, computations will not be performed by the cartesi machine.
 You should only use host mode for development and debugging!"""
 
+[features.CARTESI_FEATURE_READER_MODE_ENABLED]
+default = "false"
+go-type = "bool"
+description = """
+If set to true, the node will not generate any claims."""
+
 [features.CARTESI_FEATURE_DISABLE_CLAIMER]
 default = "false"
 go-type = "bool"

--- a/internal/node/config/generate/Config.toml
+++ b/internal/node/config/generate/Config.toml
@@ -38,7 +38,7 @@ If set to true, the node will not generate any claims."""
 default = "false"
 go-type = "bool"
 description = """
-If set to true, the node will not make claims."""
+If set to true, the authority-claimer service is disabled."""
 
 [features.CARTESI_FEATURE_DISABLE_MACHINE_HASH_CHECK]
 default = "false"
@@ -231,7 +231,8 @@ The node will also use the 20 ports after this one for internal services."""
 default = "false"
 go-type = "bool"
 description = """
-When enabled, the node does not start the authority-claimer service and the Redis server, thus not making claims."""
+When enabled, the node does not start Redis.
+It must be configured with an external Redis endpoint."""
 
 [experimental.CARTESI_EXPERIMENTAL_SUNODO_VALIDATOR_REDIS_ENDPOINT]
 go-type = "string"

--- a/internal/node/config/generated.go
+++ b/internal/node/config/generated.go
@@ -401,6 +401,18 @@ func getFeatureHostMode() bool {
 	return val
 }
 
+func getFeatureReaderModeEnabled() bool {
+	s, ok := os.LookupEnv("CARTESI_FEATURE_READER_MODE_ENABLED")
+	if !ok {
+		s = "false"
+	}
+	val, err := toBool(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse CARTESI_FEATURE_READER_MODE_ENABLED: %v", err))
+	}
+	return val
+}
+
 func getHttpAddress() string {
 	s, ok := os.LookupEnv("CARTESI_HTTP_ADDRESS")
 	if !ok {

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -87,7 +87,7 @@ func newAdvanceRunner(c config.NodeConfig, workDir string) services.CommandServi
 		c.BlockchainHttpEndpoint.Value))
 	s.Env = append(s.Env, fmt.Sprintf("ADVANCE_RUNNER_HEALTHCHECK_PORT=%v",
 		getPort(c, portOffsetAdvanceRunner)))
-	s.Env = append(s.Env, fmt.Sprintf("READER_MODE=%v", c.FeatureDisableClaimer))
+	s.Env = append(s.Env, fmt.Sprintf("READER_MODE=%v", c.FeatureReaderModeEnabled))
 	if c.FeatureHostMode || c.FeatureDisableMachineHashCheck {
 		s.Env = append(s.Env, "SNAPSHOT_VALIDATION_ENABLED=false")
 	}


### PR DESCRIPTION
Reverts some of the changes made at #559 and add a sort of reader mode to better split the configuration in the case of the sunodo validator mode.