### PR TITLE
fix(repository): get the previous epoch by index

### DIFF
--- a/internal/repository/validator_test.go
+++ b/internal/repository/validator_test.go
@@ -225,7 +225,7 @@ func (s *RepositorySuite) TestGetPreviousEpoch() {
 	previousEpoch, err = s.database.GetPreviousEpoch(s.ctx, epoch2)
 	s.Require().Nil(err)
 	s.Require().NotNil(previousEpoch)
-	s.Require().Equal(*previousEpoch, epoch)
+	s.Require().Equal(previousEpoch.Id, epoch.Id)
 }
 
 func (s *RepositorySuite) TestSetEpochClaimAndInsertProofsTransaction() {


### PR DESCRIPTION
Since epochs with no inputs won't be stored in the database, the block range between epochs might be disjointed, breaking this function. Filtering results based on the epoch index alone will be enough.