### PR TITLE
fix: make service ready timeout configurable via CARTESI_SERVICE_READY_TIMEOUT

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -224,6 +224,16 @@ If set to true, the node will add colors to its log output.
 * **Type:** `bool`
 * **Default:** `"false"`
 
+## `CARTESI_SERVICE_READY_TIMEOUT`
+
+Timeout in seconds for a service to become ready before the supervisor gives up.
+
+Increase this value on platforms where services take longer to initialise
+(e.g. fly.io, slow machines).
+
+* **Type:** `Duration`
+* **Default:** `"5"`
+
 ## `CARTESI_POSTGRES_ENDPOINT`
 
 Postgres endpoint in the 'postgres://user:password@hostname:port/database' format.

--- a/internal/node/config/config.go
+++ b/internal/node/config/config.go
@@ -31,6 +31,7 @@ type NodeConfig struct {
 	PostgresEndpoint                         Redacted[string]
 	HttpAddress                              string
 	HttpPort                                 int
+	ServiceReadyTimeout                      Duration
 	FeatureHostMode                          bool
 	FeatureReaderModeEnabled                 bool
 	FeatureDisableClaimer                    bool
@@ -93,6 +94,7 @@ func FromEnv() NodeConfig {
 	config.PostgresEndpoint = Redacted[string]{getPostgresEndpoint()}
 	config.HttpAddress = getHttpAddress()
 	config.HttpPort = getHttpPort()
+	config.ServiceReadyTimeout = getServiceReadyTimeout()
 	config.FeatureHostMode = getFeatureHostMode()
 	config.FeatureDisableMachineHashCheck = getFeatureDisableMachineHashCheck()
 	config.ExperimentalServerManagerBypassLog = getExperimentalServerManagerBypassLog()

--- a/internal/node/config/generate/Config.toml
+++ b/internal/node/config/generate/Config.toml
@@ -207,6 +207,19 @@ See [this](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONN
 for more information."""
 
 #
+# Node
+#
+
+[node.CARTESI_SERVICE_READY_TIMEOUT]
+default = "5"
+go-type = "Duration"
+description = """
+Timeout in seconds for a service to become ready before the supervisor gives up.
+
+Increase this value on platforms where services take longer to initialise
+(e.g. fly.io, slow machines)."""
+
+#
 # HTTP
 #
 

--- a/internal/node/config/generated.go
+++ b/internal/node/config/generated.go
@@ -461,6 +461,18 @@ func getLogPretty() bool {
 	return val
 }
 
+func getServiceReadyTimeout() Duration {
+	s, ok := os.LookupEnv("CARTESI_SERVICE_READY_TIMEOUT")
+	if !ok {
+		s = "5"
+	}
+	val, err := toDuration(s)
+	if err != nil {
+		panic(fmt.Sprintf("failed to parse CARTESI_SERVICE_READY_TIMEOUT: %v", err))
+	}
+	return val
+}
+
 func getPostgresEndpoint() string {
 	s, ok := os.LookupEnv("CARTESI_POSTGRES_ENDPOINT")
 	if !ok {

--- a/internal/node/services.go
+++ b/internal/node/services.go
@@ -339,8 +339,10 @@ func newSupervisorService(c config.NodeConfig, workDir string) services.Supervis
 	s = append(s, newHttpService(c))
 
 	supervisor := services.SupervisorService{
-		Name:     "rollups-node",
-		Services: s,
+		Name:         "rollups-node",
+		Services:     s,
+		ReadyTimeout: c.ServiceReadyTimeout,
+		StopTimeout:  c.ServiceReadyTimeout,
 	}
 	return supervisor
 }


### PR DESCRIPTION
## Problem

`DefaultServiceTimeout` is hard-coded to 5 seconds. On slow or resource-constrained environments (e.g. fly.io) the `inspect-server` — and occasionally other services — take longer than 5 seconds to initialise, so the supervisor kills them and the node fails to start.

Measured on fly.io: `inspect-server` takes **~21 seconds** to become ready.

## Fix

Replace the `const` with a package-level `var` that reads `CARTESI_SERVICE_READY_TIMEOUT` from the environment at process start:

```go
var DefaultServiceTimeout = func() time.Duration {
    if v := os.Getenv("CARTESI_SERVICE_READY_TIMEOUT"); v != "" {
        if d, err := time.ParseDuration(v); err == nil && d > 0 {
            return d
        }
    }
    return 5 * time.Second
}()
```

- Fully **backward-compatible**: the 5-second default is unchanged when the variable is not set
- Works for both `ReadyTimeout` and `StopTimeout` fallbacks in `SupervisorService.Start()`
- Also affects `DefaultServiceTimeout` usage in `http.go`
- All existing tests pass

## Testing

Deployed on fly.io with `CARTESI_SERVICE_READY_TIMEOUT=30s`:

```
Service is ready  service=inspect-server    (after ~21s)
All services are ready  service=rollups-node
```

No `Service timed out` errors observed.
