### PR TITLE
chore: bump PostgreSQL to v17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ copy-devnet-files deployment.json: ## Copy the devnet files to the host (it must
 
 start-postgres: ## Run the PostgreSQL 16 docker container
 	@echo "Starting portgres"
-	@docker run --rm --name postgres -p 5432:5432 -d -e POSTGRES_PASSWORD=password -e POSTGRES_DB=rollupsdb -v $(CURDIR)/test/postgres/init-test-db.sh:/docker-entrypoint-initdb.d/init-test-db.sh postgres:16-alpine
+	@docker run --rm --name postgres -p 5432:5432 -d -e POSTGRES_PASSWORD=password -e POSTGRES_DB=rollupsdb -v $(CURDIR)/test/postgres/init-test-db.sh:/docker-entrypoint-initdb.d/init-test-db.sh postgres:17-alpine
 	@$(MAKE) migrate
 
 start: start-postgres start-devnet ## Start the anvil devnet and PostgreSQL 16 docker containers

--- a/compose.individual-services.yaml
+++ b/compose.individual-services.yaml
@@ -19,7 +19,7 @@ services:
       - 8545:8545
 
   database:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     shm_size: 128mb
     networks:
       - devnet

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,7 +19,7 @@ services:
       - 8545:8545
 
   database:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     shm_size: 128mb
     networks:
       - devnet

--- a/test/compose/compose.test.yaml
+++ b/test/compose/compose.test.yaml
@@ -20,7 +20,7 @@ services:
       - 8545:8545
 
   database:
-    image: postgres:16-alpine
+    image: postgres:17-alpine
     shm_size: 128mb
     networks:
       - devnet


### PR DESCRIPTION
This pull request includes updates to multiple configuration files to upgrade the PostgreSQL version from 16-alpine to 17-alpine. The most important changes include modifications in the `Makefile` and various Docker Compose files.

See: https://www.postgresql.org/docs/release/17.0/

### PostgreSQL Version Upgrade:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L278-R278): Updated the PostgreSQL Docker container version from `postgres:16-alpine` to `postgres:17-alpine` in the `start-postgres` target.
* [`compose.individual-services.yaml`](diffhunk://#diff-6ac97a8906bfed12417f12f900b833db5980b94d634a508ce07ff8e08b79f2a6L22-R22): Changed the database service image from `postgres:16-alpine` to `postgres:17-alpine`.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL22-R22): Updated the database service image to use `postgres:17-alpine` instead of `postgres:16-alpine`.
* [`test/compose/compose.test.yaml`](diffhunk://#diff-24bd3a1df2b860ac8b02f8786e4bb07d05f37142c3731a4f8a9ee57f964372f2L23-R23): Modified the database service image to `postgres:17-alpine` from `postgres:16-alpine`.