### PR TITLE
fix(cli): handle the race condition between creating an application and setting the execution parameters

### DIFF
--- a/cmd/cartesi-rollups-cli/root/app/register/register.go
+++ b/cmd/cartesi-rollups-cli/root/app/register/register.go
@@ -154,22 +154,6 @@ func run(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	executionParameters := model.ExecutionParameters{}
-	if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
-		filePath := executionParametersFileParam
-		if executionParametersFileParam == "-" {
-			filePath = os.Stdin.Name()
-		}
-		contents, err := os.ReadFile(filePath)
-		cobra.CheckErr(err)
-
-		decoder := json.NewDecoder(strings.NewReader(string(contents)))
-		decoder.DisallowUnknownFields() // Prevent unexpected fields
-		err = decoder.Decode(&executionParameters)
-		cobra.CheckErr(err)
-		cobra.CheckErr(executionParameters.Validate())
-	}
-
 	var consensus common.Address
 	if cmd.Flags().Changed("consensus") {
 		consensus = common.HexToAddress(consensusAddress)
@@ -232,21 +216,25 @@ func run(cmd *cobra.Command, args []string) {
 		LastOutputCheckBlock: 0,
 	}
 
-	_, err = repo.CreateApplication(ctx, &application)
-	cobra.CheckErr(err)
-
-	if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
-		retrievedApplication, err := repo.GetApplication(ctx, validName)
-		if err != nil {
-			cobra.CheckErr(fmt.Errorf("failed to retrieve application from the database: %w", err))
+	// load execution parameters from a file?
+	withExecutionParameters := cmd.Flags().Changed("execution-parameters-file")
+	if withExecutionParameters {
+		filePath := executionParametersFileParam
+		if executionParametersFileParam == "-" {
+			filePath = os.Stdin.Name()
 		}
+		contents, err := os.ReadFile(filePath)
+		cobra.CheckErr(err)
 
-		executionParameters.ApplicationID = retrievedApplication.ID
-		err = repo.UpdateExecutionParameters(ctx, &executionParameters)
-		if err != nil {
-			cobra.CheckErr(fmt.Errorf("failed to update execution parameters: %w", err))
-		}
+		decoder := json.NewDecoder(strings.NewReader(string(contents)))
+		decoder.DisallowUnknownFields() // Prevent unexpected fields
+		err = decoder.Decode(&application.ExecutionParameters)
+		cobra.CheckErr(err)
+		cobra.CheckErr(application.ExecutionParameters.Validate())
 	}
+
+	_, err = repo.CreateApplication(ctx, &application, withExecutionParameters)
+	cobra.CheckErr(err)
 
 	if printAsJSON {
 		jsonData, err := json.Marshal(application)

--- a/cmd/cartesi-rollups-cli/root/deploy/application.go
+++ b/cmd/cartesi-rollups-cli/root/deploy/application.go
@@ -159,8 +159,6 @@ func runDeployApplication(cmd *cobra.Command, args []string) {
 	}
 
 	application := model.Application{}
-	executionParameters := model.ExecutionParameters{}
-
 	application.Name = applicationName
 	application.TemplateURI = templateURI
 	application.State = model.ApplicationState_Disabled
@@ -168,7 +166,9 @@ func runDeployApplication(cmd *cobra.Command, args []string) {
 		application.State = model.ApplicationState_Enabled
 	}
 
-	if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
+	// load execution parameters from a file?
+	withExecutionParameters := cmd.Flags().Changed("execution-parameters-file")
+	if withExecutionParameters {
 		filePath := executionParametersFileParam
 		if executionParametersFileParam == "-" {
 			filePath = os.Stdin.Name()
@@ -178,9 +178,9 @@ func runDeployApplication(cmd *cobra.Command, args []string) {
 
 		decoder := json.NewDecoder(strings.NewReader(string(contents)))
 		decoder.DisallowUnknownFields() // Prevent unexpected fields
-		err = decoder.Decode(&executionParameters)
+		err = decoder.Decode(&application.ExecutionParameters)
 		cobra.CheckErr(err)
-		cobra.CheckErr(executionParameters.Validate())
+		cobra.CheckErr(application.ExecutionParameters.Validate())
 
 		if verboseParam {
 			fmt.Fprintln(os.Stderr, "loading execution parameters...success")
@@ -254,35 +254,23 @@ func runDeployApplication(cmd *cobra.Command, args []string) {
 		}
 		defer repo.Close()
 
-		_, err = repo.CreateApplication(ctx, &application)
+		_, err = repo.CreateApplication(ctx, &application, withExecutionParameters)
 		if err != nil {
 			cobra.CheckErr(fmt.Errorf("failed to register application: %w", err))
 		}
-
-		// retrieve fields initialized by the database
-		retrievedApplication, err := repo.GetApplication(ctx, applicationName)
 		if verboseParam || !asJsonParam {
-			if err != nil {
-				fmt.Fprint(os.Stderr, "success, but failed to retrieve the database initialized fields. Will display them as placeholders.\n")
-			} else {
-				application = *retrievedApplication
-				fmt.Fprint(os.Stderr, "success\n")
-			}
-		}
-		if changed := cmd.Flags().Changed("execution-parameters-file"); changed {
-			executionParameters.ApplicationID = application.ID
-			err = repo.UpdateExecutionParameters(ctx, &executionParameters)
-			if err != nil {
-				cobra.CheckErr(fmt.Errorf("failed to update execution parameters: %w", err))
-			}
+			fmt.Fprint(os.Stderr, "success\n")
 		}
 
 		if verboseParam || !asJsonParam {
 			if applicationName != "" || verboseParam {
-				fmt.Fprintln(os.Stderr, "\tapplication name:     ", applicationName)
+				fmt.Fprintln(os.Stderr, "\tapplication name:          ", applicationName)
 			}
 			if templateURI != "" || verboseParam {
-				fmt.Fprintln(os.Stderr, "\tapplication path:     ", templateURI)
+				fmt.Fprintln(os.Stderr, "\tapplication path:          ", templateURI)
+			}
+			if withExecutionParameters {
+				fmt.Fprintln(os.Stderr, "\texecution parameters file: ", executionParametersFileParam)
 			}
 		}
 	} else if verboseParam {

--- a/internal/repository/postgres/application.go
+++ b/internal/repository/postgres/application.go
@@ -21,6 +21,7 @@ import (
 func (r *PostgresRepository) CreateApplication(
 	ctx context.Context,
 	app *model.Application,
+	withExecutionParameters bool,
 ) (int64, error) {
 
 	insertStmt := table.Application.
@@ -68,13 +69,49 @@ func (r *PostgresRepository) CreateApplication(
 		return 0, errors.Join(fmt.Errorf("unable to create database application: %w", err), tx.Rollback(ctx))
 	}
 
-	sqlStr, args = table.ExecutionParameters.
-		INSERT(
-			table.ExecutionParameters.ApplicationID,
-		).
-		VALUES(
-			newID,
-		).Sql()
+	if !withExecutionParameters {
+		sqlStr, args = table.ExecutionParameters.
+			INSERT(
+				table.ExecutionParameters.ApplicationID,
+			).
+			VALUES(
+				newID,
+			).Sql()
+	} else {
+		sqlStr, args = table.ExecutionParameters.
+			INSERT(
+				table.ExecutionParameters.ApplicationID,
+				table.ExecutionParameters.SnapshotPolicy,
+				table.ExecutionParameters.AdvanceIncCycles,
+				table.ExecutionParameters.AdvanceMaxCycles,
+				table.ExecutionParameters.InspectIncCycles,
+				table.ExecutionParameters.InspectMaxCycles,
+				table.ExecutionParameters.AdvanceIncDeadline,
+				table.ExecutionParameters.AdvanceMaxDeadline,
+				table.ExecutionParameters.InspectIncDeadline,
+				table.ExecutionParameters.InspectMaxDeadline,
+				table.ExecutionParameters.LoadDeadline,
+				table.ExecutionParameters.StoreDeadline,
+				table.ExecutionParameters.FastDeadline,
+				table.ExecutionParameters.MaxConcurrentInspects,
+			).
+			VALUES(
+				newID,
+				app.ExecutionParameters.SnapshotPolicy,
+				app.ExecutionParameters.AdvanceIncCycles,
+				app.ExecutionParameters.AdvanceMaxCycles,
+				app.ExecutionParameters.InspectIncCycles,
+				app.ExecutionParameters.InspectMaxCycles,
+				app.ExecutionParameters.AdvanceIncDeadline,
+				app.ExecutionParameters.AdvanceMaxDeadline,
+				app.ExecutionParameters.InspectIncDeadline,
+				app.ExecutionParameters.InspectMaxDeadline,
+				app.ExecutionParameters.LoadDeadline,
+				app.ExecutionParameters.StoreDeadline,
+				app.ExecutionParameters.FastDeadline,
+				app.ExecutionParameters.MaxConcurrentInspects,
+			).Sql()
+	}
 
 	_, err = tx.Exec(ctx, sqlStr, args...)
 	if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -58,7 +58,7 @@ type ReportFilter struct {
 }
 
 type ApplicationRepository interface {
-	CreateApplication(ctx context.Context, app *Application) (int64, error)
+	CreateApplication(ctx context.Context, app *Application, withExecutionParameters bool) (int64, error)
 	GetApplication(ctx context.Context, nameOrAddress string) (*Application, error)
 	GetProcessedInputs(ctx context.Context, nameOrAddress string) (uint64, error)
 	UpdateApplication(ctx context.Context, app *Application) error

--- a/test/validator/validator_test.go
+++ b/test/validator/validator_test.go
@@ -92,7 +92,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPristineClaim() {
 			EpochLength:         10,
 			State:               model.ApplicationState_Enabled,
 		}
-		_, err := s.repository.CreateApplication(s.ctx, app)
+		_, err := s.repository.CreateApplication(s.ctx, app, false)
 		s.Require().Nil(err)
 
 		epoch := model.Epoch{
@@ -158,7 +158,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPreviousClaim() {
 			EpochLength:         10,
 			State:               model.ApplicationState_Enabled,
 		}
-		_, err := s.repository.CreateApplication(s.ctx, app)
+		_, err := s.repository.CreateApplication(s.ctx, app, false)
 		s.Require().Nil(err)
 
 		// insert the first epoch with a claim
@@ -261,7 +261,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 			EpochLength:         10,
 			State:               model.ApplicationState_Enabled,
 		}
-		_, err := s.repository.CreateApplication(s.ctx, app)
+		_, err := s.repository.CreateApplication(s.ctx, app, false)
 		s.Require().Nil(err)
 
 		epoch := model.Epoch{
@@ -348,7 +348,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 			EpochLength:         10,
 			State:               model.ApplicationState_Enabled,
 		}
-		_, err := s.repository.CreateApplication(s.ctx, app)
+		_, err := s.repository.CreateApplication(s.ctx, app, false)
 		s.Require().Nil(err)
 
 		firstEpoch := model.Epoch{


### PR DESCRIPTION
Handle a race condition when:
 - the node is running
 - an application gets deployed `enabled` with custom `execution parameters`