### PR TITLE
feat(evm-reader): fast sync the last input check block when the appli…

### DIFF
--- a/internal/evmreader/application_adapter.go
+++ b/internal/evmreader/application_adapter.go
@@ -95,3 +95,7 @@ func (a *ApplicationContractAdapterImpl) RetrieveOutputExecutionEvents(
 	}
 	return events, nil
 }
+
+func (a *ApplicationContractAdapterImpl) GetDeploymentBlockNumber(opts *bind.CallOpts) (*big.Int, error) {
+	return a.application.GetDeploymentBlockNumber(opts)
+}

--- a/internal/evmreader/evmreader.go
+++ b/internal/evmreader/evmreader.go
@@ -57,6 +57,7 @@ type ApplicationContractAdapter interface {
 	RetrieveOutputExecutionEvents(
 		opts *bind.FilterOpts,
 	) ([]*iapplication.IApplicationOutputExecuted, error)
+	GetDeploymentBlockNumber(opts *bind.CallOpts) (*big.Int, error)
 }
 
 // Interface for Input reading
@@ -65,6 +66,7 @@ type InputSourceAdapter interface {
 	// by go-ethereum and cannot be used for testing
 	RetrieveInputs(opts *bind.FilterOpts, appAddresses []common.Address, index []*big.Int,
 	) ([]iinputbox.IInputBoxInputAdded, error)
+	GetNumberOfInputs(opts *bind.CallOpts, appContract common.Address) (*big.Int, error)
 }
 
 type SubscriptionError struct {

--- a/internal/evmreader/evmreader_test.go
+++ b/internal/evmreader/evmreader_test.go
@@ -377,6 +377,11 @@ func (m *MockInputBox) RetrieveInputs(
 	return args.Get(0).([]iinputbox.IInputBoxInputAdded), args.Error(1)
 }
 
+func (m *MockInputBox) GetNumberOfInputs(opts *bind.CallOpts, appContract common.Address) (*big.Int, error) {
+	args := m.Called(opts, appContract)
+	return args.Get(0).(*big.Int), args.Error(1)
+}
+
 // Mock InputReaderRepository
 type MockRepository struct {
 	mock.Mock
@@ -565,6 +570,11 @@ func (m *MockApplicationContract) RetrieveOutputExecutionEvents(
 ) ([]*iapplication.IApplicationOutputExecuted, error) {
 	args := m.Called(opts)
 	return args.Get(0).([]*iapplication.IApplicationOutputExecuted), args.Error(1)
+}
+
+func (m *MockApplicationContract) GetDeploymentBlockNumber(opts *bind.CallOpts) (*big.Int, error) {
+	args := m.Called(opts)
+	return args.Get(0).(*big.Int), args.Error(1)
 }
 
 type MockAdapterFactory struct {

--- a/internal/evmreader/input.go
+++ b/internal/evmreader/input.go
@@ -7,11 +7,105 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/big"
 
 	. "github.com/cartesi/rollups-node/internal/model"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 )
+
+// Find the last block number that should be considered checked when scanning the blockchain
+// for inputs of this application. The next search should start from (lastBlockChecked + 1).
+//
+// The main purpose of this function is to reduce the range of blocks that need to be scanned,
+// avoiding unnecessary lookups. Currently, it is only used when handling new applications.
+//
+// Rules applied in order:
+// 1. Default fallback: the block before the InputBox was deployed.
+// 2. If the application has never received inputs, use the most recent block.
+// 3. If the application has no inputs since its deployment, use the deployment block.
+// 4. Otherwise, return the block before the InputBox deployment (conservative bound).
+//
+// Note: this function returns the *last block checked*, not the first block to search.
+// Example:
+//
+//	lastBlockChecked := findLastInputCheckBlock(...)
+//	nextSearchBlock  := lastBlockChecked + 1
+func findLastInputCheckBlock(app *appContracts, mostRecentBlockNumber uint64, mostRecentBlockNumberCallOpts *bind.CallOpts) uint64 {
+	var noiBig *big.Int
+	var err error
+	blockBeforeInputBox := app.application.IInputBoxBlock - 1
+
+	// find if the application has ever received any input. sync to present if not
+	noiBig, err = app.inputSource.GetNumberOfInputs(
+		mostRecentBlockNumberCallOpts,
+		app.application.IApplicationAddress,
+	)
+	if err != nil {
+		return blockBeforeInputBox
+	}
+	if noiBig.Uint64() == 0 {
+		return mostRecentBlockNumber
+	}
+
+	// find if the application has received an input since its deployment. sync to that block if not
+	// we'll need its deployment block number to do that
+	deploymentBlockNumberBig, err := app.applicationContract.GetDeploymentBlockNumber(mostRecentBlockNumberCallOpts)
+	if err != nil {
+		return blockBeforeInputBox
+	}
+
+	noiBig, err = app.inputSource.GetNumberOfInputs(&bind.CallOpts{
+		BlockNumber: deploymentBlockNumberBig,
+	},
+		app.application.IApplicationAddress,
+	)
+	if err != nil {
+		return blockBeforeInputBox
+	}
+	if noiBig.Uint64() == 0 {
+		return deploymentBlockNumberBig.Uint64()
+	}
+
+	// TODO(mpolitzer): Application has inputs previous to its deployment. We can reduce the number of blocks to scan by
+	// doing a binary search over GetNumberOfInputs and finding the block where 0 -> 1 transition happens. As a simpler,
+	// also correct implementation. We return the first possible block an input could appear on.
+	return blockBeforeInputBox
+}
+
+// initializeNewApplicationInputSync initializes input synchronization for a new application
+// by finding the appropriate starting block and updating the database
+func (r *Service) initializeNewApplicationInputSync(
+	ctx context.Context,
+	app *appContracts,
+	mostRecentBlockNumber uint64,
+	mostRecentBlockNumberCallOpts *bind.CallOpts,
+) (uint64, error) {
+	lastInputCheckBlock := findLastInputCheckBlock(app,
+		mostRecentBlockNumber,
+		mostRecentBlockNumberCallOpts,
+	)
+
+	err := r.repository.UpdateEventLastCheckBlock(ctx, []int64{app.application.ID}, MonitoredEvent_InputAdded, lastInputCheckBlock)
+	if err != nil {
+		r.Logger.Error("Failed to update application LastInputCheckBlock",
+			"application", app.application.Name,
+			"last_input_check_block", lastInputCheckBlock,
+			"error", err,
+		)
+		return 0, err
+	}
+
+	r.Logger.Info("Initializing application input sync",
+		"application", app.application.Name,
+		"inputbox_block", app.application.IInputBoxBlock,
+		"next_search_block", lastInputCheckBlock+1,
+		"current_block", mostRecentBlockNumber,
+	)
+
+	app.application.LastInputCheckBlock = lastInputCheckBlock
+	return lastInputCheckBlock, nil
+}
 
 // checkForNewInputs checks if is there new Inputs for all running Applications
 func (r *Service) checkForNewInputs(
@@ -24,6 +118,10 @@ func (r *Service) checkForNewInputs(
 	}
 
 	r.Logger.Debug("Checking for new inputs")
+
+	mostRecentBlockNumberCallOpts := &bind.CallOpts{
+		BlockNumber: new(big.Int).SetUint64(mostRecentBlockNumber),
+	}
 
 	appsByInputBox := map[common.Address][]appContracts{}
 	for _, app := range applications {
@@ -39,17 +137,23 @@ func (r *Service) checkForNewInputs(
 			"inputbox_address", inputBoxAddress,
 			"most recent block", mostRecentBlockNumber,
 		)
-		appsByLastInputCheckBlock := indexApps(byLastInputCheckBlock, inputBoxApps)
+
+		appsByLastInputCheckBlock := make(map[uint64][]appContracts)
+		for _, app := range inputBoxApps {
+			lastInputCheckBlock := app.application.LastInputCheckBlock
+			if lastInputCheckBlock == 0 { // New application. Find a safe start block to scan for inputs
+				var err error
+				lastInputCheckBlock, err = r.initializeNewApplicationInputSync(ctx, &app,
+					mostRecentBlockNumber, mostRecentBlockNumberCallOpts)
+				if err != nil {
+					continue
+				}
+			}
+			appsByLastInputCheckBlock[lastInputCheckBlock] = append(appsByLastInputCheckBlock[lastInputCheckBlock], app)
+		}
 
 		for lastProcessedBlock, apps := range appsByLastInputCheckBlock {
 			appAddresses := appsToAddresses(apps)
-
-			// Only check blocks starting from the block where the InputBox
-			// contract was deployed as Inputs can be added to that same block
-			inputBoxDeploymentBlock := apps[0].application.IInputBoxBlock
-			if lastProcessedBlock < inputBoxDeploymentBlock {
-				lastProcessedBlock = inputBoxDeploymentBlock - 1
-			}
 
 			if mostRecentBlockNumber > lastProcessedBlock {
 
@@ -75,13 +179,13 @@ func (r *Service) checkForNewInputs(
 				}
 			} else if mostRecentBlockNumber < lastProcessedBlock {
 				r.Logger.Warn(
-					"Not reading inputs: most recent block is lower than the last processed one",
+					"Input search skipped: most recent block is lower than the last processed one",
 					"apps", appAddresses,
 					"last_processed_block", lastProcessedBlock,
 					"most_recent_block", mostRecentBlockNumber,
 				)
 			} else {
-				r.Logger.Info("Not reading inputs: already checked the most recent blocks",
+				r.Logger.Debug("Input search skipped: already checked the most recent block",
 					"apps", appAddresses,
 					"last_processed_block", lastProcessedBlock,
 					"most_recent_block", mostRecentBlockNumber,
@@ -339,9 +443,4 @@ func (r *Service) readInputsFromBlockchain(
 			sortByInputIndex, appInputsMap[event.AppContract], input)
 	}
 	return appInputsMap, nil
-}
-
-// byLastInputCheckBlock key extractor function intended to be used with `indexApps` function
-func byLastInputCheckBlock(app appContracts) uint64 {
-	return app.application.LastInputCheckBlock
 }

--- a/internal/evmreader/input_test.go
+++ b/internal/evmreader/input_test.go
@@ -4,6 +4,7 @@
 package evmreader
 
 import (
+	"math/big"
 	"time"
 
 	. "github.com/cartesi/rollups-node/internal/model"
@@ -56,6 +57,12 @@ func (s *EvmReaderSuite) TestItReadsInputsFromNewBlocksFilteredByDA() {
 	}}, uint64(1), nil).Once()
 
 	s.repository.Unset("UpdateEventLastCheckBlock")
+	s.repository.On("UpdateEventLastCheckBlock",
+		mock.Anything,
+		mock.Anything,
+		MonitoredEvent_InputAdded,
+		mock.Anything,
+	).Once().Return(nil)
 	s.repository.On("UpdateEventLastCheckBlock",
 		mock.Anything,
 		mock.Anything,
@@ -128,6 +135,24 @@ func (s *EvmReaderSuite) TestItReadsInputsFromNewBlocksFilteredByDA() {
 		mock.Anything,
 		mock.Anything,
 	).Return(events_1, nil)
+
+	inputBox.Unset("GetNumberOfInputs")
+	inputBox.On(
+		"GetNumberOfInputs",
+		mock.Anything,
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(2), nil)
+
+	applicationContract.On(
+		"GetDeploymentBlockNumber",
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(10), nil)
+
+	inputBox.On(
+		"GetNumberOfInputs",
+		mock.Anything,
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(0), nil)
 
 	// Start service
 	ready := make(chan struct{}, 1)
@@ -204,6 +229,12 @@ func (s *EvmReaderSuite) TestItUpdatesLastInputCheckBlockWhenThereIsNoInputs() {
 	s.repository.On("UpdateEventLastCheckBlock",
 		mock.Anything,
 		mock.Anything,
+		MonitoredEvent_InputAdded,
+		mock.Anything,
+	).Once().Return(nil)
+	s.repository.On("UpdateEventLastCheckBlock",
+		mock.Anything,
+		mock.Anything,
 		MonitoredEvent_OutputExecuted,
 		mock.Anything,
 	).Once().Return(nil)
@@ -266,6 +297,24 @@ func (s *EvmReaderSuite) TestItUpdatesLastInputCheckBlockWhenThereIsNoInputs() {
 		mock.Anything,
 		mock.Anything,
 	).Return(events_0, nil)
+
+	inputBox.Unset("GetNumberOfInputs")
+	inputBox.On(
+		"GetNumberOfInputs",
+		mock.Anything,
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(1), nil)
+
+	applicationContract.On(
+		"GetDeploymentBlockNumber",
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(10), nil)
+
+	inputBox.On(
+		"GetNumberOfInputs",
+		mock.Anything,
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(0), nil)
 
 	events_1 := []iinputbox.IInputBoxInputAdded{}
 	mostRecentBlockNumber_1 := uint64(0x12)
@@ -349,6 +398,18 @@ func (s *EvmReaderSuite) TestItReadsMultipleInputsFromSingleNewBlock() {
 		mock.Anything,
 		mock.Anything,
 	).Return(events_2, nil)
+
+	inputBox.Unset("GetNumberOfInputs")
+	inputBox.On(
+		"GetNumberOfInputs",
+		mock.Anything,
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(2), nil)
+
+	applicationContract.On(
+		"GetDeploymentBlockNumber",
+		mock.Anything,
+	).Return(new(big.Int).SetUint64(10), nil)
 
 	// Prepare Repo
 	s.repository.Unset("ListApplications")
@@ -443,16 +504,23 @@ func (s *EvmReaderSuite) TestItStartsWhenLasProcessedBlockIsTheMostRecentBlock()
 		mock.Anything,
 		false,
 	).Return([]*Application{{
-		IApplicationAddress: common.HexToAddress("0x2E663fe9aE92275242406A185AA4fC8174339D3E"),
-		IConsensusAddress:   common.HexToAddress("0xdeadbeef"),
-		IInputBoxAddress:    common.HexToAddress("0xBa3Cf8fB82E43D370117A0b7296f91ED674E94e3"),
-		DataAvailability:    DataAvailability_InputBox[:],
-		IInputBoxBlock:      0x10,
-		EpochLength:         10,
-		LastInputCheckBlock: 0x13,
+		IApplicationAddress:  common.HexToAddress("0x2E663fe9aE92275242406A185AA4fC8174339D3E"),
+		IConsensusAddress:    common.HexToAddress("0xdeadbeef"),
+		IInputBoxAddress:     common.HexToAddress("0xBa3Cf8fB82E43D370117A0b7296f91ED674E94e3"),
+		DataAvailability:     DataAvailability_InputBox[:],
+		IInputBoxBlock:       0x10,
+		EpochLength:          10,
+		LastInputCheckBlock:  0x13,
+		LastOutputCheckBlock: 0x13,
 	}}, uint64(1), nil).Once()
 
 	s.repository.Unset("UpdateEventLastCheckBlock")
+	s.repository.On("UpdateEventLastCheckBlock",
+		mock.Anything,
+		mock.Anything,
+		MonitoredEvent_InputAdded,
+		mock.Anything,
+	).Once().Return(nil)
 	s.repository.On("UpdateEventLastCheckBlock",
 		mock.Anything,
 		mock.Anything,

--- a/internal/evmreader/inputsource_adapter.go
+++ b/internal/evmreader/inputsource_adapter.go
@@ -110,3 +110,7 @@ func (i *InputSourceAdapterImpl) RetrieveInputs(
 	}
 	return events, nil
 }
+
+func (i *InputSourceAdapterImpl) GetNumberOfInputs(opts *bind.CallOpts, addr common.Address) (*big.Int, error) {
+	return i.inputbox.GetNumberOfInputs(opts, addr)
+}

--- a/internal/evmreader/output.go
+++ b/internal/evmreader/output.go
@@ -6,10 +6,22 @@ package evmreader
 import (
 	"bytes"
 	"context"
+	"math/big"
 
 	. "github.com/cartesi/rollups-node/internal/model"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 )
+
+// Find an appropriate value to start scanning the blockchain for executed outputs of this application.
+// Application deployment block is a safe block to start since this event is emitted by the application contract itself.
+// We use input box block as a fallback.
+func findLastOutputCheckBlock(app *appContracts, mostRecentBlockNumberCallOpts *bind.CallOpts) uint64 {
+	deploymentBlockNumberBig, err := app.applicationContract.GetDeploymentBlockNumber(mostRecentBlockNumberCallOpts)
+	if err != nil {
+		return app.application.IInputBoxBlock - 1
+	}
+	return deploymentBlockNumberBig.Uint64() - 1
+}
 
 func (r *Service) checkForOutputExecution(
 	ctx context.Context,
@@ -21,11 +33,22 @@ func (r *Service) checkForOutputExecution(
 
 	r.Logger.Debug("Checking for new Output Executed Events", "apps", appAddresses)
 
-	for _, app := range apps {
+	mostRecentBlockNumberCallOpts := &bind.CallOpts{
+		BlockNumber: new(big.Int).SetUint64(mostRecentBlockNumber),
+	}
 
-		// Safeguard: Only check blocks starting from the block where the InputBox
-		// contract was deployed as Inputs can be added to that same block
-		lastOutputCheck := max(app.application.LastOutputCheckBlock, app.application.IInputBoxBlock)
+	for _, app := range apps {
+		lastOutputCheck := app.application.LastOutputCheckBlock
+		if lastOutputCheck == 0 { // New application. Find a safe start block to scan for outputs
+			lastOutputCheck = findLastOutputCheckBlock(&app, mostRecentBlockNumberCallOpts)
+			r.Logger.Info("Initializing application output execution sync",
+				"application", app.application.Name,
+				"inputbox_block", app.application.IInputBoxBlock,
+				"next_search_block", lastOutputCheck+1,
+				"current_block", mostRecentBlockNumber,
+			)
+			app.application.LastOutputCheckBlock = lastOutputCheck
+		}
 
 		if mostRecentBlockNumber > lastOutputCheck {
 

--- a/internal/evmreader/output_test.go
+++ b/internal/evmreader/output_test.go
@@ -39,6 +39,7 @@ func (s *EvmReaderSuite) TestOutputExecution() {
 		DataAvailability:     DataAvailability_InputBox[:],
 		IInputBoxBlock:       0x10,
 		EpochLength:          10,
+		LastInputCheckBlock:  0x01, // don't fast sync inputs
 		LastOutputCheckBlock: 0x10,
 	}}, uint64(1), nil).Once()
 	s.repository.On(


### PR DESCRIPTION
close #686

Skip scanning blocks for inputs of new applications when provably not necessary. This is done by confirming zero inputs on certain blocks with a call to getNumberOfInputs.

update: use the same strategy to sync outputs execution as well.