### PR TITLE
fix: compose db init

### DIFF
--- a/compose.individual-services.yaml
+++ b/compose.individual-services.yaml
@@ -36,7 +36,7 @@ services:
 
   migration:
     image: cartesi/rollups-node:devel
-    command: cartesi-rollups-cli db upgrade
+    command: cartesi-rollups-cli db init
     depends_on:
       database:
         condition: service_healthy

--- a/compose.yaml
+++ b/compose.yaml
@@ -36,7 +36,7 @@ services:
 
   migration:
     image: cartesi/rollups-node:devel
-    command: cartesi-rollups-cli db upgrade
+    command: cartesi-rollups-cli db init
     depends_on:
       database:
         condition: service_healthy


### PR DESCRIPTION
Fix the compose database initialization command, which recently changed from `upgrade` to `init`.
