### PR TITLE
Fix: compose devnet check cli

### DIFF
--- a/build/compose-devnet.yaml
+++ b/build/compose-devnet.yaml
@@ -18,6 +18,8 @@ services:
     depends_on:
       devnet:
         condition: service_healthy
+      cli:
+        condition: service_completed_successfully
     environment:
       CARTESI_BLOCKCHAIN_ID: "31337"
       CARTESI_BLOCKCHAIN_HTTP_ENDPOINT: "http://devnet:8545"


### PR DESCRIPTION
When working on #535, testing worked fine, but there's actually a chance that when initiating through docker that the node starts before the cli has a chance to run migrations, thus creating an error and shutting down.

This simple PR fixes that.