### PR TITLE
getLastAcceptedEpochIndex

### DIFF
--- a/internal/jsonrpc/jsonrpc-discover.json
+++ b/internal/jsonrpc/jsonrpc-discover.json
@@ -139,9 +139,9 @@
 			}
 		},
 		{
-			"name": "cartesi_getLastAcceptedEpoch",
-			"summary": "Get the last accepted epoch",
-			"description": "Fetches the latest accepted epoch by application.",
+			"name": "cartesi_getLastAcceptedEpochIndex",
+			"summary": "Get the last accepted epoch index",
+			"description": "Fetches the latest accepted epoch index by application.",
 			"params": [
 				{
 					"name": "application",
@@ -155,7 +155,7 @@
 			"result": {
 				"name": "result",
 				"schema": {
-					"$ref": "#/components/schemas/EpochGetResult"
+					"$ref": "#/components/schemas/LastAcceptedEpochIndexResult"
 				}
 			}
 		},
@@ -724,10 +724,18 @@
 					}
 				}
 			},
+			"LastAcceptedEpochIndexResult": {
+				"type": "object",
+				"properties": {
+					"data": {
+						"$ref": "#/components/schemas/UnsignedInteger"
+					}
+				}
+			},
 			"ProcessedInputCountResult": {
 				"type": "object",
 				"properties": {
-					"processed_inputs": {
+					"data": {
 						"$ref": "#/components/schemas/UnsignedInteger"
 					}
 				}

--- a/internal/repository/postgres/application.go
+++ b/internal/repository/postgres/application.go
@@ -219,7 +219,7 @@ func (r *PostgresRepository) GetProcessedInputs(
 	var processedInputs uint64
 	err = row.Scan(&processedInputs)
 	if errors.Is(err, sql.ErrNoRows) {
-		return 0, repository.ErrApplicationNotFound
+		return 0, repository.ErrNotFound
 	}
 	return processedInputs, err
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	ErrApplicationNotFound = fmt.Errorf("application not found")
+	ErrNotFound = fmt.Errorf("not found")
 )
 
 type Pagination struct {
@@ -78,7 +78,7 @@ type EpochRepository interface {
 	CreateEpochsAndInputs(ctx context.Context, nameOrAddress string, epochInputMap map[*Epoch][]*Input, blockNumber uint64) error
 
 	GetEpoch(ctx context.Context, nameOrAddress string, index uint64) (*Epoch, error)
-	GetLastAcceptedEpoch(ctx context.Context, nameOrAddress string) (*Epoch, error)
+	GetLastAcceptedEpochIndex(ctx context.Context, nameOrAddress string) (uint64, error)
 	GetEpochByVirtualIndex(ctx context.Context, nameOrAddress string, index uint64) (*Epoch, error)
 
 	UpdateEpoch(ctx context.Context, nameOrAddress string, e *Epoch) error

--- a/pkg/jsonrpc/client/client.go
+++ b/pkg/jsonrpc/client/client.go
@@ -26,6 +26,7 @@ type JsonRpcClient interface {
 	GetApplicationAddress(ctx context.Context, name string) (string, error)
 	ListEpochs(ctx context.Context, application string, status *string, limit, offset int64) ([]*model.Epoch, error)
 	GetEpoch(ctx context.Context, application string, index uint64) (*model.Epoch, error)
+	GetLastAcceptedEpochIndex(ctx context.Context, application string) (uint64, error)
 	ListInputs(ctx context.Context, application string, epochIndex *string, sender *string, decode bool, limit, offset int64) ([]interface{}, error)
 	GetInput(ctx context.Context, application string, inputIndex string, decode bool) (any, error)
 	GetProcessedInputCount(ctx context.Context, application string) (int64, error)
@@ -295,6 +296,20 @@ func (c *Client) GetEpoch(ctx context.Context, application string, index uint64)
 		return nil, err
 	}
 	return result.Epoch, nil
+}
+
+// GetLastAcceptedEpochIndex calls "cartesi_getLastAcceptedEpochIndex".
+func (c *Client) GetLastAcceptedEpochIndex(ctx context.Context, application string) (uint64, error) {
+	params := struct {
+		Application string `json:"application"`
+	}{Application: application}
+	var result struct {
+		LastAcceptedEpochIndex uint64 `json:"data"`
+	}
+	if err := c.Call(ctx, "cartesi_getLastAcceptedEpochIndex", params, &result); err != nil {
+		return 0, err
+	}
+	return result.LastAcceptedEpochIndex, nil
 }
 
 // ListInputs calls "cartesi_ListInputs".


### PR DESCRIPTION
Replaces `cartesi_getLastAcceptedEpoch` with `cartesi_getLastAcceptedEpochIndex` that returns only the epoch index, and not the entire `Epoch` object.
I think this is more consistent with the `cartesi_getProcessedInputCount` method, that only returns a number (index), instead of a `cartesi_getLastProcessedInput` that would return an `Input` object.

Typically an application will use the last accepted epoch index to compare with the epoch index of outputs, to know if those outputs can be executed or not, with a "lower than" comparison. A full epoch object is not needed in that case.

I did not change the repository implementation to query only for the index, it is still querying for the epoch object.
