### PR TITLE
typo fix in the cartesi-rollups-cli_run-deps.md

### DIFF
--- a/docs/cli/cartesi-rollups-cli_run-deps.md
+++ b/docs/cli/cartesi-rollups-cli_run-deps.md
@@ -21,7 +21,7 @@ cartesi-rollups-cli run-deps
       --devnet-mapped-port string      Devnet local listening port number (default "8545")
       --devnet-no-mining               Devnet disable mining
   -h, --help                           help for run-deps
-      --postgres-docker-image string   Postgress docker image name (default "postgres:16-alpine")
+      --postgres-docker-image string   Postgres docker image name (default "postgres:16-alpine")
       --postgres-mapped-port string    Postgres local listening port number (default "5432")
       --postgres-password string       Postgres password (default "password")
   -v, --verbose                        verbose logs


### PR DESCRIPTION
Corrected "Postgress" to "Postgres" for accuracy.