### PR TITLE
fix: read ABI from embedded variable

### DIFF
--- a/internal/espressoreader/espresso_reader.go
+++ b/internal/espressoreader/espresso_reader.go
@@ -20,7 +20,7 @@ import (
 	"github.com/cartesi/rollups-node/internal/evmreader"
 	"github.com/cartesi/rollups-node/internal/model"
 	"github.com/cartesi/rollups-node/internal/repository"
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/cartesi/rollups-node/pkg/rollupsmachine"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
 )
@@ -151,16 +151,7 @@ func (e *EspressoReader) Run(ctx context.Context, ready chan<- struct{}) error {
 					}
 				}
 				// abi encode payload
-				abiFile, err := os.Open("pkg/rollupsmachine/abi.json")
-				if err != nil {
-					slog.Error("failed to open abi file", "error", err)
-					continue
-				}
-				abiObject, err := abi.JSON(abiFile)
-				if err != nil {
-					slog.Error("failed to read abi", "error", err)
-					continue
-				}
+				abiObject := rollupsmachine.GetAbi()
 				chainId := &big.Int{}
 				chainId.SetInt64(int64(e.chainId))
 				l1FinalizedCurrentHeightBig := &big.Int{}

--- a/internal/evmreader/input.go
+++ b/internal/evmreader/input.go
@@ -9,10 +9,9 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"os"
 
 	. "github.com/cartesi/rollups-node/internal/model"
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/cartesi/rollups-node/pkg/rollupsmachine"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -335,17 +334,7 @@ func getEpochLength(consensus ConsensusContract) (uint64, error) {
 
 func (r *EvmReader) modifyIndex(ctx context.Context, rawData []byte, appAddress common.Address) ([]byte, error) {
 	// load contract ABI
-	abiFile, err := os.Open("pkg/rollupsmachine/abi.json")
-	if err != nil {
-		slog.Error("failed to open abi file", "error", err)
-		return []byte{}, err
-	}
-	abiObject, err := abi.JSON(abiFile)
-	if err != nil {
-		slog.Error("failed to parse abi", "error", err)
-		return []byte{}, err
-	}
-
+	abiObject := rollupsmachine.GetAbi()
 	values, err := abiObject.Methods["EvmAdvance"].Inputs.Unpack(rawData[4:])
 	if err != nil {
 		slog.Error("Error unpacking abi", "err", err)

--- a/pkg/rollupsmachine/io.go
+++ b/pkg/rollupsmachine/io.go
@@ -103,3 +103,7 @@ func decodeArguments(payload []byte) (arguments []any, _ error) {
 
 	return method.Inputs.Unpack(payload[4:])
 }
+
+func GetAbi() abi.ABI {
+	return ioABI
+}


### PR DESCRIPTION
ABI should not be read from the disk all the time, much better to read the embedded variable already present in `pkg/rollupsmachine/io.go`