### PR TITLE
docs: Fix Markdown Syntax Error

### DIFF
--- a/offchain/authority-claimer/README.md
+++ b/offchain/authority-claimer/README.md
@@ -18,7 +18,7 @@ Instead of using evironment variables,
     the claimer will get the list of application addresses from Redis,
     through the `experimental-dapp-addresses-config` key.
 This key holds a [Redis Set](https://redis.io/docs/latest/develop/data-types/sets/) value.
-You must use commands such as [`SADD`](https://redis.io/docs/latest/commands/sadd/) and [`SREM`]https://redis.io/docs/latest/commands/srem/() to manipulate the set of addresses.
+You must use commands such as [`SADD`](https://redis.io/docs/latest/commands/sadd/) and [`SREM`](https://redis.io/docs/latest/commands/srem/) to manipulate the set of addresses.
 
 Application addresses must be encoded as hex strings.
 The prefix `0x` is ignored by the `authority-claimer` when loading applications adresses.


### PR DESCRIPTION
### Fix Markdown Syntax Error in Redis Command Link

#### Problem
The documentation contained a Markdown syntax error in the link for the [`SREM`] Redis command. The link was previously written as [`SREM`]https://redis.io/docs/latest/commands/srem/(), which caused incorrect rendering due to misplaced parentheses.

#### Solution
This pull request updates the link to use the correct Markdown format: [`SREM`](https://redis.io/docs/latest/commands/srem/). This ensures the link is properly rendered and clickable in the documentation.

#### Issue Reference
No specific issue was opened for this fix, as it is a minor documentation correction. If required, I can open an issue for tracking purposes.

#### Additional Notes
- This PR addresses a single documentation formatting issue and does not introduce any code changes.
- No tests are affected by this change.
- The change follows the project's contribution and documentation guidelines.

---
**Please let me know if an issue should be created for this fix, or if any further changes are required.**