### PR TITLE
allow “postgresql://“ connection prefix

### DIFF
--- a/internal/repository/factory/factory.go
+++ b/internal/repository/factory/factory.go
@@ -23,7 +23,7 @@ import (
 func NewRepositoryFromConnectionString(ctx context.Context, conn string) (Repository, error) {
 	lowerConn := strings.ToLower(conn)
 	switch {
-	case strings.HasPrefix(lowerConn, "postgres://"):
+	case strings.HasPrefix(lowerConn, "postgres://"), strings.HasPrefix(lowerConn, "postgresql://"):
 		return newPostgresRepository(ctx, conn)
 	// case strings.HasPrefix(lowerConn, "sqlite://"):
 	// 	return newSQLiteRepository(ctx, conn)


### PR DESCRIPTION
https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS

"The URI scheme designator can be either postgresql:// or postgres://."

