### PR TITLE
fix(ethutil): strict mnemonic checking

### DIFF
--- a/pkg/ethutil/mnemonic.go
+++ b/pkg/ethutil/mnemonic.go
@@ -25,7 +25,10 @@ func PrivateKeyToAddress(privateKey *ecdsa.PrivateKey) (common.Address, error) {
 // Create the private key from mnemonic and account index based on the BIP44 standard.
 // For more info on BIP44, see https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 func MnemonicToPrivateKey(mnemonic string, accountIndex uint32) (*ecdsa.PrivateKey, error) {
-	seed := bip39.NewSeed(mnemonic, "")
+	seed, err := bip39.NewSeedWithErrorChecking(mnemonic, "")
+	if err != nil {
+		return nil, err
+	}
 
 	masterKey, err := bip32.NewMasterKey(seed)
 	if err != nil {


### PR DESCRIPTION
Deploying with an incorrect mnemonic.

From:
```
Authoriy contract creation failed: transaction failed: Out of gas: gas required exceeds allowance: 0
```

To:
```
Error: Invalid mnenomic
```