### PR TITLE
jsonrpc test

### DIFF
--- a/cmd/cartesi-rollups-cli/root/deploy/application.go
+++ b/cmd/cartesi-rollups-cli/root/deploy/application.go
@@ -57,19 +57,19 @@ Supported Environment Variables:
 
 const applicationExamples = `
 # deploy both application and authority contracts together via self hosted application contract, then register the application
- - cli deploy application echo-dapp applications/echo-dapp/
+ - cartesi-rollups-cli deploy application echo-dapp applications/echo-dapp/
 
 # deploy an application contract using an existing consensus, then register the application
- - cli deploy application echo-dapp applications/echo-dapp/ --consensus=0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+ - cartesi-rollups-cli deploy application echo-dapp applications/echo-dapp/ --consensus=0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 
 # deploy but don't register into the database
- - cli deploy application echo-dapp applications/echo-dapp/ --register=false
+ - cartesi-rollups-cli deploy application echo-dapp applications/echo-dapp/ --register=false
 
 # deploy and register into the database, but disabled
- - cli deploy application echo-dapp applications/echo-dapp/ --enable=false
+ - cartesi-rollups-cli deploy application echo-dapp applications/echo-dapp/ --enable=false
 
 # deploy an application without a machine template path (both application-name and template-path may be omitted in this case)
- - cli deploy application --template-hash=0x0000000000000000000000000000000000000000000000000000000000000000 --register=false`
+ - cartesi-rollups-cli deploy application --template-hash=0x0000000000000000000000000000000000000000000000000000000000000000 --register=false`
 
 func init() {
 	applicationCmd.Flags().StringVarP(&applicationConsensusAddressParam, "consensus", "c", "",

--- a/internal/jsonrpc/jsonrpc.go
+++ b/internal/jsonrpc/jsonrpc.go
@@ -40,6 +40,27 @@ const (
 	JSONRPC_INTERNAL_ERROR     int = -32603
 )
 
+type rpcHandler = func(*Service, http.ResponseWriter, *http.Request, RPCRequest)
+type dispatchTable = map[string]rpcHandler
+
+var jsonrpcHandlers = dispatchTable{
+	"rpc.discover":                      handleDiscover,
+	"cartesi_listApplications":          handleListApplications,
+	"cartesi_getApplication":            handleGetApplication,
+	"cartesi_listEpochs":                handleListEpochs,
+	"cartesi_getEpoch":                  handleGetEpoch,
+	"cartesi_getLastAcceptedEpochIndex": handleGetLastAcceptedEpochIndex,
+	"cartesi_listInputs":                handleListInputs,
+	"cartesi_getInput":                  handleGetInput,
+	"cartesi_getProcessedInputCount":    handleGetProcessedInputCount,
+	"cartesi_listOutputs":               handleListOutputs,
+	"cartesi_getOutput":                 handleGetOutput,
+	"cartesi_listReports":               handleListReports,
+	"cartesi_getReport":                 handleGetReport,
+	"cartesi_getChainId":                handleGetChainId,
+	"cartesi_getNodeVersion":            handleGetNodeVersion,
+}
+
 // -----------------------------------------------------------------------------
 // Dispatching JSON‑RPC methods
 // -----------------------------------------------------------------------------
@@ -59,38 +80,9 @@ func (s *Service) handleRPC(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.Logger.Info(fmt.Sprintf("Received RPC request: %s", req.Method))
-	switch req.Method {
-	case "rpc.discover":
-		s.handleDiscover(w, r, req)
-	case "cartesi_listApplications":
-		s.handleListApplications(w, r, req)
-	case "cartesi_getApplication":
-		s.handleGetApplication(w, r, req)
-	case "cartesi_listEpochs":
-		s.handleListEpochs(w, r, req)
-	case "cartesi_getEpoch":
-		s.handleGetEpoch(w, r, req)
-	case "cartesi_getLastAcceptedEpochIndex":
-		s.handleGetLastAcceptedEpochIndex(w, r, req)
-	case "cartesi_listInputs":
-		s.handleListInputs(w, r, req)
-	case "cartesi_getInput":
-		s.handleGetInput(w, r, req)
-	case "cartesi_getProcessedInputCount":
-		s.handleGetProcessedInputCount(w, r, req)
-	case "cartesi_listOutputs":
-		s.handleListOutputs(w, r, req)
-	case "cartesi_getOutput":
-		s.handleGetOutput(w, r, req)
-	case "cartesi_listReports":
-		s.handleListReports(w, r, req)
-	case "cartesi_getReport":
-		s.handleGetReport(w, r, req)
-	case "cartesi_getChainId":
-		s.handleGetChainId(w, r, req)
-	case "cartesi_getNodeVersion":
-		s.handleGetNodeVersion(w, req)
-	default:
+	if fn, ok := jsonrpcHandlers[req.Method]; ok {
+		fn(s, w, r, req)
+	} else {
 		s.Logger.Info(fmt.Sprintf("RPC method not found: %s", req.Method))
 		writeRPCError(w, req.ID, JSONRPC_METHOD_NOT_FOUND, "Method not found", nil)
 	}
@@ -101,7 +93,7 @@ func (s *Service) handleRPC(w http.ResponseWriter, r *http.Request) {
 // -----------------------------------------------------------------------------
 
 // Discovery: return the embedded specification.
-func (s *Service) handleDiscover(w http.ResponseWriter, _ *http.Request, req RPCRequest) {
+func handleDiscover(s *Service, w http.ResponseWriter, _ *http.Request, req RPCRequest) {
 	data, err := discoverSpec.ReadFile("jsonrpc-discover.json")
 	if err != nil {
 		s.Logger.Error("Unable to read jsonrpc-discover content", "err", err)
@@ -117,7 +109,7 @@ func (s *Service) handleDiscover(w http.ResponseWriter, _ *http.Request, req RPC
 	writeRPCResult(w, req.ID, spec)
 }
 
-func (s *Service) handleListApplications(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleListApplications(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params ListApplicationsParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -170,7 +162,7 @@ func (s *Service) handleListApplications(w http.ResponseWriter, r *http.Request,
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetApplication(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetApplication(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetApplicationParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -205,7 +197,7 @@ func (s *Service) handleGetApplication(w http.ResponseWriter, r *http.Request, r
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleListEpochs(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleListEpochs(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params ListEpochsParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -247,6 +239,11 @@ func (s *Service) handleListEpochs(w http.ResponseWriter, r *http.Request, req R
 		writeRPCError(w, req.ID, JSONRPC_INTERNAL_ERROR, "Internal server error", nil)
 		return
 	}
+
+	if len(epochs) == 0 && !s.applicationExists(w, r, req, params.Application) {
+		writeRPCError(w, req.ID, JSONRPC_RESOURCE_NOT_FOUND, "Application not found", nil)
+		return
+	}
 	if epochs == nil {
 		epochs = []*model.Epoch{}
 	}
@@ -275,6 +272,21 @@ func (s *Service) handleListEpochs(w http.ResponseWriter, r *http.Request, req R
 	writeRPCResult(w, req.ID, result)
 }
 
+func (s *Service) applicationExists(
+	w http.ResponseWriter,
+	r *http.Request,
+	req RPCRequest,
+	validatedNameOrAddress string,
+) bool {
+	app, err := s.repository.GetApplication(r.Context(), validatedNameOrAddress)
+	if err != nil {
+		s.Logger.Error("Unable to retrieve application from repository", "err", err)
+		writeRPCError(w, req.ID, JSONRPC_INTERNAL_ERROR, "Internal server error", nil)
+		return false
+	}
+	return app != nil
+}
+
 func parseIndex(indexString string, field string) (uint64, error) {
 	if len(indexString) < 3 || (!strings.HasPrefix(indexString, "0x") && !strings.HasPrefix(indexString, "0X")) {
 		return 0, fmt.Errorf("invalid %s: expected hex encoded value", field)
@@ -287,7 +299,7 @@ func parseIndex(indexString string, field string) (uint64, error) {
 	return index, nil
 }
 
-func (s *Service) handleGetEpoch(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetEpoch(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetEpochParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -328,7 +340,7 @@ func (s *Service) handleGetEpoch(w http.ResponseWriter, r *http.Request, req RPC
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetLastAcceptedEpochIndex(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetLastAcceptedEpochIndex(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetLastAcceptedEpochIndexParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -363,7 +375,7 @@ func (s *Service) handleGetLastAcceptedEpochIndex(w http.ResponseWriter, r *http
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleListInputs(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleListInputs(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params ListInputsParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -416,6 +428,10 @@ func (s *Service) handleListInputs(w http.ResponseWriter, r *http.Request, req R
 		writeRPCError(w, req.ID, JSONRPC_INTERNAL_ERROR, "Internal server error", nil)
 		return
 	}
+	if len(inputs) == 0 && !s.applicationExists(w, r, req, params.Application) {
+		writeRPCError(w, req.ID, JSONRPC_RESOURCE_NOT_FOUND, "Application not found", nil)
+		return
+	}
 
 	var resultInputs []*DecodedInput
 	for _, in := range inputs {
@@ -453,7 +469,7 @@ func (s *Service) handleListInputs(w http.ResponseWriter, r *http.Request, req R
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetInput(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetInput(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetInputParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -499,7 +515,7 @@ func (s *Service) handleGetInput(w http.ResponseWriter, r *http.Request, req RPC
 	writeRPCResult(w, req.ID, response)
 }
 
-func (s *Service) handleGetProcessedInputCount(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetProcessedInputCount(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetApplicationParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -549,7 +565,7 @@ func ParseOutputType(s string) ([]byte, error) {
 	return b, nil
 }
 
-func (s *Service) handleListOutputs(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleListOutputs(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params ListOutputsParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -630,6 +646,11 @@ func (s *Service) handleListOutputs(w http.ResponseWriter, r *http.Request, req 
 		}
 		resultOutputs = append(resultOutputs, decoded)
 	}
+
+	if len(resultOutputs) == 0 && !s.applicationExists(w, r, req, params.Application) {
+		writeRPCError(w, req.ID, JSONRPC_RESOURCE_NOT_FOUND, "Application not found", nil)
+		return
+	}
 	if resultOutputs == nil {
 		resultOutputs = []*DecodedOutput{}
 	}
@@ -658,7 +679,7 @@ func (s *Service) handleListOutputs(w http.ResponseWriter, r *http.Request, req 
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetOutput(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetOutput(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetOutputParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -704,7 +725,7 @@ func (s *Service) handleGetOutput(w http.ResponseWriter, r *http.Request, req RP
 	writeRPCResult(w, req.ID, response)
 }
 
-func (s *Service) handleListReports(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleListReports(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params ListReportsParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -756,6 +777,11 @@ func (s *Service) handleListReports(w http.ResponseWriter, r *http.Request, req 
 		writeRPCError(w, req.ID, JSONRPC_INTERNAL_ERROR, "Internal server error", nil)
 		return
 	}
+
+	if len(reports) == 0 && !s.applicationExists(w, r, req, params.Application) {
+		writeRPCError(w, req.ID, JSONRPC_RESOURCE_NOT_FOUND, "Application not found", nil)
+		return
+	}
 	if reports == nil {
 		reports = []*model.Report{}
 	}
@@ -784,7 +810,7 @@ func (s *Service) handleListReports(w http.ResponseWriter, r *http.Request, req 
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetReport(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetReport(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 	var params GetReportParams
 	if err := UnmarshalParams(req.Params, &params); err != nil {
 		s.Logger.Debug("Invalid parameters", "err", err)
@@ -825,7 +851,7 @@ func (s *Service) handleGetReport(w http.ResponseWriter, r *http.Request, req RP
 	writeRPCResult(w, req.ID, response)
 }
 
-func (s *Service) handleGetChainId(w http.ResponseWriter, r *http.Request, req RPCRequest) {
+func handleGetChainId(s *Service, w http.ResponseWriter, r *http.Request, req RPCRequest) {
 
 	config, err := repository.LoadNodeConfig[evmreader.PersistentConfig](r.Context(), s.repository, evmreader.EvmReaderConfigKey)
 	if errors.Is(err, repository.ErrNotFound) {
@@ -847,7 +873,7 @@ func (s *Service) handleGetChainId(w http.ResponseWriter, r *http.Request, req R
 	writeRPCResult(w, req.ID, result)
 }
 
-func (s *Service) handleGetNodeVersion(w http.ResponseWriter, req RPCRequest) {
+func handleGetNodeVersion(s *Service, w http.ResponseWriter, _ *http.Request, req RPCRequest) {
 	result := struct {
 		Data string `json:"data"`
 	}{

--- a/internal/jsonrpc/jsonrpc_test.go
+++ b/internal/jsonrpc/jsonrpc_test.go
@@ -1,0 +1,1564 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+// Tests for jsonrpc API using test tables of the database.
+//
+// for a simple coverage check, run:
+// ```
+// go test -C internal/jsonrpc/ -cover
+// ```
+//
+// for an actual report, run:
+// ```
+// go test -C internal/jsonrpc/ -coverprofile=coverage.out
+// go tool -C internal/jsonrpc/ cover -html=coverage.out
+// ```
+package jsonrpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cartesi/rollups-node/internal/evmreader"
+	"github.com/cartesi/rollups-node/internal/model"
+	"github.com/cartesi/rollups-node/internal/repository"
+	"github.com/cartesi/rollups-node/internal/version"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type jsonrpcSchema struct {
+	Methods []struct {
+		Name string
+	}
+}
+
+// failure: invalid JSON (extra ',' at the end)
+func TestInvalidJSON(t *testing.T) {
+	s := newTestService(t, t.Name())
+
+	body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+		"jsonrpc": "2.0",
+		"method": "",
+		"params": {},
+		"id": 0,
+	}`))
+
+	assert.Equal(t, "Invalid JSON\n", string(body))
+}
+
+// failure: invalid method
+func TestInvalidMethod(t *testing.T) {
+	s := newTestService(t, t.Name())
+
+	body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+		"jsonrpc": "2.0",
+		"method": "cartesi_invalidMethod",
+		"params": {},
+		"id": 0
+	}`))
+
+	resp := testRPCResponse[any]{}
+	assert.Nil(t, json.Unmarshal(body, &resp))
+	assert.Equal(t, JSONRPC_METHOD_NOT_FOUND, resp.Error.Code)
+	assert.Equal(t, "Method not found", resp.Error.Message)
+}
+
+// tests for jsonrpc methods grouped by method name.
+// At the end we check if all methods ran at least once
+func TestMethod(t *testing.T) {
+	testHistogram := hist{}
+
+	getName := func(name string) string {
+		part, _ := strings.CutPrefix(name, "TestMethod/")
+		return part
+	}
+
+	////////////////////////////////////////////////////////////////////////
+	// rpc.discover
+	////////////////////////////////////////////////////////////////////////
+	t.Run("rpc.discover", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// success: return discover file contents
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			contents, err := os.ReadFile("jsonrpc-discover.json")
+			assert.Nil(t, err)
+
+			var expected any
+			assert.Nil(t, json.Unmarshal(contents, &expected))
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "rpc.discover",
+				"params": {},
+				"id": 0
+				}`))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getApplication
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getApplication", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: application not in the database -> resource not found
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(0)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getApplication",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: application is in the database -> retrieve application
+		t.Run("present", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getApplication",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[model.Application]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, nr, nameToNumber(resp.Result.Data.Name))
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getChainId
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getChainId", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: evm reader not configured -> resource not found
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, "getChainIdFailure")
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getChainId",
+				"params": {},
+				"id": 0
+				}`))
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "EVM Reader config not found", resp.Error.Message)
+		})
+
+		// success: evm reader configured -> retrieve chain id
+		t.Run("present", func(t *testing.T) {
+			testHistogram.inc(method)
+			ctx := context.Background()
+			s := newTestService(t, "getChainIdFailure")
+
+			// NodeConfig provision
+			nr := uint64(0xdeadbeef)
+			repository.SaveNodeConfig(ctx, s.repository,
+				&model.NodeConfig[evmreader.PersistentConfig]{
+					Key: evmreader.EvmReaderConfigKey,
+					Value: evmreader.PersistentConfig{
+						ChainID: nr,
+					},
+				},
+			)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getChainId",
+				"params": {},
+				"id": 0
+				}`))
+			resp := testRPCResponse[hex64]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, nr, uint64(resp.Result.Data))
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getEpoch
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getEpoch", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: epoch_index not hex encoded -> invalid param
+		t.Run("malformedEpochIndex", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			app := uint64(1)
+			nr := uint64(0)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getEpoch",
+				"params": {
+				"application": "%v",
+				"epoch_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), nr))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_INVALID_PARAMS, resp.Error.Code)
+			assert.Equal(t, "invalid epoch_index: expected hex encoded value", resp.Error.Message)
+		})
+
+		// failure: epoch not in the database -> resource not found
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(1)
+			nr := uint64(0)
+
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID:        appID,
+				Index:                nr,
+				ClaimHash:            &common.Hash{},
+				ClaimTransactionHash: &common.Hash{},
+				Status:               model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, nr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getEpoch",
+				"params": {
+				"application": "%v",
+				"epoch_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(nr+1)))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Epoch not found", resp.Error.Message)
+		})
+
+		// success: epoch is in the database -> retrieve epoch
+		t.Run("present", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(1)
+			nr := uint64(1)
+
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID:        appID,
+				Index:                nr,
+				ClaimHash:            &common.Hash{},
+				ClaimTransactionHash: &common.Hash{},
+				Status:               model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, nr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getEpoch",
+				"params": {
+				"application": "%v",
+				"epoch_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(nr)))
+
+			resp := testRPCResponse[*model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, nr, resp.Result.Data.Index)
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getInput
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getInput", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: input_index not hex encoded -> invalid param
+		t.Run("malformedInputIndex", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			app := uint64(1)
+			nr := uint64(0)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getInput",
+				"params": {
+				"application": "%v",
+				"input_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), nr))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_INVALID_PARAMS, resp.Error.Code)
+			assert.Equal(t, "invalid input_index: expected hex encoded value", resp.Error.Message)
+		})
+
+		// failure: input_index not in database -> absent input
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(2)
+			enr := uint64(1)
+			inr := uint64(0)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getInput",
+				"params": {
+				"application": "%v",
+				"input_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(inr)))
+
+			resp := testRPCResponse[*model.Input]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Input not found", resp.Error.Message)
+		})
+
+		// success: input_index of EvmAdvance in the database -> retrieve input
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(2)
+			enr := uint64(1)
+			inr := uint64(0)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			err = s.repository.CreateInput(ctx, &model.Input{
+				EpochApplicationID: appID,
+				EpochIndex:         enr,
+				Index:              inr,
+				Status:             model.InputCompletionStatus_Accepted,
+				RawData:            emptyInput(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, input_index: %v", 0, appID, inr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getInput",
+				"params": {
+				"application": "%v",
+				"input_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(inr)))
+
+			resp := testRPCResponse[*model.Input]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, enr, resp.Result.Data.EpochIndex)
+			assert.Equal(t, inr, resp.Result.Data.Index)
+		})
+
+		// TODO: also test DecodedInput
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getLastAcceptedEpochIndex
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getLastAcceptedEpochIndex", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: epoch not in the database -> resource not found
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(0xdeadbeef)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getLastAcceptedEpochIndex",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[hex64]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Epoch not found", resp.Error.Message)
+		})
+
+		// success: epoch is in the database -> retrieve epoch index
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(0)
+			epochIndex := uint64(0xdeadbeef)
+
+			appID := s.newTestApplication(t, ctx, 0, nr)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID:        appID,
+				Index:                epochIndex,
+				ClaimHash:            &common.Hash{},
+				ClaimTransactionHash: &common.Hash{},
+				Status:               model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, nr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getLastAcceptedEpochIndex",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[hex64]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, epochIndex, uint64(resp.Result.Data))
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getNodeVersion
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getNodeVersion", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// success: -> version.BuildVersion
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getNodeVersion",
+				"params": {},
+				"id": 0
+				}`))
+
+			resp := testRPCResponse[string]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, version.BuildVersion, resp.Result.Data)
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getOutput
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getOutput", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: output_index not hex encoded -> invalid param
+		t.Run("malformed", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			app := uint64(1)
+			nr := uint64(0)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getOutput",
+				"params": {
+				"application": "%v",
+				"output_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), nr))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_INVALID_PARAMS, resp.Error.Code)
+			assert.Equal(t, "invalid output_index: expected hex encoded value", resp.Error.Message)
+		})
+
+		// failure: input_index not in database -> absent input
+		t.Run("absent", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(2)
+			enr := uint64(1)
+			inr := uint64(0)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getOutput",
+				"params": {
+				"application": "%v",
+				"output_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(inr)))
+
+			resp := testRPCResponse[*model.Output]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Output not found", resp.Error.Message)
+		})
+
+		// success: output_index of Voucher in the database -> retrieve output
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(3)
+			enr := uint64(1)
+			inr := uint64(1)
+			onr := uint64(0)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			err = s.repository.CreateInput(ctx, &model.Input{
+				EpochApplicationID: appID,
+				EpochIndex:         enr,
+				Index:              inr,
+				Status:             model.InputCompletionStatus_Accepted,
+				RawData:            emptyInput(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, input_index: %v", 0, appID, inr)
+
+			err = s.repository.CreateOutput(ctx, &model.Output{
+				InputEpochApplicationID: appID,
+				InputIndex:              inr,
+				Index:                   onr,
+				RawData:                 emptyVoucher(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, output_index: %v", 0, appID, onr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getOutput",
+				"params": {
+				"application": "%v",
+				"output_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(onr)))
+
+			type Result struct {
+				EpochIndex hex64  `json:"epoch_index"`
+				InputIndex hex64  `json:"input_index"`
+				Index      hex64  `json:"index"`
+				RawData    string `json:"raw_data"` // hex encoded
+
+				Voucher *Voucher `json:"decoded_data,omitempty"`
+
+				// ... (ignore the rest of fields for test
+			}
+
+			resp := testRPCResponse[Result]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, inr, uint64(resp.Result.Data.InputIndex))
+			assert.Equal(t, onr, uint64(resp.Result.Data.Index))
+			assert.Equal(t, "0xdeadbeef", resp.Result.Data.Voucher.Value)
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getProcessedInputCount
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getProcessedInputCount", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: application not in the database -> application not found
+		t.Run("absentApplication", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			app := uint64(1)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getProcessedInputCount",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(app)))
+
+			resp := testRPCResponse[hex64]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: application has no inputs -> 0
+		t.Run("absentInput", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(1)
+
+			s.newTestApplication(t, ctx, 0, app)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getProcessedInputCount",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(app)))
+
+			resp := testRPCResponse[hex64]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, uint64(0), uint64(resp.Result.Data))
+		})
+
+		// TODO: test with inputs (need repository.CreateInput)
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// getReport
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_getReport", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: report_index not hex encoded -> invalid param
+		t.Run("malformed", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			app := uint64(1)
+			reportIndex := uint64(0)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getReport",
+				"params": {
+				"application": "%v",
+				"report_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), reportIndex))
+
+			resp := testRPCResponse[any]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_INVALID_PARAMS, resp.Error.Code)
+			assert.Equal(t, "invalid report_index: expected hex encoded value", resp.Error.Message)
+		})
+
+		// success: output_index of Voucher in the database -> retrieve output
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(3)
+			enr := uint64(1)
+			inr := uint64(1)
+			onr := uint64(0)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			err = s.repository.CreateInput(ctx, &model.Input{
+				EpochApplicationID: appID,
+				EpochIndex:         enr,
+				Index:              inr,
+				Status:             model.InputCompletionStatus_Accepted,
+				RawData:            emptyInput(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, input_index: %v", 0, appID, inr)
+
+			err = s.repository.CreateReport(ctx, &model.Report{
+				InputEpochApplicationID: appID,
+				InputIndex:              inr,
+				Index:                   onr,
+				RawData:                 emptyVoucher(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, output_index: %v", 0, appID, onr)
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_getReport",
+				"params": {
+				"application": "%v",
+				"report_index": "%v"
+				},
+				"id": 0
+				}`, numberToName(app), hexutil.EncodeUint64(onr)))
+
+			type Result struct {
+				EpochIndex hex64  `json:"epoch_index"`
+				InputIndex hex64  `json:"input_index"`
+				Index      hex64  `json:"index"`
+				RawData    string `json:"raw_data"` // hex encoded
+
+				// ... (ignore the rest of fields for test
+			}
+
+			resp := testRPCResponse[Result]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, inr, uint64(resp.Result.Data.InputIndex))
+			assert.Equal(t, onr, uint64(resp.Result.Data.Index))
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// listApplications
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_listApplications", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// success: no application is in the database -> 0
+		t.Run("empty", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listApplications",
+				"params": {
+				"limit": %v,
+				"offset": %v,
+				"descending": %v
+				},
+				"id": 0
+				}`, 0, 0, false))
+
+			resp := testRPCResponse[[]model.Application]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 0, len(resp.Result.Data))
+		})
+
+		// success: 1 application is in the database -> 1
+		t.Run("one", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listApplications",
+				"params": {
+				"limit": %v,
+				"offset": %v,
+				"descending": %v
+				},
+				"id": 0
+				}`, 1, 0, false))
+
+			resp := testRPCResponse[[]model.Application]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 1, len(resp.Result.Data))
+			assert.Equal(t, numberToName(nr), resp.Result.Data[0].Name)
+		})
+
+		// success: 1 application is in the database (array params) -> 1
+		t.Run("oneArrayParams", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listApplications",
+				"params": [%v, %v, %v],
+				"id": 0
+				}`, 1, 0, false))
+
+			resp := testRPCResponse[[]model.Application]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 1, len(resp.Result.Data))
+			assert.Equal(t, numberToName(nr), resp.Result.Data[0].Name)
+		})
+
+		// success: many applications is in the database -> limit (many - 1)
+		t.Run("many", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			many := uint64(100)
+			limit := uint64(many / 2)
+			for i := range many {
+				s.newTestApplication(t, ctx, 0, i)
+			}
+
+			{ // offset == 0, descending = false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listApplications",
+					"params": {
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, limit, 0, false))
+
+				resp := testRPCResponse[[]model.Application]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i
+					assert.Equal(t, nr, nameToNumber(resp.Result.Data[i].Name))
+				}
+			}
+
+			{ // offset == 1, descending == false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listApplications",
+					"params": {
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, limit, 1, false))
+
+				resp := testRPCResponse[[]model.Application]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i + 1
+					assert.Equal(t, nr, nameToNumber(resp.Result.Data[i].Name))
+				}
+			}
+
+			{ // offset == 0, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listApplications",
+					"params": {
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, limit, 0, true))
+
+				resp := testRPCResponse[[]model.Application]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 1
+					assert.Equal(t, nr, nameToNumber(resp.Result.Data[i].Name))
+				}
+			}
+
+			{ // offset == 1, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listApplications",
+					"params": {
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, limit, 1, true))
+
+				resp := testRPCResponse[[]model.Application]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 2
+					assert.Equal(t, nr, nameToNumber(resp.Result.Data[i].Name))
+				}
+			}
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////////////
+	// listEpochs
+	////////////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_listEpochs", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: no epoch in the database -> no application
+		t.Run("absentApplication", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(1)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listEpochs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: no epoch in the database -> 0
+		t.Run("absentEpoch", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listEpochs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 0, len(resp.Result.Data))
+		})
+
+		// failure: query invalid status -> invalid params
+		t.Run("invalid", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listEpochs",
+				"params": {
+				"application": "%v",
+				"status": "INVALID"
+				},
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_INVALID_PARAMS, resp.Error.Code)
+			assert.Equal(t, "Invalid epoch status: invalid value 'INVALID' for EpochStatus enum", resp.Error.Message)
+		})
+
+		// success: many epochs is in the database -> limit
+		t.Run("many", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			many := uint64(100)
+			limit := uint64(many / 2)
+			appID := s.newTestApplication(t, ctx, 0, nr)
+			for i := range many {
+				err := s.repository.CreateEpoch(ctx, &model.Epoch{
+					ApplicationID: appID,
+					Index:         i,
+					VirtualIndex:  i,
+					Status:        model.EpochStatus_ClaimAccepted,
+				})
+				assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, nr)
+			}
+
+			{ // offset == 0, descending = false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listEpochs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(nr), limit, 0, false))
+
+				resp := testRPCResponse[[]model.Epoch]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i
+					assert.Equal(t, nr, resp.Result.Data[i].Index)
+				}
+			}
+
+			{ // offset == 0, descending = false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listEpochs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(nr), limit, 1, false))
+
+				resp := testRPCResponse[[]model.Epoch]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i + 1
+					assert.Equal(t, nr, resp.Result.Data[i].Index)
+				}
+			}
+
+			{ // offset == 0, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listEpochs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(nr), limit, 0, true))
+
+				resp := testRPCResponse[[]model.Epoch]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 1
+					assert.Equal(t, nr, resp.Result.Data[i].Index)
+				}
+			}
+
+			{ // offset == 1, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listEpochs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(nr), limit, 1, true))
+
+				resp := testRPCResponse[[]model.Epoch]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 2
+					assert.Equal(t, nr, resp.Result.Data[i].Index)
+				}
+			}
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// listInputs
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_listInputs", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: no epoch in the database -> no application
+		t.Run("absentApplication", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(1)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listInputs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: no epoch in the database -> 0
+		t.Run("absentInput", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listInputs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 0, len(resp.Result.Data))
+		})
+
+		// TODO: test many inputs in the database (requires: repository.CreateInput)
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// listOutputs
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_listOutputs", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: no epoch in the database -> no application
+		t.Run("absentApplication", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(1)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listOutputs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: no epoch in the database -> 0
+		t.Run("absentOutput", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listOutputs",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 0, len(resp.Result.Data))
+		})
+
+		// success: many outputs in the database ordered correctly
+		t.Run("success", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(3)
+			enr := uint64(1)
+			inr := uint64(1)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			err = s.repository.CreateInput(ctx, &model.Input{
+				EpochApplicationID: appID,
+				EpochIndex:         enr,
+				Index:              inr,
+				Status:             model.InputCompletionStatus_Accepted,
+				RawData:            emptyInput(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, input_index: %v", 0, appID, inr)
+
+			many := uint64(100)
+			limit := uint64(many / 2)
+			for onr := range many {
+				err = s.repository.CreateOutput(ctx, &model.Output{
+					InputEpochApplicationID: appID,
+					InputIndex:              inr,
+					Index:                   onr,
+					RawData:                 emptyVoucher(),
+				})
+				assert.Nil(t, err, "on test case: %v, application: %v, output_index: %v", 0, appID, onr)
+			}
+
+			type Result struct {
+				EpochIndex hex64  `json:"epoch_index"`
+				InputIndex hex64  `json:"input_index"`
+				Index      hex64  `json:"index"`
+				RawData    string `json:"raw_data"` // hex encoded
+
+				Voucher *Voucher `json:"decoded_data,omitempty"`
+
+				// ... (ignore the rest of fields for test
+			}
+
+			{ // offset == 0, descending = false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listOutputs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 0, false))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 1, descending == false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listOutputs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 1, false))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i + 1
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 0, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listOutputs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 0, true))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 1
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 1, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listOutputs",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 1, true))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 2
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+		})
+	})
+
+	////////////////////////////////////////////////////////////////////////
+	// listReports
+	////////////////////////////////////////////////////////////////////////
+	t.Run("cartesi_listReports", func(t *testing.T) {
+		method := getName(t.Name())
+
+		// failure: no epoch in the database -> no application
+		t.Run("absentApplication", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+
+			nr := uint64(1)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listReports",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, JSONRPC_RESOURCE_NOT_FOUND, resp.Error.Code)
+			assert.Equal(t, "Application not found", resp.Error.Message)
+		})
+
+		// success: no epoch in the database -> 0
+		t.Run("empty", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			nr := uint64(1)
+			s.newTestApplication(t, ctx, 0, nr)
+			body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+				"jsonrpc": "2.0",
+				"method": "cartesi_listReports",
+				"params": { "application": "%v" },
+				"id": 0
+				}`, numberToName(nr)))
+
+			resp := testRPCResponse[[]model.Epoch]{}
+			assert.Nil(t, json.Unmarshal(body, &resp))
+			assert.Equal(t, 0, len(resp.Result.Data))
+		})
+
+		// success: many reports
+		t.Run("many", func(t *testing.T) {
+			testHistogram.inc(method)
+			s := newTestService(t, t.Name())
+			ctx := context.Background()
+
+			app := uint64(3)
+			enr := uint64(1)
+			inr := uint64(1)
+			appID := s.newTestApplication(t, ctx, 0, app)
+			err := s.repository.CreateEpoch(ctx, &model.Epoch{
+				ApplicationID: appID,
+				Index:         enr,
+				VirtualIndex:  enr,
+				Status:        model.EpochStatus_ClaimAccepted,
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, epoch_index: %v", 0, appID, enr)
+
+			err = s.repository.CreateInput(ctx, &model.Input{
+				EpochApplicationID: appID,
+				EpochIndex:         enr,
+				Index:              inr,
+				Status:             model.InputCompletionStatus_Accepted,
+				RawData:            emptyInput(),
+			})
+			assert.Nil(t, err, "on test case: %v, application: %v, input_index: %v", 0, appID, inr)
+
+			many := uint64(100)
+			limit := uint64(many / 2)
+			for onr := range many {
+				err = s.repository.CreateReport(ctx, &model.Report{
+					InputEpochApplicationID: appID,
+					InputIndex:              inr,
+					Index:                   onr,
+					RawData:                 emptyVoucher(),
+				})
+				assert.Nil(t, err, "on test case: %v, application: %v, report_index: %v", 0, appID, onr)
+			}
+
+			type Result struct {
+				EpochIndex hex64  `json:"epoch_index"`
+				InputIndex hex64  `json:"input_index"`
+				Index      hex64  `json:"index"`
+				RawData    string `json:"raw_data"` // hex encoded
+
+				// ... (ignore the rest of fields for test
+			}
+
+			{ // offset == 0, descending = false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listReports",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 0, false))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 1, descending == false
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listReports",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 1, false))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := i + 1
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 0, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listReports",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 0, true))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 1
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+
+			{ // offset == 1, descending = true
+				body := s.doRequest(t, 0, fmt.Appendf([]byte{}, `{
+					"jsonrpc": "2.0",
+					"method": "cartesi_listReports",
+					"params": {
+					"application": "%v",
+					"limit": %v,
+					"offset": %v,
+					"descending": %v
+					},
+					"id": 0
+					}`, numberToName(app), limit, 1, true))
+
+				resp := testRPCResponse[[]Result]{}
+				assert.Nil(t, json.Unmarshal(body, &resp))
+				assert.Equal(t, int(limit), len(resp.Result.Data))
+				for i := range limit {
+					nr := many - i - 2
+					assert.Equal(t, nr, uint64(resp.Result.Data[i].Index))
+				}
+			}
+		})
+	})
+
+	// tested methods, implemented methods and discover methods must match:
+	data, err := discoverSpec.ReadFile("jsonrpc-discover.json")
+	assert.Nil(t, err)
+
+	var schema jsonrpcSchema
+	err = json.Unmarshal(data, &schema)
+	assert.Nil(t, err)
+
+	result := hist{
+		"rpc.discover": 1, // +1, because it doesn't show up in the jsonrpc file
+	}
+
+	for k := range testHistogram {
+		result.inc(k)
+	}
+
+	for k := range jsonrpcHandlers {
+		result.inc(k)
+	}
+
+	for _, v := range schema.Methods {
+		result.inc(v.Name)
+	}
+
+	for k, v := range result {
+		assert.Equal(t, v, 3, "method %v is not: tested && implemented && discovered", k)
+	}
+}

--- a/internal/jsonrpc/types.go
+++ b/internal/jsonrpc/types.go
@@ -253,6 +253,10 @@ type DecodedInput struct {
 
 func DecodeInput(input *model.Input, parsedAbi *abi.ABI) (*DecodedInput, error) {
 	decoded := make(map[string]any)
+	if len(input.RawData) < 4 {
+		return nil, fmt.Errorf("error: input needs at least 4 bytes")
+	}
+
 	err := parsedAbi.Methods["EvmAdvance"].Inputs.UnpackIntoMap(decoded, input.RawData[4:])
 	if err != nil {
 		return &DecodedInput{Input: input}, err

--- a/internal/jsonrpc/util_test.go
+++ b/internal/jsonrpc/util_test.go
@@ -1,0 +1,144 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package jsonrpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/cartesi/rollups-node/internal/model"
+	"github.com/cartesi/rollups-node/internal/repository/factory"
+	"github.com/cartesi/rollups-node/pkg/service"
+	"github.com/cartesi/rollups-node/test/tooling/db"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// histogram to gather statistics for each method
+type hist map[string]int
+
+func (h hist) inc(k string) {
+	x, ok := h[k]
+	if ok {
+		h[k] = x + 1
+	} else {
+		h[k] = 1
+	}
+}
+
+// auxiliary type to encode/decode hex strings in json
+type hex64 uint64
+
+func (x *hex64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(hexutil.EncodeUint64(uint64(*x)))
+}
+
+func (x *hex64) UnmarshalJSON(in []byte) error {
+	var hexString string
+	json.Unmarshal(in, &hexString)
+	hexValue, err := model.ParseHexUint64(hexString)
+	if err != nil {
+		return err
+	}
+	*x = hex64(hexValue)
+	return nil
+}
+
+// RPC response type
+type testRPCResponse[T any] struct {
+	JSONRPC string `json:"jsonrpc"`
+	Result  struct {
+		Data T `json:"data"`
+	} `json:"result"`
+	Error *RPCError `json:"error,omitempty"`
+	ID    any       `json:"id"`
+}
+
+func newTestService(t *testing.T, name string) *Service {
+	ctx := context.Background()
+
+	dbTestEndpoint, err := db.GetTestDatabaseEndpoint()
+	assert.Nil(t, err)
+
+	err = db.SetupTestPostgres(dbTestEndpoint)
+	assert.Nil(t, err)
+
+	repo, err := factory.NewRepositoryFromConnectionString(ctx, dbTestEndpoint)
+	assert.Nil(t, err)
+
+	ci := CreateInfo{
+		CreateInfo: service.CreateInfo{
+			Name:     name,
+			LogLevel: slog.LevelDebug,
+			LogColor: true,
+		},
+		Repository: repo,
+	}
+	s, err := Create(ctx, &ci)
+	assert.Nil(t, err, "on new test service")
+
+	return s
+}
+
+func nameToNumber(in string) uint64 {
+	xs := hexutil.MustDecode(in)
+	return big.NewInt(0).SetBytes(xs).Uint64()
+}
+
+func numberToName(x uint64) string {
+	return fmt.Sprintf("0x%016x", x)
+}
+
+// create an application with mostly stub values.
+func (s *Service) newTestApplication(t *testing.T, ctx context.Context, test, i uint64) int64 {
+	hex := numberToName(i)
+	id, err := s.repository.CreateApplication(ctx, &model.Application{
+		Name:                hex,
+		IApplicationAddress: common.HexToAddress(hex),
+		DataAvailability:    []byte{0x00, 0x00, 0x00, 0x00},
+		State:               model.ApplicationState_Enabled,
+	}, false)
+	assert.Nil(t, err, "on test case: %v, when creating application: %v", test, i)
+	return id
+}
+
+func (s *Service) doRequest(t *testing.T, i uint64, reqData []byte) []byte {
+	w := httptest.NewRecorder()
+	s.handleRPC(
+		w,
+		httptest.NewRequest(
+			http.MethodGet,
+			"/rpc",
+			bytes.NewReader(reqData),
+		),
+	)
+
+	body := new(strings.Builder)
+	_, err := io.Copy(body, w.Result().Body)
+	assert.Nil(t, err, "on test case: %v", i)
+
+	return []byte(body.String())
+}
+
+// input from ./cartesi-rollups-cli send echo-dapp -y ""
+func emptyInput() []byte {
+	raw, _ := hexutil.Decode("0x415bf363000000000000000000000000000000000000000000000000000000000000343a0000000000000000000000002e662c8a1a6c8008482a41ef6d3b333497e7f956000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb92266000000000000000000000000000000000000000000000000000000000000000c0000000000000000000000000000000000000000000000000000000068c97fb45a1ab2f3478ee32e84c0a464f70d9da8d470868984ba5f00d9da757bbcee2098000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000")
+	return raw
+}
+
+// output from ./cartesi-rollups-cli send echo-dapp -y ""
+func emptyVoucher() []byte {
+	raw, _ := hexutil.Decode("0x237a816f000000000000000000000000f39fd6e51aad88f6f4ce6ab8827279cfffb9226600000000000000000000000000000000000000000000000000000000deadbeef00000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000000")
+	return raw
+}

--- a/internal/model/models.go
+++ b/internal/model/models.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 type Application struct {
@@ -64,6 +65,61 @@ func (a *Application) MarshalJSON() ([]byte, error) {
 		ProcessedInputs:      fmt.Sprintf("0x%x", a.ProcessedInputs),
 	}
 	return json.Marshal(aux)
+}
+
+func (a *Application) UnmarshalJSON(in []byte) error {
+	type Alias Application
+	aux := &struct {
+		*Alias
+
+		DataAvailability     string `json:"data_availability"`
+		IInputBoxBlock       string `json:"iinputbox_block"`
+		LastInputCheckBlock  string `json:"last_input_check_block"`
+		LastOutputCheckBlock string `json:"last_output_check_block"`
+		EpochLength          string `json:"epoch_length"`
+		ProcessedInputs      string `json:"processed_inputs"`
+	}{}
+
+	var err error
+
+	if err = json.Unmarshal(in, aux); err != nil {
+		return err
+	}
+
+	*a = Application(*aux.Alias)
+
+	// manually decode the following values as hex instead of the default (base64)
+	a.DataAvailability, err = hexutil.Decode(aux.DataAvailability)
+	if err != nil {
+		return err
+	}
+
+	a.IInputBoxBlock, err = ParseHexUint64(aux.IInputBoxBlock)
+	if err != nil {
+		return err
+	}
+
+	a.LastInputCheckBlock, err = ParseHexUint64(aux.LastInputCheckBlock)
+	if err != nil {
+		return err
+	}
+
+	a.LastOutputCheckBlock, err = ParseHexUint64(aux.LastOutputCheckBlock)
+	if err != nil {
+		return err
+	}
+
+	a.EpochLength, err = ParseHexUint64(aux.EpochLength)
+	if err != nil {
+		return err
+	}
+
+	a.ProcessedInputs, err = ParseHexUint64(aux.ProcessedInputs)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type ApplicationState string
@@ -467,6 +523,49 @@ func (e *Epoch) MarshalJSON() ([]byte, error) {
 	return json.Marshal(aux)
 }
 
+func (e *Epoch) UnmarshalJSON(in []byte) error {
+	type Alias Epoch
+	aux := &struct {
+		*Alias
+
+		Index        string `json:"index"`
+		FirstBlock   string `json:"first_block"`
+		LastBlock    string `json:"last_block"`
+		VirtualIndex string `json:"virtual_index"`
+	}{}
+
+	var err error
+
+	if err = json.Unmarshal(in, aux); err != nil {
+		return err
+	}
+
+	*e = Epoch(*aux.Alias)
+
+	// manually decode the following values as hex instead of the default (base64)
+	e.Index, err = ParseHexUint64(aux.Index)
+	if err != nil {
+		return err
+	}
+
+	e.FirstBlock, err = ParseHexUint64(aux.FirstBlock)
+	if err != nil {
+		return err
+	}
+
+	e.LastBlock, err = ParseHexUint64(aux.LastBlock)
+	if err != nil {
+		return err
+	}
+
+	e.VirtualIndex, err = ParseHexUint64(aux.VirtualIndex)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type EpochStatus string
 
 const (
@@ -559,6 +658,46 @@ func (i *Input) MarshalJSON() ([]byte, error) {
 		Alias:       (*Alias)(i),
 	}
 	return json.Marshal(aux)
+}
+
+func (i *Input) UnmarshalJSON(in []byte) error {
+	type Alias Input
+	aux := &struct {
+		EpochIndex  string `json:"epoch_index"`
+		Index       string `json:"index"`
+		BlockNumber string `json:"block_number"`
+		RawData     string `json:"raw_data"`
+		*Alias
+	}{}
+
+	var err error
+	if err = json.Unmarshal(in, aux); err != nil {
+		return err
+	}
+
+	*i = Input(*aux.Alias)
+
+	i.EpochIndex, err = ParseHexUint64(aux.EpochIndex)
+	if err != nil {
+		return fmt.Errorf("error on EpochIndex: %v", err)
+	}
+
+	i.Index, err = ParseHexUint64(aux.Index)
+	if err != nil {
+		return fmt.Errorf("error on Index: %v", err)
+	}
+
+	i.BlockNumber, err = ParseHexUint64(aux.BlockNumber)
+	if err != nil {
+		return fmt.Errorf("error on BlockNumber: %v", err)
+	}
+
+	i.RawData, err = hexutil.Decode(aux.RawData)
+	if err != nil {
+		return fmt.Errorf("error on RawData: %v", err)
+	}
+
+	return nil
 }
 
 type InputCompletionStatus string

--- a/internal/repository/postgres/application.go
+++ b/internal/repository/postgres/application.go
@@ -242,12 +242,6 @@ func (r *PostgresRepository) GetProcessedInputs(
 
 	stmt := table.Application.
 		SELECT(table.Application.ProcessedInputs).
-		FROM(
-			table.Application.INNER_JOIN(
-				table.ExecutionParameters,
-				table.ExecutionParameters.ApplicationID.EQ(table.Application.ID),
-			),
-		).
 		WHERE(whereClause)
 
 	sqlStr, args := stmt.Sql()

--- a/internal/repository/postgres/epoch.go
+++ b/internal/repository/postgres/epoch.go
@@ -17,50 +17,6 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (r *PostgresRepository) CreateEpoch(
-	ctx context.Context,
-	nameOrAddress string,
-	e *model.Epoch,
-) error {
-
-	whereClause, err := getWhereClauseFromNameOrAddress(nameOrAddress)
-	if err != nil {
-		return err
-	}
-
-	selectQuery := postgres.SELECT(
-		table.Application.ID,
-		postgres.RawFloat(fmt.Sprintf("%d", e.Index)),
-		postgres.RawFloat(fmt.Sprintf("%d", e.FirstBlock)),
-		postgres.RawFloat(fmt.Sprintf("%d", e.LastBlock)),
-		postgres.Bytea(e.ClaimHash),
-		postgres.Bytea(e.ClaimTransactionHash),
-		postgres.NewEnumValue(e.Status.String()),
-		postgres.RawFloat(fmt.Sprintf("%d", e.VirtualIndex)),
-	).FROM(
-		table.Application,
-	).WHERE(
-		whereClause,
-	)
-
-	insertStmt := table.Epoch.INSERT(
-		table.Epoch.ApplicationID,
-		table.Epoch.Index,
-		table.Epoch.FirstBlock,
-		table.Epoch.LastBlock,
-		table.Epoch.ClaimHash,
-		table.Epoch.ClaimTransactionHash,
-		table.Epoch.Status,
-		table.Epoch.VirtualIndex,
-	).QUERY(
-		selectQuery,
-	)
-
-	sqlStr, args := insertStmt.Sql()
-	_, err = r.db.Exec(ctx, sqlStr, args...)
-	return err
-}
-
 func getEpochNextVirtualIndex(
 	ctx context.Context,
 	tx pgx.Tx,

--- a/internal/repository/postgres/test_only.go
+++ b/internal/repository/postgres/test_only.go
@@ -1,0 +1,122 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package postgres
+
+import (
+	"context"
+
+	"github.com/cartesi/rollups-node/internal/model"
+	"github.com/cartesi/rollups-node/internal/repository/postgres/db/rollupsdb/public/table"
+)
+
+func (r *PostgresRepository) CreateEpoch(
+	ctx context.Context,
+	e *model.Epoch,
+) error {
+	insertStmt := table.Epoch.INSERT(
+		table.Epoch.ApplicationID,
+		table.Epoch.Index,
+		table.Epoch.FirstBlock,
+		table.Epoch.LastBlock,
+		table.Epoch.ClaimHash,
+		table.Epoch.ClaimTransactionHash,
+		table.Epoch.Status,
+		table.Epoch.VirtualIndex,
+	).VALUES(
+		e.ApplicationID,
+		e.Index,
+		e.FirstBlock,
+		e.LastBlock,
+		e.ClaimHash,
+		e.ClaimTransactionHash,
+		e.Status,
+		e.VirtualIndex,
+	)
+
+	sqlStr, args := insertStmt.Sql()
+	_, err := r.db.Exec(ctx, sqlStr, args...)
+	return err
+}
+
+func (r *PostgresRepository) CreateInput(
+	ctx context.Context,
+	inp *model.Input,
+) error {
+	insertStmt := table.Input.INSERT(
+		table.Input.EpochApplicationID,
+		table.Input.EpochIndex,
+		table.Input.Index,
+		table.Input.BlockNumber,
+		table.Input.RawData,
+		table.Input.Status,
+		table.Input.MachineHash,
+		table.Input.OutputsHash,
+		table.Input.TransactionReference,
+		table.Input.SnapshotURI,
+	).VALUES(
+		inp.EpochApplicationID,
+		inp.EpochIndex,
+		inp.Index,
+		inp.BlockNumber,
+		inp.RawData,
+		inp.Status,
+		inp.MachineHash,
+		inp.OutputsHash,
+		inp.TransactionReference,
+		inp.SnapshotURI,
+	)
+
+	sqlStr, args := insertStmt.Sql()
+	_, err := r.db.Exec(ctx, sqlStr, args...)
+	return err
+}
+
+func (r *PostgresRepository) CreateOutput(
+	ctx context.Context,
+	out *model.Output,
+) error {
+	insertStmt := table.Output.INSERT(
+		table.Output.InputEpochApplicationID,
+		table.Output.InputIndex,
+		table.Output.Index,
+		table.Output.RawData,
+		table.Output.Hash,
+		table.Output.OutputHashesSiblings,
+		table.Output.ExecutionTransactionHash,
+	).VALUES(
+		out.InputEpochApplicationID,
+		out.InputIndex,
+		out.Index,
+		out.RawData,
+		out.Hash,
+		out.OutputHashesSiblings,
+		out.ExecutionTransactionHash,
+	)
+
+	sqlStr, args := insertStmt.Sql()
+	_, err := r.db.Exec(ctx, sqlStr, args...)
+	return err
+}
+
+func (r *PostgresRepository) CreateReport(
+	ctx context.Context,
+	out *model.Report,
+) error {
+	insertStmt := table.Report.INSERT(
+		table.Report.InputEpochApplicationID,
+		table.Report.InputIndex,
+		table.Report.Index,
+		table.Report.RawData,
+	).VALUES(
+		out.InputEpochApplicationID,
+		out.InputIndex,
+		out.Index,
+		out.RawData,
+	)
+
+	sqlStr, args := insertStmt.Sql()
+	_, err := r.db.Exec(ctx, sqlStr, args...)
+	return err
+}
+

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -75,7 +75,6 @@ type ApplicationRepository interface {
 }
 
 type EpochRepository interface {
-	CreateEpoch(ctx context.Context, nameOrAddress string, e *Epoch) error
 	// FIXME move to BulkOperationsRepository
 	CreateEpochsAndInputs(ctx context.Context, nameOrAddress string, epochInputMap map[*Epoch][]*Input, blockNumber uint64) error
 
@@ -147,6 +146,13 @@ type ClaimerRepository interface {
 	) error
 }
 
+type TestRepository interface {
+	CreateEpoch(ctx context.Context, e *Epoch) error
+	CreateInput(ctx context.Context, inp *Input) error
+	CreateOutput(ctx context.Context, out *Output) error
+	CreateReport(ctx context.Context, report *Report) error
+}
+
 type Repository interface {
 	ApplicationRepository
 	EpochRepository
@@ -156,6 +162,7 @@ type Repository interface {
 	BulkOperationsRepository
 	NodeConfigRepository
 	ClaimerRepository
+	TestRepository
 	Close()
 }
 


### PR DESCRIPTION
Implementation of jsonrpc integration tests (using the test database). Brings coverage from 0 to 57.7%
it also checks that the implemented, discover and tested methods match.

```
coverage: 57.7% of statements
ok      github.com/cartesi/rollups-node/internal/jsonrpc        1.570s
```