### PR TITLE
Feature/max block range

### DIFF
--- a/cmd/cartesi-rollups-claimer/root/root.go
+++ b/cmd/cartesi-rollups-claimer/root/root.go
@@ -32,6 +32,7 @@ var (
 	enableSubmission       bool
 	telemetryAddress       string
 	cfg                    *config.ClaimerConfig
+	maxBlockRange          uint64
 )
 
 var Cmd = &cobra.Command{
@@ -71,6 +72,10 @@ func init() {
 
 	Cmd.Flags().BoolVar(&enableSubmission, "claim-submission", true, "Enable or disable claim submission (reader mode)")
 	cobra.CheckErr(viper.BindPFlag(config.FEATURE_CLAIM_SUBMISSION_ENABLED, Cmd.Flags().Lookup("claim-submission")))
+
+	Cmd.Flags().Uint64Var(&maxBlockRange, "max-block-range", 0,
+		"Maximum number of blocks in a single query. large queries will be split automatically. Zero for unlimited.")
+	cobra.CheckErr(viper.BindPFlag(config.BLOCKCHAIN_MAX_BLOCK_RANGE, Cmd.Flags().Lookup("max-block-range")))
 
 	// TODO: validate on preRunE
 	Cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/cartesi-rollups-evm-reader/root/root.go
+++ b/cmd/cartesi-rollups-evm-reader/root/root.go
@@ -33,6 +33,7 @@ var (
 	enableInputReader      bool
 	telemetryAddress       string
 	cfg                    *config.EvmreaderConfig
+	maxBlockRange          uint64
 )
 
 var Cmd = &cobra.Command{
@@ -72,6 +73,10 @@ func init() {
 
 	Cmd.Flags().BoolVar(&enableInputReader, "input-reader", true, "Enable or disable the input reader (for external input readers)")
 	cobra.CheckErr(viper.BindPFlag(config.FEATURE_INPUT_READER_ENABLED, Cmd.Flags().Lookup("input-reader")))
+
+	Cmd.Flags().Uint64Var(&maxBlockRange, "max-block-range", 0,
+		"Maximum number of blocks in a single query. large queries will be split automatically. Zero for unlimited.")
+	cobra.CheckErr(viper.BindPFlag(config.BLOCKCHAIN_MAX_BLOCK_RANGE, Cmd.Flags().Lookup("max-block-range")))
 
 	// TODO: validate on preRunE
 	Cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/cmd/cartesi-rollups-node/root/root.go
+++ b/cmd/cartesi-rollups-node/root/root.go
@@ -43,6 +43,7 @@ var (
 	telemetryAddress       string
 	machinelogLevel        string
 	cfg                    *config.NodeConfig
+	maxBlockRange          uint64
 )
 
 var Cmd = &cobra.Command{
@@ -114,6 +115,10 @@ func init() {
 	Cmd.Flags().StringVar(&machinelogLevel, "machine-log-level", "info",
 		"Remote Machine log level: trace, debug, info, warning, error, fatal")
 	cobra.CheckErr(viper.BindPFlag(config.REMOTE_MACHINE_LOG_LEVEL, Cmd.Flags().Lookup("machine-log-level")))
+
+	Cmd.Flags().Uint64Var(&maxBlockRange, "max-block-range", 0,
+		"Maximum number of blocks in a single query. large queries will be split automatically. Zero for unlimited.")
+	cobra.CheckErr(viper.BindPFlag(config.BLOCKCHAIN_MAX_BLOCK_RANGE, Cmd.Flags().Lookup("max-block-range")))
 
 	// TODO: validate on preRunE
 	Cmd.PreRunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/claimer/blockchain.go
+++ b/internal/claimer/blockchain.go
@@ -73,6 +73,7 @@ type claimerBlockchain struct {
 	client       *ethclient.Client
 	txOpts       *bind.TransactOpts
 	logger       *slog.Logger
+	filter       ethutil.Filter
 	defaultBlock config.DefaultBlock
 }
 
@@ -150,7 +151,7 @@ func (self *claimerBlockchain) findClaimSubmittedEventAndSucc(
 		return nil, nil, nil, err
 	}
 
-	it, err := ethutil.ChunkedFilterLogs(ctx, self.client, ethereum.FilterQuery{
+	it, err := self.filter.ChunkedFilterLogs(ctx, self.client, ethereum.FilterQuery{
 		FromBlock: new(big.Int).SetUint64(epoch.LastBlock),
 		ToBlock:   endBlock,
 		Addresses: []common.Address{application.IConsensusAddress},
@@ -230,7 +231,7 @@ func (self *claimerBlockchain) findClaimAcceptedEventAndSucc(
 		return nil, nil, nil, err
 	}
 
-	it, err := ethutil.ChunkedFilterLogs(ctx, self.client, ethereum.FilterQuery{
+	it, err := self.filter.ChunkedFilterLogs(ctx, self.client, ethereum.FilterQuery{
 		FromBlock: new(big.Int).SetUint64(epoch.LastBlock),
 		ToBlock:   endBlock,
 		Addresses: []common.Address{application.IConsensusAddress},

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -155,6 +155,13 @@ description = """
 Maximum wait time in seconds for the exponential backoff retry policy. The delay between retries for HTTP blockchain requests will never exceed this value, regardless of the backoff calculation."""
 used-by = ["evmreader", "claimer", "node"]
 
+[rollups.CARTESI_BLOCKCHAIN_MAX_BLOCK_RANGE]
+default = "math.MaxUint64"
+go-type = "uint64"
+description = """
+Maximum number of blocks in a single query to the provider. Queries with larger ranges will be broken into multiple smaller queries. Zero for unlimited."""
+used-by = ["evmreader", "claimer", "node"]
+
 #
 # Contracts
 #

--- a/internal/evmreader/application_adapter.go
+++ b/internal/evmreader/application_adapter.go
@@ -22,11 +22,13 @@ type ApplicationContractAdapterImpl struct {
 	application        *iapplication.IApplication
 	client             *ethclient.Client
 	applicationAddress common.Address
+	filter             ethutil.Filter
 }
 
 func NewApplicationContractAdapter(
 	appAddress common.Address,
 	client *ethclient.Client,
+	filter ethutil.Filter,
 ) (ApplicationContractAdapter, error) {
 	applicationContract, err := iapplication.NewIApplication(appAddress, client)
 	if err != nil {
@@ -36,6 +38,7 @@ func NewApplicationContractAdapter(
 		application:        applicationContract,
 		applicationAddress: appAddress,
 		client:             client,
+		filter:             filter,
 	}, nil
 }
 
@@ -74,7 +77,7 @@ func (a *ApplicationContractAdapterImpl) RetrieveOutputExecutionEvents(
 		return nil, err
 	}
 
-	itr, err := ethutil.ChunkedFilterLogs(opts.Context, a.client, q)
+	itr, err := a.filter.ChunkedFilterLogs(opts.Context, a.client, q)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evmreader/evmreader.go
+++ b/internal/evmreader/evmreader.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cartesi/rollups-node/internal/repository"
 	"github.com/cartesi/rollups-node/pkg/contracts/iapplication"
 	"github.com/cartesi/rollups-node/pkg/contracts/iinputbox"
+	"github.com/cartesi/rollups-node/pkg/ethutil"
 )
 
 // Interface for the node repository
@@ -234,7 +235,9 @@ type AdapterFactory interface {
 	CreateAdapters(app *Application, client EthClientInterface) (ApplicationContractAdapter, InputSourceAdapter, error)
 }
 
-type DefaultAdapterFactory struct{}
+type DefaultAdapterFactory struct {
+	Filter ethutil.Filter
+}
 
 func (f *DefaultAdapterFactory) CreateAdapters(app *Application, client EthClientInterface) (ApplicationContractAdapter, InputSourceAdapter, error) {
 	if app == nil {
@@ -247,7 +250,7 @@ func (f *DefaultAdapterFactory) CreateAdapters(app *Application, client EthClien
 		return nil, nil, fmt.Errorf("client is not an *ethclient.Client, cannot create adapters")
 	}
 
-	applicationContract, err := NewApplicationContractAdapter(app.IApplicationAddress, ethClient)
+	applicationContract, err := NewApplicationContractAdapter(app.IApplicationAddress, ethClient, f.Filter)
 	if err != nil {
 		return nil, nil, errors.Join(
 			fmt.Errorf("error building application contract"),
@@ -255,7 +258,7 @@ func (f *DefaultAdapterFactory) CreateAdapters(app *Application, client EthClien
 		)
 	}
 
-	inputSource, err := NewInputSourceAdapter(app.IInputBoxAddress, ethClient)
+	inputSource, err := NewInputSourceAdapter(app.IInputBoxAddress, ethClient, f.Filter)
 	if err != nil {
 		return nil, nil, errors.Join(
 			fmt.Errorf("error building inputbox contract"),
@@ -265,5 +268,3 @@ func (f *DefaultAdapterFactory) CreateAdapters(app *Application, client EthClien
 
 	return applicationContract, inputSource, nil
 }
-
-var defaultAdapterFactory = &DefaultAdapterFactory{}

--- a/internal/evmreader/inputsource_adapter.go
+++ b/internal/evmreader/inputsource_adapter.go
@@ -22,11 +22,13 @@ type InputSourceAdapterImpl struct {
 	inputbox        *iinputbox.IInputBox
 	client          *ethclient.Client
 	inputBoxAddress common.Address
+	filter          ethutil.Filter
 }
 
 func NewInputSourceAdapter(
 	inputBoxAddress common.Address,
 	client *ethclient.Client,
+	filter ethutil.Filter,
 ) (InputSourceAdapter, error) {
 	inputbox, err := iinputbox.NewIInputBox(inputBoxAddress, client)
 	if err != nil {
@@ -36,6 +38,7 @@ func NewInputSourceAdapter(
 		inputbox:        inputbox,
 		client:          client,
 		inputBoxAddress: inputBoxAddress,
+		filter:          filter,
 	}, nil
 }
 
@@ -89,7 +92,7 @@ func (i *InputSourceAdapterImpl) RetrieveInputs(
 		return nil, err
 	}
 
-	itr, err := ethutil.ChunkedFilterLogs(opts.Context, i.client, q)
+	itr, err := i.filter.ChunkedFilterLogs(opts.Context, i.client, q)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Providers limit the range of blocks it accepts, a.k.a `to - from` value. To accommodate the particularities of each provider we implemented a refinement algorithm that splits a large query into multiple smaller ones and the stitches the results back together.

Now in addition to that algorithm, we've implemented a environment variable that lets users directly specify the split point as a environment variable `CARTESI_BLOCKCHAIN_MAX_BLOCK_RANGE`.