### PR TITLE
feat(cli): optionally set execution-parameters during deploy and register

### DIFF
--- a/cmd/cartesi-rollups-cli/root/app/register/register.go
+++ b/cmd/cartesi-rollups-cli/root/app/register/register.go
@@ -42,18 +42,19 @@ const examples = `# Adds an application to Rollups Node:
 cartesi-rollups-cli app register -n echo-dapp -a 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF -t applications/echo-dapp`
 
 var (
-	name                   string
-	applicationAddress     string
-	consensusAddress       string
-	templatePath           string
-	templateHash           string
-	epochLength            uint64
-	inputBoxBlockNumber    uint64
-	inputBoxAddressFromEnv bool
-	dataAvailability       string
-	enableMachineHashCheck bool
-	disabled               bool
-	printAsJSON            bool
+	name                         string
+	applicationAddress           string
+	consensusAddress             string
+	templatePath                 string
+	templateHash                 string
+	epochLength                  uint64
+	inputBoxBlockNumber          uint64
+	inputBoxAddressFromEnv       bool
+	dataAvailability             string
+	enableMachineHashCheck       bool
+	disabled                     bool
+	printAsJSON                  bool
+	executionParametersFileParam string
 )
 
 func init() {
@@ -88,6 +89,9 @@ func init() {
 	Cmd.Flags().BoolVarP(&disabled, "disabled", "d", false, "Sets the application state to disabled")
 
 	Cmd.Flags().BoolVarP(&printAsJSON, "print-json", "j", false, "Prints the application data as JSON")
+
+	Cmd.Flags().StringVarP(&executionParametersFileParam, "execution-parameters-file", "", "",
+		"JSON encoded execution parameters of the application. Default values will be used if not defined.")
 
 	Cmd.Flags().BoolVar(&enableMachineHashCheck, "machine-hash-check", true,
 		"Enable or disable machine hash check (DO NOT DISABLE IN PRODUCTION)")
@@ -150,6 +154,22 @@ func run(cmd *cobra.Command, args []string) {
 		}
 	}
 
+	executionParameters := model.ExecutionParameters{}
+	if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
+		filePath := executionParametersFileParam
+		if executionParametersFileParam == "-" {
+			filePath = os.Stdin.Name()
+		}
+		contents, err := os.ReadFile(filePath)
+		cobra.CheckErr(err)
+
+		decoder := json.NewDecoder(strings.NewReader(string(contents)))
+		decoder.DisallowUnknownFields() // Prevent unexpected fields
+		err = decoder.Decode(&executionParameters)
+		cobra.CheckErr(err)
+		cobra.CheckErr(executionParameters.Validate())
+	}
+
 	var consensus common.Address
 	if cmd.Flags().Changed("consensus") {
 		consensus = common.HexToAddress(consensusAddress)
@@ -203,6 +223,19 @@ func run(cmd *cobra.Command, args []string) {
 
 	_, err = repo.CreateApplication(ctx, &application)
 	cobra.CheckErr(err)
+
+	if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
+		retrievedApplication, err := repo.GetApplication(ctx, validName)
+		if err != nil {
+			cobra.CheckErr(fmt.Errorf("failed to retrieve application from the database: %w", err))
+		}
+
+		executionParameters.ApplicationID = retrievedApplication.ID
+		err = repo.UpdateExecutionParameters(ctx, &executionParameters)
+		if err != nil {
+			cobra.CheckErr(fmt.Errorf("failed to update execution parameters: %w", err))
+		}
+	}
 
 	if printAsJSON {
 		jsonData, err := json.Marshal(application)

--- a/cmd/cartesi-rollups-cli/root/deploy/application.go
+++ b/cmd/cartesi-rollups-cli/root/deploy/application.go
@@ -175,7 +175,6 @@ func runDeployApplication(cmd *cobra.Command, args []string) {
 		contents, err := os.ReadFile(filePath)
 		cobra.CheckErr(err)
 
-		// TODO: validateParameters after decoding
 		decoder := json.NewDecoder(strings.NewReader(string(contents)))
 		decoder.DisallowUnknownFields() // Prevent unexpected fields
 		err = decoder.Decode(&executionParameters)

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -365,6 +365,60 @@ func (e *ExecutionParameters) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// validateParameters constants
+const maxDuration = 24 * time.Hour
+const maxConcurrentInspects = 1000
+
+// validateParameters performs validation on the loaded parameters
+func (e *ExecutionParameters) Validate() error {
+	// Validate durations are reasonable
+	if e.AdvanceIncDeadline < 0 || e.AdvanceIncDeadline > maxDuration {
+		return fmt.Errorf("advance_inc_deadline must be between 0 and 24h")
+	}
+
+	if e.AdvanceMaxDeadline < 0 || e.AdvanceMaxDeadline > maxDuration {
+		return fmt.Errorf("advance_max_deadline must be between 0 and 24h")
+	}
+
+	if e.InspectIncDeadline < 0 || e.InspectIncDeadline > maxDuration {
+		return fmt.Errorf("inspect_inc_deadline must be between 0 and 24h")
+	}
+
+	if e.InspectMaxDeadline < 0 || e.InspectMaxDeadline > maxDuration {
+		return fmt.Errorf("inspect_max_deadline must be between 0 and 24h")
+	}
+
+	if e.LoadDeadline < 0 || e.LoadDeadline > maxDuration {
+		return fmt.Errorf("load_deadline must be between 0 and 24h")
+	}
+
+	if e.StoreDeadline < 0 || e.StoreDeadline > maxDuration {
+		return fmt.Errorf("store_deadline must be between 0 and 24h")
+	}
+
+	if e.FastDeadline < 0 || e.FastDeadline > maxDuration {
+		return fmt.Errorf("fast_deadline must be between 0 and 24h")
+	}
+
+	// Validate max_concurrent_inspects
+	if e.MaxConcurrentInspects > maxConcurrentInspects {
+		return fmt.Errorf("max_concurrent_inspects must be between 0 and 1000")
+	}
+
+	// Validate snapshot policy
+	validPolicy := false
+	switch e.SnapshotPolicy {
+	case SnapshotPolicy_None, SnapshotPolicy_EveryInput, SnapshotPolicy_EveryEpoch:
+		validPolicy = true
+	}
+
+	if !validPolicy {
+		return fmt.Errorf("invalid snapshot policy: %s. Valid values are: NONE, EVERY_INPUT, EVERY_EPOCH", e.SnapshotPolicy)
+	}
+
+	return nil
+}
+
 func ParseHexUint64(s string) (uint64, error) {
 	if s == "" || len(s) < 3 || (!strings.HasPrefix(s, "0x") && !strings.HasPrefix(s, "0X")) {
 		return 0, fmt.Errorf("invalid hex string: %s", s)


### PR DESCRIPTION
closes #679

Optionally set execution parameters during deploy with `--execution-parameters-file`.