### PR TITLE
Fix Typos in Documentation

### DIFF
--- a/offchain/advance-runner/tests/host_integration.rs
+++ b/offchain/advance-runner/tests/host_integration.rs
@@ -209,7 +209,7 @@ async fn advance_runner_finishes_epoch_when_the_previous_epoch_has_inputs() {
     assert_eq!(claims.len(), 0);
 }
 
-/// Send an input, an finish epoch, and another input.
+/// Send an input, a finish epoch, and another input.
 /// After the second input is processed by the server-manager we know
 /// for sure that the advance_runner finished processing the finish epoch.
 /// We can't simply wait for the epoch to be finished because the advance_runner

--- a/offchain/advance-runner/tests/server_integration.rs
+++ b/offchain/advance-runner/tests/server_integration.rs
@@ -205,7 +205,7 @@ async fn test_advance_runner_finishes_epoch_when_it_has_no_inputs() {
     assert_eq!(claims.len(), 0);
 }
 
-/// Send an input, an finish epoch, and another input.
+/// Send an input, a finish epoch, and another input.
 /// After the second input is processed by the server-manager we know
 /// for sure that the advance_runner finished processing the finish epoch.
 /// We can't simply wait for the epoch to be finished because the advance_runner

--- a/offchain/http-server/src/lib.rs
+++ b/offchain/http-server/src/lib.rs
@@ -23,7 +23,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-/// Starts a HTTP server with two endpoints: /healthz and /metrics.
+/// Starts an HTTP server with two endpoints: /healthz and /metrics.
 ///
 /// The `Registry` parameter is a `prometheus` type used for metric tracking.
 pub async fn start(

--- a/offchain/inspect-server/src/server.rs
+++ b/offchain/inspect-server/src/server.rs
@@ -85,7 +85,7 @@ impl From<InspectStateResponse> for HttpInspectResponse {
 }
 
 fn convert_status(status: i32) -> String {
-    // Unfortunaly, the gRPC interface uses i32 instead of a Enum type,
+    // Unfortunaly, the gRPC interface uses i32 instead of an Enum type,
     // so it is clearer to use if-else instead of match.
     if status == CompletionStatus::Accepted as i32 {
         String::from("Accepted")

--- a/offchain/rollups-events/src/rollups_inputs.rs
+++ b/offchain/rollups-events/src/rollups_inputs.rs
@@ -33,7 +33,7 @@ pub enum RollupsData {
     /// Input that advances the Cartesi Rollups epoch
     AdvanceStateInput(RollupsAdvanceStateInput),
 
-    /// End of an Cartesi Rollups epoch
+    /// End of a Cartesi Rollups epoch
     FinishEpoch {},
 }
 


### PR DESCRIPTION
This pull request addresses several minor typographical errors in documentation and comments across five files in the project. These changes improve clarity and maintain consistency without altering the functionality of the code.

### Summary of Changes
1. **`host_integration.rs`**: Corrected article usage in comments.
2. **`server_integration.rs`**: Fixed article consistency in a comment.
3. **`lib.rs`**: Adjusted grammar for HTTP server documentation.
4. **`server.rs`**: Resolved typo in gRPC-related comment.
5. **`rollups_inputs.rs`**: Improved article usage in enum description.

---

## Guidelines Followed
- The PR focuses solely on fixing typos and does not include any functional changes.
- Each file addresses a specific typo, and changes are isolated for review simplicity.

---

## Checklist
- [x] Detailed description provided.
- [x] Changes follow the project's [Contributing Guidelines](https://github.com/cartesi/rollups-node/blob/main/docs/contributing.md).
- [x] PR does not introduce functional or behavioral changes.
- [x] Tests are not applicable for comment/documentation changes.
- [x] Verified changes do not affect the output of existing tests using `make test`.