### PR TITLE
chore: update emulator and tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG EMULATOR_VERSION=0.19.0
 # Build directories.
 ARG GO_BUILD_PATH=/build/cartesi/go
 
-FROM debian:bookworm-20250113 AS common-env
+FROM debian:bookworm-20250407 AS common-env
 
 USER root
 
@@ -120,7 +120,7 @@ RUN make build-debian-package DESTDIR=$PWD/_install
 # (This stage copies the binaries from previous stages.)
 # =============================================================================
 
-FROM debian:bookworm-20250113 AS rollups-node
+FROM debian:bookworm-20250407 AS rollups-node
 
 ARG NODE_RUNTIME_DIR=/var/lib/cartesi-rollups-node
 ARG GO_BUILD_PATH

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN <<EOF
     addgroup --system --gid 102 cartesi
     adduser --system --uid 102 --ingroup cartesi --disabled-login --no-create-home --home /nonexistent --gecos "cartesi user" --shell /bin/false cartesi
     ARCH=$(dpkg --print-architecture)
-    wget -O /tmp/cartesi-machine.deb "https://github.com/cartesi/machine-emulator/releases/download/v${EMULATOR_VERSION}-alpha3/cartesi-machine-v${EMULATOR_VERSION}_${ARCH}.deb"
+    wget -O /tmp/cartesi-machine-emulator.deb "https://github.com/cartesi/machine-emulator/releases/download/v${EMULATOR_VERSION}-alpha4/machine-emulator_${ARCH}.deb"
     case "$ARCH" in
-        amd64) echo "726c510632eedad51aec366634711f5062808c5aedf34b7fb7e6b2263de88e1f  /tmp/cartesi-machine.deb" | sha256sum --check ;;
-        arm64) echo "45712294ddd9cef0130074066b800d3b090a5e576ec9215e1a16f3ddcb146d29  /tmp/cartesi-machine.deb" | sha256sum --check ;;
+        amd64) echo "c18c078bc42e5fdbb1366912d0dd99173de96522580589478d96dbd0f8aa48bf  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
+        arm64) echo "bc19d297d48c4b86843486f8b0a998d46f05373a11b8fa96ad8f009fb76edbd2  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
         *) echo "unsupported architecture: $ARCH"; exit 1 ;;
     esac
-    apt-get install -y --no-install-recommends /tmp/cartesi-machine.deb
+    apt-get install -y --no-install-recommends /tmp/cartesi-machine-emulator.deb
     mkdir -p /opt/go ${GO_BUILD_PATH}/rollups-node
     chown -R cartesi:cartesi /opt/go ${GO_BUILD_PATH}
 EOF
@@ -128,8 +128,8 @@ ARG GO_BUILD_PATH
 USER root
 
 COPY --from=common-env \
-    /tmp/cartesi-machine.deb \
-    cartesi-machine.deb
+    /tmp/cartesi-machine-emulator.deb \
+    cartesi-machine-emulator.deb
 COPY --from=debian-packager \
     ${GO_BUILD_PATH}/rollups-node/cartesi-rollups-node-v*.deb \
     cartesi-rollups-node.deb
@@ -145,7 +145,7 @@ RUN <<EOF
         ca-certificates \
         curl \
         procps \
-        ./cartesi-machine.deb \
+        ./cartesi-machine-emulator.deb \
         ./cartesi-rollups-node.deb
     rm -rf /var/lib/apt/lists/* cartesi-*.deb
     mkdir -p ${NODE_RUNTIME_DIR}/snapshots ${NODE_RUNTIME_DIR}/data

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,7 @@ $(CARTESI_TEST_MACHINE_IMAGES):
 	@mkdir -p $(DOWNLOADS_DIR)
 	@wget -nc -i test/dependencies -P $(DOWNLOADS_DIR)
 	@shasum -ca 256 test/dependencies.sha256
-	@cd $(DOWNLOADS_DIR) && ln -s rootfs-tools-v0.17.0-test2.ext2 rootfs.ext2
+	@cd $(DOWNLOADS_DIR) && ln -s rootfs-tools.ext2 rootfs.ext2
 	@cd $(DOWNLOADS_DIR) && ln -s linux-6.5.13-ctsi-1-v0.20.0.bin linux.bin
 
 download-test-dependencies: | $(CARTESI_TEST_MACHINE_IMAGES)

--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ echo-dapp: applications/echo-dapp ## Echo the dapp
 applications/echo-dapp: ## Create echo-dapp test application
 	@echo "Creating echo-dapp test application"
 	@mkdir -p applications
-	@cartesi-machine --ram-length=128Mi --store=applications/echo-dapp --final-hash -- ioctl-echo-loop --vouchers=1 --notices=1 --reports=1 --verbose=1
+	@cartesi-machine --ram-length=128Mi --store=applications/echo-dapp --final-hash -- ioctl-echo-loop --vouchers=1 --delegate-call-vouchers=1 --notices=1 --reports=1 --verbose=1
 
 deploy-echo-dapp: applications/echo-dapp ## Deploy echo-dapp test application
 	@echo "Deploying echo-dapp test application"

--- a/control.template
+++ b/control.template
@@ -5,7 +5,7 @@ Homepage: https://docs.cartesi.io/cartesi-rollups/
 Architecture: ARG_ARCH
 Maintainer: Node Reference Unit <https://discord.com/channels/600597137524391947/1110564973115097179>
 Provides: cartesi-rollups-node
-Depends: cartesi-machine (>= 0.19.0), cartesi-machine (<< 0.20.0)
+Depends: cartesi-machine-emulator (>= 0.19.0), cartesi-machine-emulator (<< 0.20.0)
 Section: net
 Priority: optional
 Multi-Arch: no

--- a/pkg/emulator/emulator.go
+++ b/pkg/emulator/emulator.go
@@ -12,28 +12,29 @@ package emulator
 import "C"
 
 import (
+	"time"
 	"unsafe"
 )
 
-func ConnectServer(address string) (*RemoteMachine, error) {
+func ConnectServer(address string, timeout time.Duration) (*RemoteMachine, error) {
 	cAddr := C.CString(address)
 	defer C.free(unsafe.Pointer(cAddr))
 
 	var cm *C.cm_machine
-	if err := newError(C.cm_jsonrpc_connect_server(cAddr, &cm)); err != nil {
+	if err := newError(C.cm_jsonrpc_connect_server(cAddr, C.int64_t(timeout.Milliseconds()), &cm)); err != nil {
 		return nil, err
 	}
 	return &RemoteMachine{Machine: Machine{ptr: cm}}, nil
 }
 
-func SpawnServer(address string) (*RemoteMachine, string, uint32, error) {
+func SpawnServer(address string, timeout time.Duration) (*RemoteMachine, string, uint32, error) {
 	cAddr := C.CString(address)
 	defer C.free(unsafe.Pointer(cAddr))
 
 	var cm *C.cm_machine
 	var boundAddr *C.char
 	var pid C.uint32_t
-	code := C.cm_jsonrpc_spawn_server(cAddr, &cm, &boundAddr, &pid)
+	code := C.cm_jsonrpc_spawn_server(cAddr, C.int64_t(timeout.Milliseconds()), &cm, &boundAddr, &pid)
 	if err := newError(code); err != nil {
 		return nil, "", 0, err
 	}

--- a/pkg/rollupsmachine/abi.json
+++ b/pkg/rollupsmachine/abi.json
@@ -21,6 +21,13 @@
     ]
 }, {
     "type" : "function",
+    "name" : "DelegateCallVoucher",
+    "inputs" : [
+        { "type" : "address" },
+        { "type" : "bytes"   }
+    ]
+}, {
+    "type" : "function",
     "name" : "Notice",
     "inputs" : [
         { "type" : "bytes"   }

--- a/pkg/rollupsmachine/cartesimachine/machine.go
+++ b/pkg/rollupsmachine/cartesimachine/machine.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/cartesi/rollups-node/internal/model"
 	"github.com/cartesi/rollups-node/pkg/emulator"
 )
 
@@ -38,6 +39,7 @@ func Load(ctx context.Context,
 	path string,
 	address string,
 	config *emulator.MachineRuntimeConfig,
+	executionParameters *model.ExecutionParameters,
 ) (CartesiMachine, error) {
 	machine := &cartesiMachine{address: address}
 
@@ -52,7 +54,7 @@ func Load(ctx context.Context,
 	}
 
 	// Connect to the machine server
-	server, err := emulator.ConnectServer(address)
+	server, err := emulator.ConnectServer(address, executionParameters.FastDeadline)
 	if err != nil {
 		err = fmt.Errorf("could not connect to the remote machine: %w", err)
 		return nil, errCartesiMachine(err)

--- a/pkg/rollupsmachine/cartesimachine/server.go
+++ b/pkg/rollupsmachine/cartesimachine/server.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/cartesi/rollups-node/internal/model"
 	"github.com/cartesi/rollups-node/internal/services/linewriter"
 	"github.com/cartesi/rollups-node/pkg/emulator"
 )
@@ -74,7 +75,7 @@ func StartServer(logger *slog.Logger, verbosity MachineLogLevel, port uint32, st
 	}
 
 	// Creates the command.
-	cmd := exec.Command("jsonrpc-remote-cartesi-machine", args...)
+	cmd := exec.Command("cartesi-jsonrpc-machine", args...)
 
 	// Redirects stdout and stderr.
 	interceptor := portInterceptor{
@@ -103,13 +104,13 @@ func StartServer(logger *slog.Logger, verbosity MachineLogLevel, port uint32, st
 }
 
 // StopServer shuts down the JSON RPC remote cartesi machine server hosted at address.
-func StopServer(address string, logger *slog.Logger) error {
+func StopServer(address string, logger *slog.Logger, executionParameters *model.ExecutionParameters) error {
 	if logger == nil {
 		return ErrNilLogger
 	}
 
 	logger.Info("Stopping server at", "address", address)
-	remote, err := emulator.ConnectServer(address)
+	remote, err := emulator.ConnectServer(address, executionParameters.FastDeadline)
 	if err != nil {
 		return err
 	}

--- a/test/dependencies
+++ b/test/dependencies
@@ -1,2 +1,2 @@
 https://github.com/cartesi/image-kernel/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin
-https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.0-test2/rootfs-tools-v0.17.0-test2.ext2
+https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.0/rootfs-tools.ext2

--- a/test/dependencies.sha256
+++ b/test/dependencies.sha256
@@ -1,2 +1,2 @@
 65dd100ff6204346ac2f50f772721358b5c1451450ceb39a154542ee27b4c947  test/downloads/linux-6.5.13-ctsi-1-v0.20.0.bin
-293f377b0cb32cc477ef2c71be9430bab3a25d54eb0ab9aff07a4e6fac6aa829  test/downloads/rootfs-tools-v0.17.0-test2.ext2
+8eb9d03b2653fc6090caf4ae3fb49b44fe1ccd57d9903dd696c0a3024ea1a031  test/downloads/rootfs-tools.ext2

--- a/test/devnet/Dockerfile
+++ b/test/devnet/Dockerfile
@@ -2,7 +2,7 @@ ARG FOUNDRY_VERSION=1.0.0
 ARG CONTRACTS_VERSION=2.0.0-rc.17
 ARG DEVNET_BUILD_PATH=/opt/cartesi/rollups-contracts
 
-FROM debian:bookworm-20250113 AS rollups-node-devnet
+FROM debian:bookworm-20250407 AS rollups-node-devnet
 ARG FOUNDRY_VERSION
 ARG CONTRACTS_VERSION
 ARG DEVNET_BUILD_PATH


### PR DESCRIPTION
Draft to test the latest `machine-emulator` (https://github.com/cartesi/machine-emulator/pull/323) and tools 0.17-test2.

blocked by: https://github.com/cartesi/machine-emulator/pull/323

TODO:
- [x] update docker image version
- [x] update base docker images