### PR TITLE
fix: build locally with out of tree emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: all
 all: help
 
+export PATH:=$(PATH):$(PWD)/emulator/usr/bin
+export LD_LIBRARY_PATH:=$(PWD)/emulator/usr/lib
+
 .PHONY: submodules
 submodules: ## Download the git submodules
 	@git submodule update --init --recursive

--- a/pkg/emulator/emulator.go
+++ b/pkg/emulator/emulator.go
@@ -6,7 +6,8 @@
 // (mainly machine-c-api.h and jsonrpc-machine-c-api.h).
 package emulator
 
-// #cgo LDFLAGS: -lcartesi -lcartesi_jsonrpc
+// #cgo CFLAGS: -I${SRCDIR}/../../emulator/usr/include
+// #cgo LDFLAGS: -L${SRCDIR}/../../emulator/usr/lib -lcartesi -lcartesi_jsonrpc
 // #include <stdlib.h>
 // #include "cartesi-machine/jsonrpc-machine-c-api.h"
 import "C"

--- a/pkg/emulator/emulator_test.go
+++ b/pkg/emulator/emulator_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	imagesPath = "/usr/share/cartesi-machine/images/"
+	imagesPath = "../../"
 	address    = "127.0.0.1:8081"
 )
 

--- a/test/tooling/snapshot/snapshot.go
+++ b/test/tooling/snapshot/snapshot.go
@@ -20,7 +20,7 @@ const ramLength = 64 << 20
 
 // ImagesPath is the path to the folder containing the linux.bin and rootfs.ext2 files.
 // It can be redefined in case the files are not in the default folder.
-var ImagesPath = "/usr/share/cartesi-machine/images/"
+var ImagesPath = "../../" //"/usr/share/cartesi-machine/images/"
 
 func init() {
 	if value, ok := os.LookupEnv("TESTS_IMAGES_PATH"); ok {


### PR DESCRIPTION
Run unit tests locally.
1) Setup the emulator: clone, build install into: emulator
```
git clone git@github.com:cartesi/machine-emulator.git emulator-src
make -C emulator-src -j$(nproc) install DESTDIR=$PWD/emulator
```

2) Setup linux and rootfs
```
wget -O linux.bin https://github.com/cartesi/image-kernel/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin
wget -O rootfs.ext2 https://github.com/cartesi/machine-emulator-tools/releases/download/v0.16.1/rootfs-tools-v0.16.1.ext2
```

3) run tests
```
make test
```