### PR TITLE
chore: wrap address book loading errors with %w

### DIFF
--- a/pkg/addresses/addresses.go
+++ b/pkg/addresses/addresses.go
@@ -56,12 +56,12 @@ func GetTestBook() *Book {
 func GetBookFromFile(path string) (*Book, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read address book file: %v", err)
+		return nil, fmt.Errorf("read address book file: %w", err)
 	}
 	var book Book
 	err = json.Unmarshal(data, &book)
 	if err != nil {
-		return nil, fmt.Errorf("parse address book json: %v", err)
+		return nil, fmt.Errorf("parse address book json: %w", err)
 	}
 	return &book, nil
 }


### PR DESCRIPTION
Use Go 1.13+ error wrapping (%w) instead of %v when returning errors from address book loading functions. This preserves the original error and allows callers to use errors.Is / errors.As if needed