### PR TITLE
fix main.go

### DIFF
--- a/internal/services/fakeservice/main.go
+++ b/internal/services/fakeservice/main.go
@@ -1,7 +1,7 @@
 // (c) Cartesi and individual authors (see AUTHORS)
 // SPDX-License-Identifier: Apache-2.0 (see LICENSE)
 
-// This file creates a dummy webserver with the sole pupose of being used
+// This file creates a dummy webserver with the sole purpose of being used
 // as a binary to test the services.Service struct
 package main
 


### PR DESCRIPTION
- Corrected the typo from "pupose" to "purpose" in `main.go`.
