### PR TITLE
feat(config): add support for authorization header on blockchain http requests

### DIFF
--- a/cmd/cartesi-rollups-claimer/root/root.go
+++ b/cmd/cartesi-rollups-claimer/root/root.go
@@ -111,8 +111,17 @@ func run(cmd *cobra.Command, args []string) {
 	rclient.RetryWaitMin = cfg.BlockchainHttpRetryMinWait
 	rclient.RetryWaitMax = cfg.BlockchainHttpRetryMaxWait
 
-	clientOption := rpc.WithHTTPClient(rclient.StandardClient())
-	rpcClient, err := rpc.DialOptions(ctx, cfg.BlockchainHttpEndpoint.String(), clientOption)
+	clientOptions := []rpc.ClientOption{
+		rpc.WithHTTPClient(rclient.StandardClient()),
+	}
+
+	authOpt, err := config.HTTPAuthorizationOption()
+	cobra.CheckErr(err)
+	if authOpt != nil {
+		clientOptions = append(clientOptions, authOpt)
+	}
+
+	rpcClient, err := rpc.DialOptions(ctx, cfg.BlockchainHttpEndpoint.String(), clientOptions...)
 	cobra.CheckErr(err)
 	createInfo.EthConn = ethclient.NewClient(rpcClient)
 

--- a/cmd/cartesi-rollups-evm-reader/root/root.go
+++ b/cmd/cartesi-rollups-evm-reader/root/root.go
@@ -95,9 +95,18 @@ func createEthClient(ctx context.Context, endpoint string, logger *slog.Logger) 
 	rclient.RetryMax = int(cfg.BlockchainHttpMaxRetries)
 	rclient.RetryWaitMin = cfg.BlockchainHttpRetryMinWait
 	rclient.RetryWaitMax = cfg.BlockchainHttpRetryMaxWait
-	clientOption := rpc.WithHTTPClient(rclient.StandardClient())
 
-	rpcClient, err := rpc.DialOptions(ctx, endpoint, clientOption)
+	clientOptions := []rpc.ClientOption{
+		rpc.WithHTTPClient(rclient.StandardClient()),
+	}
+
+	authOpt, err := config.HTTPAuthorizationOption()
+	cobra.CheckErr(err)
+	if authOpt != nil {
+		clientOptions = append(clientOptions, authOpt)
+	}
+
+	rpcClient, err := rpc.DialOptions(ctx, endpoint, clientOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/cartesi-rollups-node/root/root.go
+++ b/cmd/cartesi-rollups-node/root/root.go
@@ -137,9 +137,18 @@ func createEthClient(ctx context.Context, endpoint string, logger *slog.Logger) 
 	rclient.RetryMax = int(cfg.BlockchainHttpMaxRetries)
 	rclient.RetryWaitMin = cfg.BlockchainHttpRetryMinWait
 	rclient.RetryWaitMax = cfg.BlockchainHttpRetryMaxWait
-	clientOption := rpc.WithHTTPClient(rclient.StandardClient())
 
-	rpcClient, err := rpc.DialOptions(ctx, endpoint, clientOption)
+	clientOptions := []rpc.ClientOption{
+		rpc.WithHTTPClient(rclient.StandardClient()),
+	}
+
+	authOpt, err := config.HTTPAuthorizationOption()
+	cobra.CheckErr(err)
+	if authOpt != nil {
+		clientOptions = append(clientOptions, authOpt)
+	}
+
+	rpcClient, err := rpc.DialOptions(ctx, endpoint, clientOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/generate/Config.toml
+++ b/internal/config/generate/Config.toml
@@ -106,6 +106,20 @@ description = """
 HTTP endpoint for the blockchain RPC provider."""
 used-by = ["evmreader", "claimer", "node"]
 
+[blockchain.CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION]
+file = true
+go-type = "RedactedString"
+description = """
+Additional security when interacting with providers.
+Specify a Key ':' Value pair to include in the HTTP header with authorization keys.
+Examples:
+ - Alchemy: "Authorization:Bearer ${API_Key}"
+ - Infura:  "Authorization:Basic base64(':' + ${<INFURA-API-KEY-SECRET>})"
+ - Google:  "X-goog-api-key:${API_Key}"
+"""
+omit = true
+used-by = ["evmreader", "claimer", "node"]
+
 [blockchain.CARTESI_BLOCKCHAIN_WS_ENDPOINT]
 file = true
 go-type = "URL"

--- a/internal/config/generated.go
+++ b/internal/config/generated.go
@@ -29,6 +29,7 @@ const (
 	AUTH_MNEMONIC_ACCOUNT_INDEX                       = "CARTESI_AUTH_MNEMONIC_ACCOUNT_INDEX"
 	AUTH_PRIVATE_KEY                                  = "CARTESI_AUTH_PRIVATE_KEY"
 	BLOCKCHAIN_DEFAULT_BLOCK                          = "CARTESI_BLOCKCHAIN_DEFAULT_BLOCK"
+	BLOCKCHAIN_HTTP_AUTHORIZATION                     = "CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION"
 	BLOCKCHAIN_HTTP_ENDPOINT                          = "CARTESI_BLOCKCHAIN_HTTP_ENDPOINT"
 	BLOCKCHAIN_ID                                     = "CARTESI_BLOCKCHAIN_ID"
 	BLOCKCHAIN_LEGACY_ENABLED                         = "CARTESI_BLOCKCHAIN_LEGACY_ENABLED"
@@ -66,7 +67,8 @@ const (
 
 	AUTH_PRIVATE_KEY_FILE = "CARTESI_AUTH_PRIVATE_KEY_FILE"
 
-	BLOCKCHAIN_HTTP_ENDPOINT_FILE = "CARTESI_BLOCKCHAIN_HTTP_ENDPOINT_FILE"
+	BLOCKCHAIN_HTTP_AUTHORIZATION_FILE = "CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION_FILE"
+	BLOCKCHAIN_HTTP_ENDPOINT_FILE      = "CARTESI_BLOCKCHAIN_HTTP_ENDPOINT_FILE"
 
 	BLOCKCHAIN_WS_ENDPOINT_FILE = "CARTESI_BLOCKCHAIN_WS_ENDPOINT_FILE"
 
@@ -89,6 +91,8 @@ func SetDefaults() {
 	// no default for CARTESI_AUTH_PRIVATE_KEY
 
 	viper.SetDefault(BLOCKCHAIN_DEFAULT_BLOCK, "finalized")
+
+	// no default for CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION
 
 	// no default for CARTESI_BLOCKCHAIN_HTTP_ENDPOINT
 
@@ -1329,6 +1333,27 @@ func GetBlockchainDefaultBlock() (DefaultBlock, error) {
 		return v, nil
 	}
 	return notDefinedDefaultBlock(), fmt.Errorf("%s: %w", BLOCKCHAIN_DEFAULT_BLOCK, ErrNotDefined)
+}
+
+// GetBlockchainHttpAuthorization returns the value for the environment variable CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION.
+func GetBlockchainHttpAuthorization() (RedactedString, error) {
+	s := viper.GetString(BLOCKCHAIN_HTTP_AUTHORIZATION)
+	if s == "" {
+		filename := viper.GetString(BLOCKCHAIN_HTTP_AUTHORIZATION_FILE)
+		contents, err := os.ReadFile(filename)
+		if err != nil {
+			return notDefinedRedactedString(), fmt.Errorf("failed to parse %s: %w", BLOCKCHAIN_HTTP_AUTHORIZATION_FILE, err)
+		}
+		s = strings.TrimSpace(string(contents))
+	}
+	if s != "" {
+		v, err := toRedactedString(s)
+		if err != nil {
+			return v, fmt.Errorf("failed to parse %s: %w", BLOCKCHAIN_HTTP_AUTHORIZATION, err)
+		}
+		return v, nil
+	}
+	return notDefinedRedactedString(), fmt.Errorf("%s: %w", BLOCKCHAIN_HTTP_AUTHORIZATION, ErrNotDefined)
 }
 
 // GetBlockchainHttpEndpoint returns the value for the environment variable CARTESI_BLOCKCHAIN_HTTP_ENDPOINT.

--- a/internal/config/http_authorization.go
+++ b/internal/config/http_authorization.go
@@ -1,0 +1,34 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package config
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Unwrap the http authorization config `key:val` into a ClientOption that rpc accepts
+func HTTPAuthorizationOption() (rpc.ClientOption, error) {
+
+	// no authorization is allowed.
+	auth, err := GetBlockchainHttpAuthorization()
+	if err != nil {
+		return nil, nil
+	}
+
+	kv := strings.SplitN(auth.Value, ":", 2)
+	if len(kv) != 2 {
+		return nil, fmt.Errorf("malformed BlockchainHttpAuthorization, expected <key>:<value>")
+	}
+	key := strings.TrimSpace(kv[0])
+	val := strings.TrimSpace(kv[1])
+
+	return rpc.WithHTTPAuth(func(h http.Header) error {
+		h.Set(key, val)
+		return nil
+	}), nil
+}


### PR DESCRIPTION
Add an option to fill in a `key:val` pair on the HTTP request header If either `CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION` or `CARTESI_BLOCKCHAIN_HTTP_AUTHORIZATION_FILE` are provided.
This helps prevent key leakage via logs and URLs when interacting with providers.

Examples for what values the providers expect in the [wiki](https://github.com/cartesi/rollups-node/wiki/Provider-Authorization).