### PR TITLE
feat(config): add generalized secret support to configs via _FILE suffix

### DIFF
--- a/compose.individual-services.yaml
+++ b/compose.individual-services.yaml
@@ -1,14 +1,14 @@
 x-env: &env
   CARTESI_LOG_LEVEL: info
-  CARTESI_BLOCKCHAIN_HTTP_ENDPOINT: http://ethereum_provider:8545
-  CARTESI_BLOCKCHAIN_WS_ENDPOINT: ws://ethereum_provider:8545
+  CARTESI_BLOCKCHAIN_HTTP_ENDPOINT_FILE: /run/secrets/blockchain_http_endpoint
+  CARTESI_BLOCKCHAIN_WS_ENDPOINT_FILE: /run/secrets/blockchain_http_endpoint
   CARTESI_BLOCKCHAIN_ID: 13370
   CARTESI_CONTRACTS_INPUT_BOX_ADDRESS: 0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051
   CARTESI_CONTRACTS_AUTHORITY_FACTORY_ADDRESS: 0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051
   CARTESI_CONTRACTS_APPLICATION_FACTORY_ADDRESS: 0xc7006f70875BaDe89032001262A846D3Ee160051
   CARTESI_CONTRACTS_SELF_HOSTED_APPLICATION_FACTORY_ADDRESS: 0xc700285Ab555eeB5201BC00CFD4b2CC8DED90051
-  CARTESI_DATABASE_CONNECTION: postgres://postgres:password@database:5432/rollupsdb?sslmode=disable
-  CARTESI_AUTH_MNEMONIC: "test test test test test test test test test test test junk"
+  CARTESI_DATABASE_CONNECTION_FILE: /run/secrets/database_connection
+  CARTESI_AUTH_MNEMONIC_FILE: /run/secrets/auth_mnemonic
 
 services:
   ethereum_provider:
@@ -43,6 +43,8 @@ services:
     networks:
       - devnet
     restart: "no"
+    secrets:
+      - database_connection
     environment:
       <<: *env
 
@@ -58,6 +60,11 @@ services:
       - devnet
     ports:
       - "10001:10001" # Supervisor
+    secrets:
+      - auth_mnemonic
+      - blockchain_http_endpoint
+      - blockchain_ws_endpoint
+      - database_connection
     environment:
       <<: *env
 
@@ -76,6 +83,9 @@ services:
     ports:
       - "10002:10002" # Supervisor
       - "10012:10012" # Inspect Service
+    secrets:
+      - auth_mnemonic
+      - database_connection
     environment:
       <<: *env
 
@@ -89,6 +99,8 @@ services:
       - devnet
     ports:
       - "10003:10003" # Supervisor
+    secrets:
+      - database_connection
     environment:
       <<: *env
 
@@ -104,6 +116,10 @@ services:
       - devnet
     ports:
       - "10004:10004" # Supervisor
+    secrets:
+      - auth_mnemonic
+      - blockchain_http_endpoint
+      - database_connection
     environment:
       <<: *env
 
@@ -118,6 +134,10 @@ services:
     ports:
       - "10005:10005" # Supervisor
       - "10011:10011" # Jsonrpc API service
+    secrets:
+      - auth_mnemonic
+      - blockchain_http_endpoint
+      - database_connection
     environment:
       <<: *env
 volumes:
@@ -125,3 +145,13 @@ volumes:
 
 networks:
   devnet:
+
+secrets:
+  auth_mnemonic:
+    file: test/secrets/auth_mnemonic.txt
+  blockchain_http_endpoint:
+    file: test/secrets/blockchain_http_endpoint.txt
+  blockchain_ws_endpoint:
+    file: test/secrets/blockchain_ws_endpoint.txt
+  database_connection:
+    file: test/secrets/database_connection.txt

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,14 +1,14 @@
 x-env: &env
   CARTESI_LOG_LEVEL: info
-  CARTESI_BLOCKCHAIN_HTTP_ENDPOINT: http://ethereum_provider:8545
-  CARTESI_BLOCKCHAIN_WS_ENDPOINT: ws://ethereum_provider:8545
+  CARTESI_BLOCKCHAIN_HTTP_ENDPOINT_FILE: /run/secrets/blockchain_http_endpoint
+  CARTESI_BLOCKCHAIN_WS_ENDPOINT_FILE: /run/secrets/blockchain_http_endpoint
   CARTESI_BLOCKCHAIN_ID: 13370
   CARTESI_CONTRACTS_INPUT_BOX_ADDRESS: 0xc70074BDD26d8cF983Ca6A5b89b8db52D5850051
   CARTESI_CONTRACTS_AUTHORITY_FACTORY_ADDRESS: 0xC7003566dD09Aa0fC0Ce201aC2769aFAe3BF0051
   CARTESI_CONTRACTS_APPLICATION_FACTORY_ADDRESS: 0xc7006f70875BaDe89032001262A846D3Ee160051
   CARTESI_CONTRACTS_SELF_HOSTED_APPLICATION_FACTORY_ADDRESS: 0xc700285Ab555eeB5201BC00CFD4b2CC8DED90051
-  CARTESI_DATABASE_CONNECTION: postgres://postgres:password@database:5432/rollupsdb?sslmode=disable
-  CARTESI_AUTH_MNEMONIC: "test test test test test test test test test test test junk"
+  CARTESI_DATABASE_CONNECTION_FILE: /run/secrets/database_connection
+  CARTESI_AUTH_MNEMONIC_FILE: /run/secrets/auth_mnemonic
 
 services:
   ethereum_provider:
@@ -42,6 +42,8 @@ services:
         condition: service_healthy
     networks:
       - devnet
+    secrets:
+      - database_connection
     restart: "no"
     environment:
       <<: *env
@@ -62,6 +64,11 @@ services:
       - "10000:10000" # Supervisor
       - "10011:10011" # Jsonrpc API service
       - "10012:10012" # Inspect Service
+    secrets:
+      - auth_mnemonic
+      - blockchain_http_endpoint
+      - blockchain_ws_endpoint
+      - database_connection
     environment:
       <<: *env
 
@@ -70,3 +77,13 @@ volumes:
 
 networks:
   devnet:
+
+secrets:
+  auth_mnemonic:
+    file: test/secrets/auth_mnemonic.txt
+  blockchain_http_endpoint:
+    file: test/secrets/blockchain_http_endpoint.txt
+  blockchain_ws_endpoint:
+    file: test/secrets/blockchain_ws_endpoint.txt
+  database_connection:
+    file: test/secrets/database_connection.txt

--- a/internal/config/auth/auth.go
+++ b/internal/config/auth/auth.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -42,44 +41,12 @@ func GetTransactOpts(chainId *big.Int) (*bind.TransactOpts, error) {
 			return nil, err
 		}
 		return bind.NewKeyedTransactorWithChainID(privateKey, chainId)
-	case AuthKindMnemonicFile:
-		mnemonicFile, err := GetAuthMnemonicFile()
-		if err != nil {
-			return nil, err
-		}
-		mnemonic, err := os.ReadFile(mnemonicFile)
-		if err != nil {
-			return nil, err
-		}
-		accountIndex, err := GetAuthMnemonicAccountIndex()
-		if err != nil {
-			return nil, err
-		}
-		privateKey, err := ethutil.MnemonicToPrivateKey(string(mnemonic), accountIndex.Value)
-		if err != nil {
-			return nil, err
-		}
-		return bind.NewKeyedTransactorWithChainID(privateKey, chainId)
 	case AuthKindPrivateKeyVar:
 		privateKey, err := GetAuthPrivateKey()
 		if err != nil {
 			return nil, err
 		}
 		key, err := crypto.HexToECDSA(ethutil.TrimHex(privateKey.Value))
-		if err != nil {
-			return nil, err
-		}
-		return bind.NewKeyedTransactorWithChainID(key, chainId)
-	case AuthKindPrivateKeyFile:
-		privateKeyFile, err := GetAuthPrivateKeyFile()
-		if err != nil {
-			return nil, err
-		}
-		privateKey, err := os.ReadFile(privateKeyFile)
-		if err != nil {
-			return nil, err
-		}
-		key, err := crypto.HexToECDSA(ethutil.TrimHex(string(privateKey)))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -100,12 +100,14 @@ An unique identifier representing a blockchain network."""
 used-by = ["evmreader", "claimer", "node"]
 
 [blockchain.CARTESI_BLOCKCHAIN_HTTP_ENDPOINT]
+file = true
 go-type = "URL"
 description = """
 HTTP endpoint for the blockchain RPC provider."""
 used-by = ["evmreader", "claimer", "node"]
 
 [blockchain.CARTESI_BLOCKCHAIN_WS_ENDPOINT]
+file = true
 go-type = "URL"
 description = """
 WebSocket endpoint for the blockchain RPC provider."""
@@ -220,31 +222,18 @@ omit = true
 used-by = ["claimer", "node", "cli"]
 
 [auth.CARTESI_AUTH_PRIVATE_KEY]
+file = true
 go-type = "RedactedString"
 description = """
 The node will use this private key to sign transactions."""
 omit = true
 used-by = ["claimer", "node", "cli"]
 
-[auth.CARTESI_AUTH_PRIVATE_KEY_FILE]
-go-type = "string"
-description = """
-The node will use the private key contained in this file to sign transactions."""
-omit = true
-used-by = ["claimer", "node", "cli"]
-
 [auth.CARTESI_AUTH_MNEMONIC]
+file = true
 go-type = "RedactedString"
 description = """
 The node will use the private key generated from this mnemonic to sign transactions."""
-omit = true
-used-by = ["claimer", "node", "cli"]
-
-[auth.CARTESI_AUTH_MNEMONIC_FILE]
-go-type = "string"
-description = """
-The node will use the private key generated from the mnemonic contained in this file
-to sign transactions."""
 omit = true
 used-by = ["claimer", "node", "cli"]
 
@@ -281,6 +270,7 @@ used-by = ["claimer", "node", "cli"]
 
 [database.CARTESI_DATABASE_CONNECTION]
 default = ""
+file = true
 go-type = "URL"
 description = """
 Postgres endpoint in the 'postgres://user:password@hostname:port/database' format (URL).

--- a/internal/config/generate/code.go
+++ b/internal/config/generate/code.go
@@ -117,6 +117,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -131,6 +133,10 @@ func init() {
 const (
 {{ range . -}}
 	{{ toConstName .Name }} = "{{ .Name }}"
+{{ end }}
+	// File variants
+{{ range . -}}
+	{{ if .File -}}{{ toConstName .Name }}_FILE = "{{ .Name }}_FILE"{{ end }}
 {{ end -}}
 )
 
@@ -209,6 +215,16 @@ func (c *NodeConfig) To{{ capitalize $service }}Config() *{{ capitalize $service
 // Get{{ toFieldName .Name }} returns the value for the environment variable {{ .Name }}.
 func Get{{ toFieldName .Name }}() ({{ .GoType }}, error) {
 	s := viper.GetString({{ toConstName .Name }})
+	{{- if .File }}
+	if s == "" {
+		filename := viper.GetString({{toConstName .Name}}_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefined{{ .GoType }}(), fmt.Errorf("failed to parse %s: %w", {{ toConstName .Name }}_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
+	{{- end }}
 	if s != "" {
 		v, err := {{ toGoFunc .GoType }}(s)
 		if err != nil {

--- a/internal/config/generate/env.go
+++ b/internal/config/generate/env.go
@@ -23,6 +23,9 @@ type Env struct {
 	// If defined omit the field from the generated Config struct
 	Omit bool `toml:"omit"`
 
+	// Configuration also has a "_FILE" variant that should be searched
+	File bool `toml:"file"`
+
 	// List of services that use this environment variable.
 	// Possible values: "advancer", "claimer", "cli", "evm-reader", "jsonrpc-api", "node", "validator"
 	UsedBy []string `toml:"used-by"`

--- a/internal/config/generated.go
+++ b/internal/config/generated.go
@@ -8,6 +8,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -25,9 +27,7 @@ const (
 	AUTH_KIND                                         = "CARTESI_AUTH_KIND"
 	AUTH_MNEMONIC                                     = "CARTESI_AUTH_MNEMONIC"
 	AUTH_MNEMONIC_ACCOUNT_INDEX                       = "CARTESI_AUTH_MNEMONIC_ACCOUNT_INDEX"
-	AUTH_MNEMONIC_FILE                                = "CARTESI_AUTH_MNEMONIC_FILE"
 	AUTH_PRIVATE_KEY                                  = "CARTESI_AUTH_PRIVATE_KEY"
-	AUTH_PRIVATE_KEY_FILE                             = "CARTESI_AUTH_PRIVATE_KEY_FILE"
 	BLOCKCHAIN_DEFAULT_BLOCK                          = "CARTESI_BLOCKCHAIN_DEFAULT_BLOCK"
 	BLOCKCHAIN_HTTP_ENDPOINT                          = "CARTESI_BLOCKCHAIN_HTTP_ENDPOINT"
 	BLOCKCHAIN_ID                                     = "CARTESI_BLOCKCHAIN_ID"
@@ -59,6 +59,18 @@ const (
 	MAX_STARTUP_TIME                                  = "CARTESI_MAX_STARTUP_TIME"
 	VALIDATOR_POLLING_INTERVAL                        = "CARTESI_VALIDATOR_POLLING_INTERVAL"
 	SNAPSHOTS_DIR                                     = "CARTESI_SNAPSHOTS_DIR"
+
+	// File variants
+
+	AUTH_MNEMONIC_FILE = "CARTESI_AUTH_MNEMONIC_FILE"
+
+	AUTH_PRIVATE_KEY_FILE = "CARTESI_AUTH_PRIVATE_KEY_FILE"
+
+	BLOCKCHAIN_HTTP_ENDPOINT_FILE = "CARTESI_BLOCKCHAIN_HTTP_ENDPOINT_FILE"
+
+	BLOCKCHAIN_WS_ENDPOINT_FILE = "CARTESI_BLOCKCHAIN_WS_ENDPOINT_FILE"
+
+	DATABASE_CONNECTION_FILE = "CARTESI_DATABASE_CONNECTION_FILE"
 )
 
 func SetDefaults() {
@@ -74,11 +86,7 @@ func SetDefaults() {
 
 	viper.SetDefault(AUTH_MNEMONIC_ACCOUNT_INDEX, "0")
 
-	// no default for CARTESI_AUTH_MNEMONIC_FILE
-
 	// no default for CARTESI_AUTH_PRIVATE_KEY
-
-	// no default for CARTESI_AUTH_PRIVATE_KEY_FILE
 
 	viper.SetDefault(BLOCKCHAIN_DEFAULT_BLOCK, "finalized")
 
@@ -1258,6 +1266,14 @@ func GetAuthKind() (AuthKind, error) {
 // GetAuthMnemonic returns the value for the environment variable CARTESI_AUTH_MNEMONIC.
 func GetAuthMnemonic() (RedactedString, error) {
 	s := viper.GetString(AUTH_MNEMONIC)
+	if s == "" {
+		filename := viper.GetString(AUTH_MNEMONIC_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedRedactedString(), fmt.Errorf("failed to parse %s: %w", AUTH_MNEMONIC_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
 	if s != "" {
 		v, err := toRedactedString(s)
 		if err != nil {
@@ -1281,22 +1297,17 @@ func GetAuthMnemonicAccountIndex() (RedactedUint, error) {
 	return notDefinedRedactedUint(), fmt.Errorf("%s: %w", AUTH_MNEMONIC_ACCOUNT_INDEX, ErrNotDefined)
 }
 
-// GetAuthMnemonicFile returns the value for the environment variable CARTESI_AUTH_MNEMONIC_FILE.
-func GetAuthMnemonicFile() (string, error) {
-	s := viper.GetString(AUTH_MNEMONIC_FILE)
-	if s != "" {
-		v, err := toString(s)
-		if err != nil {
-			return v, fmt.Errorf("failed to parse %s: %w", AUTH_MNEMONIC_FILE, err)
-		}
-		return v, nil
-	}
-	return notDefinedstring(), fmt.Errorf("%s: %w", AUTH_MNEMONIC_FILE, ErrNotDefined)
-}
-
 // GetAuthPrivateKey returns the value for the environment variable CARTESI_AUTH_PRIVATE_KEY.
 func GetAuthPrivateKey() (RedactedString, error) {
 	s := viper.GetString(AUTH_PRIVATE_KEY)
+	if s == "" {
+		filename := viper.GetString(AUTH_PRIVATE_KEY_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedRedactedString(), fmt.Errorf("failed to parse %s: %w", AUTH_PRIVATE_KEY_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
 	if s != "" {
 		v, err := toRedactedString(s)
 		if err != nil {
@@ -1305,19 +1316,6 @@ func GetAuthPrivateKey() (RedactedString, error) {
 		return v, nil
 	}
 	return notDefinedRedactedString(), fmt.Errorf("%s: %w", AUTH_PRIVATE_KEY, ErrNotDefined)
-}
-
-// GetAuthPrivateKeyFile returns the value for the environment variable CARTESI_AUTH_PRIVATE_KEY_FILE.
-func GetAuthPrivateKeyFile() (string, error) {
-	s := viper.GetString(AUTH_PRIVATE_KEY_FILE)
-	if s != "" {
-		v, err := toString(s)
-		if err != nil {
-			return v, fmt.Errorf("failed to parse %s: %w", AUTH_PRIVATE_KEY_FILE, err)
-		}
-		return v, nil
-	}
-	return notDefinedstring(), fmt.Errorf("%s: %w", AUTH_PRIVATE_KEY_FILE, ErrNotDefined)
 }
 
 // GetBlockchainDefaultBlock returns the value for the environment variable CARTESI_BLOCKCHAIN_DEFAULT_BLOCK.
@@ -1336,6 +1334,14 @@ func GetBlockchainDefaultBlock() (DefaultBlock, error) {
 // GetBlockchainHttpEndpoint returns the value for the environment variable CARTESI_BLOCKCHAIN_HTTP_ENDPOINT.
 func GetBlockchainHttpEndpoint() (URL, error) {
 	s := viper.GetString(BLOCKCHAIN_HTTP_ENDPOINT)
+	if s == "" {
+		filename := viper.GetString(BLOCKCHAIN_HTTP_ENDPOINT_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedURL(), fmt.Errorf("failed to parse %s: %w", BLOCKCHAIN_HTTP_ENDPOINT_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
 	if s != "" {
 		v, err := toURL(s)
 		if err != nil {
@@ -1388,6 +1394,14 @@ func GetBlockchainSubscriptionTimeout() (uint64, error) {
 // GetBlockchainWsEndpoint returns the value for the environment variable CARTESI_BLOCKCHAIN_WS_ENDPOINT.
 func GetBlockchainWsEndpoint() (URL, error) {
 	s := viper.GetString(BLOCKCHAIN_WS_ENDPOINT)
+	if s == "" {
+		filename := viper.GetString(BLOCKCHAIN_WS_ENDPOINT_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedURL(), fmt.Errorf("failed to parse %s: %w", BLOCKCHAIN_WS_ENDPOINT_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
 	if s != "" {
 		v, err := toURL(s)
 		if err != nil {
@@ -1453,6 +1467,14 @@ func GetContractsSelfHostedApplicationFactoryAddress() (Address, error) {
 // GetDatabaseConnection returns the value for the environment variable CARTESI_DATABASE_CONNECTION.
 func GetDatabaseConnection() (URL, error) {
 	s := viper.GetString(DATABASE_CONNECTION)
+	if s == "" {
+		filename := viper.GetString(DATABASE_CONNECTION_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedURL(), fmt.Errorf("failed to parse %s: %w", DATABASE_CONNECTION_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
 	if s != "" {
 		v, err := toURL(s)
 		if err != nil {

--- a/test/secrets/auth_mnemonic.txt
+++ b/test/secrets/auth_mnemonic.txt
@@ -1,0 +1,2 @@
+test test test test test test test test test test test junk
+

--- a/test/secrets/blockchain_http_endpoint.txt
+++ b/test/secrets/blockchain_http_endpoint.txt
@@ -1,0 +1,1 @@
+http://ethereum_provider:8545

--- a/test/secrets/blockchain_ws_endpoint.txt
+++ b/test/secrets/blockchain_ws_endpoint.txt
@@ -1,0 +1,1 @@
+ws://ethereum_provider:8545

--- a/test/secrets/database_connection.txt
+++ b/test/secrets/database_connection.txt
@@ -1,0 +1,1 @@
+postgres://postgres:password@database:5432/rollupsdb?sslmode=disable


### PR DESCRIPTION
Added `file` option to `Config.toml`.

When enabled (`file: true`), the configuration may be provided either as the contents of an environment variable; or as a file containing the variable when suffixed by `_FILE`.

1. Original behavior is maintained and has higher precedence. Environment variable contains the value:
```sh
${VAR} = "value"
```

2. New behavior, environment variable points to a file that contains the value. Lower precedence.
```sh
${VAR_FILE} = "path/to/file"

cat "path/to/file"
"value"
```

This is a partial implementation of the suggested solution from issue #681.
1. Implemented
2. Unimplemented
3. Partial (CARTESI_DATABASE_CONNECTION_FILE works, but no splitting)
4. Partial (explicit var > _FILE)
5. Implemented (Same redaction policy as the original variable)

Updated sample `compose.yaml` and `compose.individual-services.yaml` with `_FILE` and secrets usage.