### PR TITLE
feat(cli): add contract diagnostic tool for direct on-chain inspection

### DIFF
--- a/cmd/cartesi-rollups-cli/root/contract/app.go
+++ b/cmd/cartesi-rollups-cli/root/contract/app.go
@@ -1,0 +1,152 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/iapplication"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var appCmd = &cobra.Command{
+	Use:   "app <application-address>",
+	Short: "Query application contract state (IApplication)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runApp,
+}
+
+func runApp(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	result, err := cc.queryApp()
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+	printApp(result, cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}
+
+// queryApp reads all IApplication view functions and returns an AppResult.
+func (c *chainClient) queryApp() (*AppResult, error) {
+	if err := c.ensureContract(c.appAddr, "application"); err != nil {
+		return nil, err
+	}
+
+	app, err := iapplication.NewIApplicationCaller(c.appAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IApplication: %w", err)
+	}
+
+	templateHash, err := app.GetTemplateHash(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetTemplateHash: %w", err)
+	}
+
+	owner, err := app.Owner(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("owner: %w", err)
+	}
+
+	deploymentBlockRaw, err := app.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deploymentBlock, err := safeUint64(deploymentBlockRaw, "deployment block")
+	if err != nil {
+		return nil, err
+	}
+
+	executedOutputsRaw, err := app.GetNumberOfExecutedOutputs(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetNumberOfExecutedOutputs: %w", err)
+	}
+	executedOutputs, err := safeUint64(executedOutputsRaw, "executed outputs")
+	if err != nil {
+		return nil, err
+	}
+
+	consensusAddr, err := app.GetOutputsMerkleRootValidator(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetOutputsMerkleRootValidator: %w", err)
+	}
+
+	dataAvailability, err := app.GetDataAvailability(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDataAvailability: %w", err)
+	}
+
+	// Detect consensus type for display.
+	consensusLabel := consensusUnknown.String()
+	if err := c.ensureContract(consensusAddr, "consensus"); err == nil {
+		var detectErr error
+		var cType consensusType
+		var contractVersion string
+		cType, contractVersion, detectErr = c.detectConsensus(consensusAddr)
+		if detectErr != nil {
+			slog.Warn("failed to detect consensus type", "error", detectErr)
+		}
+		consensusLabel = cType.String()
+		if contractVersion != "" {
+			consensusLabel += fmt.Sprintf(" (IConsensus %s)", contractVersion)
+		}
+	}
+
+	return &AppResult{
+		Address:          formatAddr(c.appAddr),
+		Owner:            formatAddr(owner),
+		TemplateHash:     formatHash(templateHash),
+		DeploymentBlock:  deploymentBlock,
+		ExecutedOutputs:  executedOutputs,
+		ConsensusAddress: formatAddr(consensusAddr),
+		ConsensusType:    consensusLabel,
+		DataAvailability: "0x" + hex.EncodeToString(dataAvailability),
+	}, nil
+}
+
+func printApp(r *AppResult, blockNum, chainID, blockTime uint64) {
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Application  %s", r.Address), func() {
+		p.field("Template Hash", r.TemplateHash)
+		p.field("Owner", r.Owner)
+		p.field("Deployment Block", fmt.Sprintf("%d", r.DeploymentBlock))
+		p.field("Executed Outputs", fmt.Sprintf("%d", r.ExecutedOutputs))
+		p.field("Consensus", fmt.Sprintf("%s (%s)", r.ConsensusAddress, r.ConsensusType))
+		p.field("Data Availability", r.DataAvailability)
+	})
+	p.footer(blockNum, chainID, blockTime)
+}
+
+func outputJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+// getConsensusAddress is a helper that reads the consensus address from the app contract.
+func (c *chainClient) getConsensusAddress() (common.Address, error) {
+	app, err := iapplication.NewIApplicationCaller(c.appAddr, c.eth)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("bind IApplication: %w", err)
+	}
+	addr, err := app.GetOutputsMerkleRootValidator(c.callOpts)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("GetOutputsMerkleRootValidator: %w", err)
+	}
+	return addr, nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/commitment.go
+++ b/cmd/cartesi-rollups-cli/root/contract/commitment.go
@@ -1,0 +1,96 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/itournament"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var commitmentCmd = &cobra.Command{
+	Use:   "commitment <application-address> <commitment-hash>",
+	Short: "Read a commitment's on-chain state from the current tournament",
+	Args:  cobra.ExactArgs(2), //nolint:mnd
+	RunE:  runCommitment,
+}
+
+func runCommitment(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	if err := validateHash(args[1], "commitment hash"); err != nil {
+		return err
+	}
+	commitmentHash := common.HexToHash(args[1])
+
+	// Resolve tournament address using the same logic as the tournament subcommand.
+	res, err := cc.resolveTournamentAddress(args[:1]) // only pass app addr
+	if err != nil {
+		return fmt.Errorf("resolve tournament: %w", err)
+	}
+	tournamentAddr := res.addr
+
+	if err := cc.ensureContract(tournamentAddr, "tournament"); err != nil {
+		return err
+	}
+
+	caller, err := itournament.NewITournamentCaller(tournamentAddr, cc.eth)
+	if err != nil {
+		return fmt.Errorf("bind ITournament: %w", err)
+	}
+
+	commitment, err := caller.GetCommitment(cc.callOpts, [32]byte(commitmentHash))
+	if err != nil {
+		return fmt.Errorf("GetCommitment: %w", err)
+	}
+
+	levelConsts, err := caller.TournamentLevelConstants(cc.callOpts)
+	if err != nil {
+		return fmt.Errorf("TournamentLevelConstants: %w", err)
+	}
+
+	levelName := "root"
+	if levelConsts.Level == levelConsts.MaxLevel {
+		levelName = "leaf"
+	} else if levelConsts.Level > 0 {
+		levelName = "inner"
+	}
+
+	result := &CommitmentResult{
+		Commitment:       formatHash([32]byte(commitmentHash)),
+		Tournament:       formatAddr(tournamentAddr),
+		TournamentLevel:  fmt.Sprintf("%d/%d (%s)", levelConsts.Level, levelConsts.MaxLevel, levelName),
+		ClockAllowance:   commitment.Clock.Allowance,
+		ClockStartBlock:  commitment.Clock.StartInstant,
+		FinalMachineHash: formatHash(commitment.FinalState),
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Commitment  %s", result.Commitment), func() {
+		p.field("Tournament",
+			fmt.Sprintf("%s (level %s)", result.Tournament, result.TournamentLevel))
+		p.field("Clock Allowance",
+			fmt.Sprintf("%d blocks remaining", result.ClockAllowance))
+		if result.ClockStartBlock > 0 {
+			p.field("Clock Start", fmt.Sprintf("block %d", result.ClockStartBlock))
+		} else {
+			p.field("Clock Start", "not started")
+		}
+		p.field("Final Machine Hash", result.FinalMachineHash)
+	})
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/consensus.go
+++ b/cmd/cartesi-rollups-cli/root/contract/consensus.go
@@ -1,0 +1,145 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var consensusCmd = &cobra.Command{
+	Use:   "consensus <application-address>",
+	Short: "Query consensus contract state (auto-detects Authority/Quorum/DaveConsensus)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runConsensus,
+}
+
+func runConsensus(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	consensusAddr, err := cc.getConsensusAddress()
+	if err != nil {
+		return err
+	}
+
+	if err := cc.ensureContract(consensusAddr, "consensus"); err != nil {
+		return err
+	}
+
+	cType, contractVersion, err := cc.detectConsensus(consensusAddr)
+	if err != nil {
+		return err
+	}
+
+	switch cType {
+	case consensusAuthority:
+		return cc.printAuthority(consensusAddr, contractVersion)
+	case consensusQuorum:
+		return cc.printQuorum(consensusAddr)
+	case consensusDave:
+		return cc.printDave(consensusAddr)
+	case consensusUnknown:
+		return fmt.Errorf("unknown consensus type at %s", consensusAddr)
+	}
+	return fmt.Errorf("unknown consensus type at %s", consensusAddr)
+}
+
+func (c *chainClient) printAuthority(addr common.Address, contractVersion string) error {
+	result, err := c.queryAuthority(addr, contractVersion)
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Authority  %s", result.Address), func() {
+		p.field("Owner (Validator)", result.Owner)
+		p.field("Epoch Length", fmt.Sprintf("%d blocks", result.EpochLength))
+		p.field("Accepted Claims", fmt.Sprintf("%d", result.AcceptedClaims))
+		p.field("IConsensus Version", result.ContractVersion)
+	})
+	p.footer(c.blockNum, c.chainID, c.resolveTimestamp(c.blockNum))
+	return nil
+}
+
+func (c *chainClient) printQuorum(addr common.Address) error {
+	result, err := c.queryQuorum(addr)
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Quorum  %s", result.Address), func() {
+		p.field("Validators", fmt.Sprintf("%d", result.NumValidators))
+		p.field("Quorum Threshold",
+			fmt.Sprintf("%d (computed: strict majority)", result.QuorumThreshold))
+		p.field("Epoch Length", fmt.Sprintf("%d blocks", result.EpochLength))
+		p.field("Accepted Claims", fmt.Sprintf("%d", result.AcceptedClaims))
+		for i, v := range result.Validators {
+			p.field(fmt.Sprintf("  Validator #%d", i+1), v)
+		}
+	})
+	p.footer(c.blockNum, c.chainID, c.resolveTimestamp(c.blockNum))
+	return nil
+}
+
+func (c *chainClient) printDave(addr common.Address) error {
+	result, err := c.queryDave(addr)
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("DaveConsensus  %s", result.Address), func() {
+		p.field("Deployment Block", fmt.Sprintf("%d", result.DeploymentBlock))
+		p.field("InputBox", result.InputBox)
+		p.field("Tournament Factory", result.Factory)
+		printTournamentFinished(p, result)
+		p.field("Current Sealed Epoch", fmt.Sprintf("%d", result.CurrentEpochNumber))
+		p.field("Input Range",
+			fmt.Sprintf("[%d, %d)", result.InputLowerBound, result.InputUpperBound))
+		p.field("Root Tournament", result.RootTournament)
+	})
+	p.footer(c.blockNum, c.chainID, c.resolveTimestamp(c.blockNum))
+	return nil
+}
+
+// printTournamentFinished renders the IsFinished field, distinguishing winner from no-winner.
+// Note: IsFinished means the tournament has concluded, NOT that settle() can be called
+// successfully — settle() will revert if there is no winner.
+func printTournamentFinished(p *printer, r *DaveConsensusResult) {
+	if !r.IsFinished {
+		p.field("Tournament Finished", "no")
+		return
+	}
+	if r.HasWinner != nil && !*r.HasWinner {
+		p.field("Tournament Finished", "yes (NO WINNER — all commitments eliminated)")
+		return
+	}
+	if r.WinnerCommitment != "" {
+		p.field("Tournament Finished",
+			fmt.Sprintf("yes (winner: %s)", r.WinnerCommitment))
+		return
+	}
+	p.field("Tournament Finished", "yes")
+}

--- a/cmd/cartesi-rollups-cli/root/contract/contract.go
+++ b/cmd/cartesi-rollups-cli/root/contract/contract.go
@@ -1,0 +1,387 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cartesi/rollups-node/internal/config"
+	"github.com/cartesi/rollups-node/pkg/contracts/idaveconsensus"
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/spf13/cobra"
+)
+
+var (
+	blockParam      string
+	jsonParam       bool
+	timeoutParam    string
+	timestampsParam bool
+)
+
+// Cmd is the parent `contract` cobra command.
+var Cmd = &cobra.Command{
+	Use:   "contract",
+	Short: "[Experimental] Read on-chain contract state directly via eth_call and eth_getLogs",
+	Long: `
+Read-only diagnostic tool that queries Cartesi Ethereum smart contracts directly.
+No database required — only an RPC endpoint and an application address.
+
+Experimental:
+This tool is experimental and may produce inaccurate results. Values are read
+directly from on-chain contracts and may not reflect finalized state. Verify
+critical information independently before acting on it.
+
+Supported Environment Variables:
+  CARTESI_BLOCKCHAIN_HTTP_ENDPOINT    Ethereum RPC endpoint URL
+  CARTESI_CONTRACTS_INPUT_BOX_ADDRESS InputBox contract address (optional override)`,
+	Run: runContract,
+}
+
+func init() {
+	Cmd.PersistentFlags().StringVar(&blockParam, "block", "latest",
+		"Query view functions at this block number (default: latest, pinned at startup)")
+	Cmd.PersistentFlags().BoolVar(&jsonParam, "json", false,
+		"Machine-readable JSON output")
+	Cmd.PersistentFlags().StringVar(&timeoutParam, "timeout", "30s",
+		"Context deadline for the entire command execution")
+	Cmd.PersistentFlags().BoolVar(&timestampsParam, "timestamps", false,
+		"Resolve block numbers to wall-clock times (extra RPC calls)")
+
+	// Unhide root persistent flags in the contract command's help.
+	origHelpFunc := Cmd.HelpFunc()
+	Cmd.SetHelpFunc(func(command *cobra.Command, args []string) {
+		if f := command.Flags().Lookup("blockchain-http-endpoint"); f != nil {
+			f.Hidden = false
+		}
+		if f := command.Flags().Lookup("inputbox"); f != nil {
+			f.Hidden = false
+		}
+		origHelpFunc(command, args)
+	})
+
+	Cmd.AddCommand(appCmd)
+	Cmd.AddCommand(consensusCmd)
+	Cmd.AddCommand(inputboxCmd)
+	Cmd.AddCommand(tournamentCmd)
+	Cmd.AddCommand(epochCmd)
+	Cmd.AddCommand(summaryCmd)
+	Cmd.AddCommand(outputCmd)
+	Cmd.AddCommand(commitmentCmd)
+	Cmd.AddCommand(matchCmd)
+}
+
+func runContract(cmd *cobra.Command, _ []string) {
+	err := cmd.Help()
+	cobra.CheckErr(err)
+}
+
+// consensusType represents the detected on-chain consensus mechanism.
+type consensusType int
+
+const (
+	consensusUnknown   consensusType = iota
+	consensusAuthority               // IAuthority (single validator, Ownable)
+	consensusQuorum                  // IQuorum (multi-validator, majority threshold)
+	consensusDave                    // IDaveConsensus (PRT)
+)
+
+func (t consensusType) String() string {
+	switch t {
+	case consensusAuthority:
+		return "Authority"
+	case consensusQuorum:
+		return "Quorum"
+	case consensusDave:
+		return "DaveConsensus (PRT)"
+	case consensusUnknown:
+		return "Unknown"
+	}
+	return "Unknown"
+}
+
+// ERC-165 interface IDs for consensus type detection.
+// Solidity's type(I).interfaceId XORs only functions DEFINED in I, excluding inherited ones.
+var (
+	// IDataProvider: provideMerkleRootOfInput(uint256,bytes)
+	iDataProviderInterfaceID = [4]byte{0x7a, 0x96, 0xf4, 0x80}
+	// IConsensus interface IDs by version (own functions only, excluding inherited
+	// isOutputsMerkleRootValid). Checked in order; first match wins.
+	// v2.2.0: submitClaim ^ getEpochLength ^ getNumberOfAcceptedClaims ^ getNumberOfSubmittedClaims
+	iConsensusInterfaceIDv220 = [4]byte{0x90, 0xb2, 0xf3, 0x46}
+	// v2.1.x: submitClaim ^ getEpochLength ^ getNumberOfAcceptedClaims (no getNumberOfSubmittedClaims)
+	iConsensusInterfaceIDv21x = [4]byte{0x7e, 0xec, 0xfc, 0xec}
+	// IQuorum: own 7 functions (excluding inherited IConsensus). Same across versions.
+	iQuorumInterfaceID = [4]byte{0x3c, 0x92, 0x5a, 0x62}
+)
+
+// chainClient holds the shared Ethereum client and call options for all subcommands.
+// All view functions are called through this client to ensure consistent block-number
+// queries. The block number is ALWAYS pinned to a concrete value (never nil/latest).
+type chainClient struct {
+	eth      *ethclient.Client
+	callOpts *bind.CallOpts
+	filter   ethutil.Filter
+	appAddr  common.Address
+	chainID  uint64
+	blockNum uint64
+
+	// tsCache caches block number → timestamp lookups for --timestamps.
+	tsMu    sync.RWMutex
+	tsCache map[uint64]uint64
+}
+
+func newChainClient(
+	ctx context.Context,
+	endpoint string,
+	appAddr common.Address,
+	block *big.Int,
+) (*chainClient, error) {
+	client, err := ethclient.DialContext(ctx, endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("connect to RPC endpoint: %w", err)
+	}
+	success := false
+	defer func() {
+		if !success {
+			client.Close()
+		}
+	}()
+
+	chainIDRaw, err := client.ChainID(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get chain ID: %w", err)
+	}
+	chainID, err := safeUint64(chainIDRaw, "chain ID")
+	if err != nil {
+		return nil, err
+	}
+
+	var blockNum uint64
+	if block != nil && block.Sign() >= 0 {
+		blockNum, err = safeUint64(block, "block number")
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		// block is nil ("latest") or negative ("safe", "finalized").
+		// Resolve to a concrete block number via the RPC.
+		header, hErr := client.HeaderByNumber(ctx, block)
+		if hErr != nil {
+			return nil, fmt.Errorf("resolve block tag: %w", hErr)
+		}
+		blockNum = header.Number.Uint64()
+	}
+	pinnedBlock := new(big.Int).SetUint64(blockNum)
+
+	success = true
+	return &chainClient{
+		eth: client,
+		callOpts: &bind.CallOpts{
+			Context:     ctx,
+			BlockNumber: pinnedBlock,
+		},
+		filter: ethutil.Filter{
+			MinChunkSize: new(big.Int).Set(ethutil.DefaultMinChunkSize),
+			Logger:       slog.Default(),
+		},
+		appAddr:  appAddr,
+		chainID:  chainID,
+		blockNum: blockNum,
+		tsCache:  make(map[uint64]uint64),
+	}, nil
+}
+
+// resolveTimestamp returns the timestamp for a block number, using a cache.
+// Returns 0 if --timestamps is not enabled or the lookup fails.
+func (c *chainClient) resolveTimestamp(blockNum uint64) uint64 {
+	if !timestampsParam {
+		return 0
+	}
+	// Check cache under read lock first to avoid holding the write lock
+	// during a blocking RPC call.
+	c.tsMu.RLock()
+	if ts, ok := c.tsCache[blockNum]; ok {
+		c.tsMu.RUnlock()
+		return ts
+	}
+	c.tsMu.RUnlock()
+
+	header, err := c.eth.HeaderByNumber(
+		c.callOpts.Context, new(big.Int).SetUint64(blockNum))
+	if err != nil {
+		slog.Warn("failed to resolve timestamp", "block", blockNum, "error", err)
+		return 0
+	}
+
+	c.tsMu.Lock()
+	c.tsCache[blockNum] = header.Time
+	c.tsMu.Unlock()
+	return header.Time
+}
+
+// ensureContract verifies the address has deployed code at the pinned block.
+func (c *chainClient) ensureContract(addr common.Address, label string) error {
+	code, err := c.eth.CodeAt(c.callOpts.Context, addr, c.callOpts.BlockNumber)
+	if err != nil {
+		return fmt.Errorf("check contract code at %s: %w", addr, err)
+	}
+	if len(code) == 0 {
+		return fmt.Errorf(
+			"no contract deployed at %s (%s) — wrong address or wrong chain?",
+			addr, label)
+	}
+	return nil
+}
+
+// iConsensusVersion pairs an ERC-165 interface ID with a human-readable contract version label.
+type iConsensusVersion struct {
+	id      [4]byte
+	version string
+}
+
+var iConsensusVersions = []iConsensusVersion{
+	{iConsensusInterfaceIDv220, "v2.2.0"},
+	{iConsensusInterfaceIDv21x, "v2.1.x"},
+}
+
+// detectConsensus uses ERC-165 supportsInterface to determine the consensus type.
+// Checks IDataProvider → Dave, IQuorum → Quorum, IConsensus → Authority.
+// The returned contractVersion is non-empty only for Authority/Quorum, indicating which
+// IConsensus interface version was matched.
+func (c *chainClient) detectConsensus(
+	consensusAddr common.Address,
+) (consensusType, string, error) {
+	caller, err := idaveconsensus.NewIDaveConsensusCaller(consensusAddr, c.eth)
+	if err != nil {
+		return consensusUnknown, "", fmt.Errorf("bind consensus contract: %w", err)
+	}
+
+	isDave, err := caller.SupportsInterface(c.callOpts, iDataProviderInterfaceID)
+	if err != nil {
+		return consensusUnknown, "", fmt.Errorf("supportsInterface(IDataProvider): %w", err)
+	}
+	if isDave {
+		return consensusDave, "", nil
+	}
+
+	isQuorum, err := caller.SupportsInterface(c.callOpts, iQuorumInterfaceID)
+	if err != nil {
+		return consensusUnknown, "", fmt.Errorf("supportsInterface(IQuorum): %w", err)
+	}
+	if isQuorum {
+		return consensusQuorum, "", nil
+	}
+
+	for _, cv := range iConsensusVersions {
+		isConsensus, err := caller.SupportsInterface(c.callOpts, cv.id)
+		if err != nil {
+			return consensusUnknown, "", fmt.Errorf("supportsInterface(IConsensus): %w", err)
+		}
+		if isConsensus {
+			return consensusAuthority, cv.version, nil
+		}
+	}
+
+	return consensusUnknown, "", fmt.Errorf(
+		"consensus at %s does not implement IDataProvider, IQuorum, or IConsensus"+
+			" — wrong address or unsupported consensus type", consensusAddr)
+}
+
+// safeUint64 converts a *big.Int to uint64, returning an error if the value is nil or overflows.
+func safeUint64(v *big.Int, field string) (uint64, error) {
+	if v == nil {
+		return 0, fmt.Errorf("%s: nil value", field)
+	}
+	if !v.IsUint64() {
+		return 0, fmt.Errorf("%s value %s exceeds uint64 range", field, v.String())
+	}
+	return v.Uint64(), nil
+}
+
+// parseBlockFlag parses the --block flag value into a *big.Int.
+// Returns nil for "latest". Returns negative big.Int for named tags
+// ("safe", "finalized") using go-ethereum's rpc.BlockNumber constants.
+// The caller resolves all non-positive values to a concrete block number.
+func parseBlockFlag(s string) (*big.Int, error) {
+	switch s {
+	case "", "latest":
+		return nil, nil
+	case "safe":
+		return big.NewInt(int64(rpc.SafeBlockNumber)), nil
+	case "finalized":
+		return big.NewInt(int64(rpc.FinalizedBlockNumber)), nil
+	}
+	n, ok := new(big.Int).SetString(s, 0)
+	if !ok || n.Sign() < 0 {
+		return nil, fmt.Errorf("invalid block number: %q (use a number, \"latest\", \"safe\", or \"finalized\")", s)
+	}
+	return n, nil
+}
+
+// validateHash checks that s is a valid 32-byte hex hash (with or without 0x prefix).
+func validateHash(s, label string) error {
+	h := strings.TrimPrefix(s, "0x")
+	if len(h) != 64 { //nolint:mnd
+		return fmt.Errorf("invalid %s: expected 32-byte hex (66 chars with 0x prefix), got %q", label, s)
+	}
+	if _, err := hex.DecodeString(h); err != nil {
+		return fmt.Errorf("invalid %s: %w", label, err)
+	}
+	return nil
+}
+
+// initChainClient creates a chainClient from the command flags and arguments.
+func initChainClient(cmd *cobra.Command, args []string) (*chainClient, context.CancelFunc, error) {
+	if len(args) < 1 {
+		return nil, nil, fmt.Errorf("application address argument is required")
+	}
+
+	appAddrStr := args[0]
+	if !common.IsHexAddress(appAddrStr) {
+		return nil, nil, fmt.Errorf("invalid application address: %q", appAddrStr)
+	}
+	appAddr := common.HexToAddress(appAddrStr)
+
+	ethEndpoint, err := config.GetBlockchainHttpEndpoint()
+	if err != nil {
+		return nil, nil, fmt.Errorf("blockchain endpoint: %w", err)
+	}
+
+	block, err := parseBlockFlag(blockParam)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	ctx := cmd.Context()
+
+	var cancel context.CancelFunc
+	if timeoutParam != "" {
+		dur, parseErr := time.ParseDuration(timeoutParam)
+		if parseErr != nil {
+			return nil, nil, fmt.Errorf("invalid timeout: %w", parseErr)
+		}
+		ctx, cancel = context.WithTimeout(ctx, dur)
+	} else {
+		cancel = func() {}
+	}
+
+	cc, err := newChainClient(ctx, ethEndpoint.Raw(), appAddr, block)
+	if err != nil {
+		cancel()
+		return nil, nil, err
+	}
+
+	return cc, cancel, nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/contract_test.go
+++ b/cmd/cartesi-rollups-cli/root/contract/contract_test.go
@@ -1,0 +1,170 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"math"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeUint64(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   *big.Int
+		field   string
+		want    uint64
+		wantErr bool
+	}{
+		{
+			name:  "zero",
+			value: big.NewInt(0),
+			field: "test",
+			want:  0,
+		},
+		{
+			name:  "normal value",
+			value: big.NewInt(12345),
+			field: "block",
+			want:  12345,
+		},
+		{
+			name:  "max uint64",
+			value: new(big.Int).SetUint64(math.MaxUint64),
+			field: "max",
+			want:  math.MaxUint64,
+		},
+		{
+			name:    "overflow",
+			value:   new(big.Int).Add(new(big.Int).SetUint64(math.MaxUint64), big.NewInt(1)),
+			field:   "overflow",
+			wantErr: true,
+		},
+		{
+			name:    "negative",
+			value:   big.NewInt(-1),
+			field:   "negative",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := safeUint64(tt.value, tt.field)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.field)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestParseBlockFlag(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    *big.Int
+		wantErr bool
+	}{
+		{
+			name:  "empty string returns nil",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "latest returns nil",
+			input: "latest",
+			want:  nil,
+		},
+		{
+			name:  "decimal number",
+			input: "12345",
+			want:  big.NewInt(12345),
+		},
+		{
+			name:  "hex number",
+			input: "0xFF",
+			want:  big.NewInt(255),
+		},
+		{
+			name:  "zero",
+			input: "0",
+			want:  big.NewInt(0),
+		},
+		{
+			name:    "negative number",
+			input:   "-1",
+			wantErr: true,
+		},
+		{
+			name:    "invalid string",
+			input:   "abc",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBlockFlag(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if tt.want == nil {
+					assert.Nil(t, got)
+				} else {
+					require.NotNil(t, got)
+					assert.Equal(t, 0, tt.want.Cmp(got))
+				}
+			}
+		})
+	}
+}
+
+func TestSafeUint64Nil(t *testing.T) {
+	_, err := safeUint64(nil, "test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil")
+}
+
+func TestValidateHash(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid with prefix", "0x" + strings.Repeat("ab", 32), false},
+		{"valid uppercase", "0x" + strings.Repeat("AB", 32), false},
+		{"no prefix accepted", strings.Repeat("ab", 32), false},
+		{"too short", "0xabcd", true},
+		{"too long", "0x" + strings.Repeat("ab", 33), true},
+		{"invalid hex", "0x" + strings.Repeat("gg", 32), true},
+		{"empty", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateHash(tt.input, "test hash")
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConsensusTypeString(t *testing.T) {
+	assert.Equal(t, "Authority", consensusAuthority.String())
+	assert.Equal(t, "Quorum", consensusQuorum.String())
+	assert.Equal(t, "DaveConsensus (PRT)", consensusDave.String())
+	assert.Equal(t, "Unknown", consensusUnknown.String())
+}

--- a/cmd/cartesi-rollups-cli/root/contract/epoch.go
+++ b/cmd/cartesi-rollups-cli/root/contract/epoch.go
@@ -1,0 +1,676 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"os"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/iapplication"
+	"github.com/cartesi/rollups-node/pkg/contracts/iconsensus"
+	"github.com/cartesi/rollups-node/pkg/contracts/idaveconsensus"
+	"github.com/cartesi/rollups-node/pkg/contracts/iquorum"
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var (
+	epochFromBlock int64
+	epochToBlock   int64
+	epochLimitFlag int
+)
+
+var epochCmd = &cobra.Command{
+	Use:   "epoch <application-address>",
+	Short: "Show epoch history (claims, sealed epochs, events)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runEpoch,
+}
+
+func init() {
+	epochCmd.Flags().Int64Var(&epochFromBlock, "from-block", -1,
+		"Start block for event scan (default: deployment block)")
+	epochCmd.Flags().Int64Var(&epochToBlock, "to-block", -1,
+		"End block for event scan (default: pinned block)")
+	epochCmd.Flags().IntVar(&epochLimitFlag, "limit", 50, //nolint:mnd
+		"Maximum number of events to display")
+}
+
+func runEpoch(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	consensusAddr, err := cc.getConsensusAddress()
+	if err != nil {
+		return err
+	}
+
+	if err := cc.ensureContract(consensusAddr, "consensus"); err != nil {
+		return err
+	}
+
+	cType, _, err := cc.detectConsensus(consensusAddr)
+	if err != nil {
+		return err
+	}
+
+	var history *EpochHistory
+	switch cType {
+	case consensusDave:
+		history, err = cc.epochHistoryDave(consensusAddr)
+	case consensusAuthority:
+		history, err = cc.epochHistoryAuthority(consensusAddr)
+	case consensusQuorum:
+		history, err = cc.epochHistoryQuorum(consensusAddr)
+	case consensusUnknown:
+		return fmt.Errorf("unknown consensus type at %s", consensusAddr)
+	}
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(history)
+	}
+
+	cc.printEpochHistory(history)
+	return nil
+}
+
+// epochHistoryDave uses FindTransitions on GetCurrentSealedEpoch().EpochNumber
+// to discover EpochSealed events.
+func (c *chainClient) epochHistoryDave(consensusAddr common.Address) (*EpochHistory, error) {
+	daveCaller, err := idaveconsensus.NewIDaveConsensusCaller(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IDaveConsensus: %w", err)
+	}
+	daveFilterer, err := idaveconsensus.NewIDaveConsensusFilterer(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IDaveConsensus filterer: %w", err)
+	}
+
+	deployBlockRaw, err := daveCaller.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deployBlock, err := safeUint64(deployBlockRaw, "deployment block")
+	if err != nil {
+		return nil, err
+	}
+
+	// Get template hash for the machine hash chain.
+	appCaller, err := iapplication.NewIApplicationCaller(c.appAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IApplication: %w", err)
+	}
+	templateHash, err := appCaller.GetTemplateHash(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetTemplateHash: %w", err)
+	}
+
+	fromBlock, toBlock, err := c.resolveBlockRange(deployBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		sealed, sErr := daveCaller.GetCurrentSealedEpoch(opts)
+		if sErr != nil {
+			return nil, sErr
+		}
+		return sealed.EpochNumber, nil
+	}
+
+	var epochs []EpochEvent
+	limit := epochLimitFlag
+
+	onHit := func(block uint64) error {
+		if limit > 0 && len(epochs) >= limit {
+			return errLimitReached
+		}
+		q, qErr := buildEventFilterQuery(
+			consensusAddr, "EpochSealed",
+			idaveconsensus.IDaveConsensusMetaData, block, block,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		itr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, q)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range itr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := daveFilterer.ParseEpochSealed(*log)
+			if pErr != nil {
+				return pErr
+			}
+			epochNum, sErr := safeUint64(ev.EpochNumber, "epoch number")
+			if sErr != nil {
+				return sErr
+			}
+			inputLower, sErr := safeUint64(ev.InputIndexLowerBound, "input lower bound")
+			if sErr != nil {
+				return sErr
+			}
+			inputUpper, sErr := safeUint64(ev.InputIndexUpperBound, "input upper bound")
+			if sErr != nil {
+				return sErr
+			}
+
+			// Check if outputs root is valid on-chain.
+			var rootValid *bool
+			if rv, rvErr := daveCaller.IsOutputsMerkleRootValid(
+				c.callOpts, c.appAddr, ev.OutputsMerkleRoot); rvErr == nil {
+				rootValid = &rv
+			} else {
+				slog.Debug("IsOutputsMerkleRootValid failed", "error", rvErr)
+			}
+
+			epochs = append(epochs, EpochEvent{
+				EpochNumber:        epochNum,
+				BlockNumber:        log.BlockNumber,
+				TxHash:             log.TxHash.Hex(),
+				InputLowerBound:    inputLower,
+				InputUpperBound:    inputUpper,
+				InitialMachineHash: formatHash(ev.InitialMachineStateHash),
+				OutputsMerkleRoot:  formatHash(ev.OutputsMerkleRoot),
+				OutputsRootValid:   rootValid,
+				Tournament:         formatAddr(ev.Tournament),
+			})
+		}
+		return nil
+	}
+
+	// Use -1 as prevValue so the first sealed epoch (epoch 0) is detected as a
+	// transition from -1→0. Without this, epoch 0 would be invisible (0→0 = no change).
+	prevValue := big.NewInt(-1)
+	if fromBlock > deployBlock && fromBlock > 0 {
+		val, pErr := oracle(c.callOpts.Context, fromBlock-1)
+		if pErr != nil {
+			return nil, fmt.Errorf("get prevValue at block %d: %w", fromBlock-1, pErr)
+		}
+		prevValue = val
+	}
+
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, fromBlock, toBlock, prevValue, oracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errLimitReached) {
+		return nil, fmt.Errorf("find sealed epoch transitions: %w", err)
+	}
+
+	return &EpochHistory{
+		ConsensusType: "DaveConsensus",
+		TemplateHash:  formatHash(templateHash),
+		Epochs:        epochs,
+	}, nil
+}
+
+// epochHistoryAuthority uses FindTransitions on GetNumberOfAcceptedClaims
+// to discover ClaimSubmitted and ClaimAccepted events.
+func (c *chainClient) epochHistoryAuthority(
+	consensusAddr common.Address,
+) (*EpochHistory, error) {
+	consensusCaller, err := iconsensus.NewIConsensusCaller(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IConsensus: %w", err)
+	}
+	consensusFilterer, err := iconsensus.NewIConsensusFilterer(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IConsensus filterer: %w", err)
+	}
+
+	appCaller, err := iapplication.NewIApplicationCaller(c.appAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IApplication: %w", err)
+	}
+	deployBlockRaw, err := appCaller.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deployBlock, err := safeUint64(deployBlockRaw, "deployment block")
+	if err != nil {
+		return nil, err
+	}
+
+	fromBlock, toBlock, err := c.resolveBlockRange(deployBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		return consensusCaller.GetNumberOfAcceptedClaims(opts)
+	}
+
+	var claims []ClaimEvent
+	limit := epochLimitFlag
+
+	onHit := func(block uint64) error {
+		if limit > 0 && len(claims) >= limit {
+			return errLimitReached
+		}
+		// Filter by app address as indexed topic to avoid fetching events
+		// for other applications on shared consensus contracts.
+		appTopic := common.BytesToHash(c.appAddr.Bytes())
+
+		// Retrieve ClaimSubmitted events at this block.
+		// ClaimSubmitted has indexed topics (submitter, appContract).
+		// Use nil wildcard for topic1 (submitter) and appTopic for topic2 (appContract).
+		subQ, qErr := buildEventFilterQuery(
+			consensusAddr, "ClaimSubmitted",
+			iconsensus.IConsensusMetaData, block, block, nil, &appTopic,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		subItr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, subQ)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range subItr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := consensusFilterer.ParseClaimSubmitted(*log)
+			if pErr != nil {
+				return pErr
+			}
+			lastBlock, sErr := safeUint64(ev.LastProcessedBlockNumber, "last processed block")
+			if sErr != nil {
+				return sErr
+			}
+			claims = append(claims, ClaimEvent{
+				EventType:          "ClaimSubmitted",
+				BlockNumber:        log.BlockNumber,
+				TxHash:             log.TxHash.Hex(),
+				Submitter:          formatAddr(ev.Submitter),
+				LastProcessedBlock: lastBlock,
+				OutputsMerkleRoot:  formatHash(ev.OutputsMerkleRoot),
+			})
+		}
+
+		// Retrieve ClaimAccepted events at this block.
+		accQ, qErr := buildEventFilterQuery(
+			consensusAddr, "ClaimAccepted",
+			iconsensus.IConsensusMetaData, block, block, &appTopic,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		accItr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, accQ)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range accItr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := consensusFilterer.ParseClaimAccepted(*log)
+			if pErr != nil {
+				return pErr
+			}
+			lastBlock, sErr := safeUint64(ev.LastProcessedBlockNumber, "last processed block")
+			if sErr != nil {
+				return sErr
+			}
+
+			var rootValid *bool
+			if rv, rvErr := consensusCaller.IsOutputsMerkleRootValid(
+				c.callOpts, c.appAddr, ev.OutputsMerkleRoot); rvErr == nil {
+				rootValid = &rv
+			} else {
+				slog.Debug("IsOutputsMerkleRootValid failed", "error", rvErr)
+			}
+
+			ce := ClaimEvent{
+				EventType:          "ClaimAccepted",
+				BlockNumber:        log.BlockNumber,
+				TxHash:             log.TxHash.Hex(),
+				LastProcessedBlock: lastBlock,
+				OutputsMerkleRoot:  formatHash(ev.OutputsMerkleRoot),
+				OutputsRootValid:   rootValid,
+			}
+			claims = append(claims, ce)
+		}
+		return nil
+	}
+
+	prevValue := big.NewInt(0)
+	if fromBlock > deployBlock && fromBlock > 0 {
+		val, pErr := oracle(c.callOpts.Context, fromBlock-1)
+		if pErr != nil {
+			return nil, fmt.Errorf("get prevValue at block %d: %w", fromBlock-1, pErr)
+		}
+		prevValue = val
+	}
+
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, fromBlock, toBlock, prevValue, oracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errLimitReached) {
+		return nil, fmt.Errorf("find claim transitions: %w", err)
+	}
+
+	return &EpochHistory{
+		ConsensusType: "Authority",
+		Claims:        claims,
+	}, nil
+}
+
+// epochHistoryQuorum uses two-pass: FindTransitions for ClaimAccepted,
+// then ChunkedFilterLogs for ClaimSubmitted over the full range.
+func (c *chainClient) epochHistoryQuorum(
+	consensusAddr common.Address,
+) (*EpochHistory, error) {
+	consensusCaller, err := iconsensus.NewIConsensusCaller(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IConsensus: %w", err)
+	}
+	consensusFilterer, err := iconsensus.NewIConsensusFilterer(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IConsensus filterer: %w", err)
+	}
+	quorumCaller, err := iquorum.NewIQuorumCaller(consensusAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IQuorum: %w", err)
+	}
+
+	appCaller, err := iapplication.NewIApplicationCaller(c.appAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IApplication: %w", err)
+	}
+	deployBlockRaw, err := appCaller.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deployBlock, err := safeUint64(deployBlockRaw, "deployment block")
+	if err != nil {
+		return nil, err
+	}
+
+	numValRaw, err := quorumCaller.NumOfValidators(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("NumOfValidators: %w", err)
+	}
+	numVal, err := safeUint64(numValRaw, "num validators")
+	if err != nil {
+		return nil, err
+	}
+	threshold := 1 + numVal/2 //nolint:mnd
+
+	fromBlock, toBlock, err := c.resolveBlockRange(deployBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	var claims []ClaimEvent
+	limit := epochLimitFlag
+
+	// Pass 1: FindTransitions for ClaimAccepted.
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		return consensusCaller.GetNumberOfAcceptedClaims(opts)
+	}
+
+	onHit := func(block uint64) error {
+		if limit > 0 && len(claims) >= limit {
+			return errLimitReached
+		}
+		// Filter by app address as indexed topic to avoid fetching events
+		// for other applications on shared Quorum contracts.
+		appTopic := common.BytesToHash(c.appAddr.Bytes())
+		accQ, qErr := buildEventFilterQuery(
+			consensusAddr, "ClaimAccepted",
+			iconsensus.IConsensusMetaData, block, block, &appTopic,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		accItr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, accQ)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range accItr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := consensusFilterer.ParseClaimAccepted(*log)
+			if pErr != nil {
+				return pErr
+			}
+			if ev.AppContract != c.appAddr {
+				continue
+			}
+			lastBlock, sErr := safeUint64(ev.LastProcessedBlockNumber, "last processed block")
+			if sErr != nil {
+				return sErr
+			}
+			var rootValid *bool
+			if rv, rvErr := consensusCaller.IsOutputsMerkleRootValid(
+				c.callOpts, c.appAddr, ev.OutputsMerkleRoot); rvErr == nil {
+				rootValid = &rv
+			} else {
+				slog.Debug("IsOutputsMerkleRootValid failed", "error", rvErr)
+			}
+			claims = append(claims, ClaimEvent{
+				EventType:          "ClaimAccepted",
+				BlockNumber:        log.BlockNumber,
+				TxHash:             log.TxHash.Hex(),
+				LastProcessedBlock: lastBlock,
+				OutputsMerkleRoot:  formatHash(ev.OutputsMerkleRoot),
+				OutputsRootValid:   rootValid,
+			})
+		}
+		return nil
+	}
+
+	prevValue := big.NewInt(0)
+	if fromBlock > deployBlock && fromBlock > 0 {
+		val, pErr := oracle(c.callOpts.Context, fromBlock-1)
+		if pErr != nil {
+			return nil, fmt.Errorf("get prevValue at block %d: %w", fromBlock-1, pErr)
+		}
+		prevValue = val
+	}
+
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, fromBlock, toBlock, prevValue, oracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errLimitReached) {
+		return nil, fmt.Errorf("find claim accepted transitions: %w", err)
+	}
+
+	// Pass 2: ChunkedFilterLogs for ClaimSubmitted over full range.
+	// ClaimSubmitted has indexed topics (submitter, appContract).
+	// Use nil wildcard for topic1 (submitter) and appTopic for topic2 (appContract).
+	appTopic := common.BytesToHash(c.appAddr.Bytes())
+	subQ, err := buildEventFilterQuery(
+		consensusAddr, "ClaimSubmitted",
+		iconsensus.IConsensusMetaData, fromBlock, toBlock, nil, &appTopic,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("build ClaimSubmitted query: %w", err)
+	}
+	subItr, err := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, subQ)
+	if err != nil {
+		return nil, fmt.Errorf("filter ClaimSubmitted: %w", err)
+	}
+
+	var submissions []ClaimEvent
+	for log, logErr := range subItr {
+		if logErr != nil {
+			return nil, fmt.Errorf("iterate ClaimSubmitted: %w", logErr)
+		}
+		if limit > 0 && len(submissions) >= limit {
+			break
+		}
+		ev, pErr := consensusFilterer.ParseClaimSubmitted(*log)
+		if pErr != nil {
+			return nil, fmt.Errorf("parse ClaimSubmitted: %w", pErr)
+		}
+		lastBlock, sErr := safeUint64(ev.LastProcessedBlockNumber, "last processed block")
+		if sErr != nil {
+			return nil, sErr
+		}
+
+		// Get vote count for this specific claim.
+		votesRaw, vErr := quorumCaller.NumOfValidatorsInFavorOf(
+			c.callOpts, c.appAddr, ev.LastProcessedBlockNumber, ev.OutputsMerkleRoot)
+		var votes *uint64
+		if vErr == nil {
+			v, sErr := safeUint64(votesRaw, "votes")
+			if sErr == nil {
+				votes = &v
+			}
+		}
+
+		ce := ClaimEvent{
+			EventType:          "ClaimSubmitted",
+			BlockNumber:        log.BlockNumber,
+			TxHash:             log.TxHash.Hex(),
+			Submitter:          formatAddr(ev.Submitter),
+			LastProcessedBlock: lastBlock,
+			OutputsMerkleRoot:  formatHash(ev.OutputsMerkleRoot),
+			VotesForClaim:      votes,
+			VotesNeeded:        &threshold,
+		}
+		submissions = append(submissions, ce)
+	}
+
+	// Merge submissions and acceptances, sorted by block number.
+	allClaims := mergeClaimEvents(submissions, claims)
+
+	return &EpochHistory{
+		ConsensusType: "Quorum",
+		Claims:        allClaims,
+	}, nil
+}
+
+// mergeClaimEvents merges two sorted-by-block slices of ClaimEvents.
+func mergeClaimEvents(a, b []ClaimEvent) []ClaimEvent {
+	result := make([]ClaimEvent, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		if a[i].BlockNumber <= b[j].BlockNumber {
+			result = append(result, a[i])
+			i++
+		} else {
+			result = append(result, b[j])
+			j++
+		}
+	}
+	result = append(result, a[i:]...)
+	result = append(result, b[j:]...)
+	return result
+}
+
+// resolveBlockRange computes the from/to block range for event scanning.
+// Returns an error if --from-block or --to-block exceeds the pinned block, or from > to.
+func (c *chainClient) resolveBlockRange(deployBlock uint64) (uint64, uint64, error) {
+	from := deployBlock
+	if epochFromBlock >= 0 {
+		from = uint64(epochFromBlock)
+	}
+	to := c.blockNum
+	if epochToBlock >= 0 {
+		to = uint64(epochToBlock)
+	}
+	if from > c.blockNum {
+		return 0, 0, fmt.Errorf(
+			"--from-block %d exceeds pinned block %d", from, c.blockNum)
+	}
+	if to > c.blockNum {
+		return 0, 0, fmt.Errorf(
+			"--to-block %d exceeds pinned block %d", to, c.blockNum)
+	}
+	if from > to {
+		return 0, 0, fmt.Errorf(
+			"--from-block %d exceeds --to-block %d", from, to)
+	}
+	return from, to, nil
+}
+
+// printEpochHistory renders the epoch history as text.
+func (c *chainClient) printEpochHistory(h *EpochHistory) {
+	p := &printer{w: os.Stdout}
+
+	switch h.ConsensusType {
+	case "DaveConsensus":
+		c.printDaveEpochHistory(p, h)
+	case "Authority":
+		c.printClaimHistory(p, h, "Authority")
+	case "Quorum":
+		c.printClaimHistory(p, h, "Quorum")
+	}
+
+	p.footer(c.blockNum, c.chainID, c.resolveTimestamp(c.blockNum))
+}
+
+func (c *chainClient) printDaveEpochHistory(p *printer, h *EpochHistory) {
+	p.withSection(fmt.Sprintf("Epoch History  (DaveConsensus, %d epochs)", len(h.Epochs)), func() {
+		if h.TemplateHash != "" {
+			p.field("Template Hash", h.TemplateHash+" (epoch 0 initial state)")
+		}
+	})
+
+	for _, ep := range h.Epochs {
+		ts := formatBlockTime(c.resolveTimestamp(ep.BlockNumber))
+		p.withSection(
+			fmt.Sprintf("Epoch %d  (sealed at block %d%s, tx %s)",
+				ep.EpochNumber, ep.BlockNumber, ts, ep.TxHash), func() {
+				p.field("Input Range",
+					fmt.Sprintf("[%d, %d)", ep.InputLowerBound, ep.InputUpperBound))
+				p.field("Initial Machine Hash", ep.InitialMachineHash)
+				rootStatus := "unknown"
+				if ep.OutputsRootValid != nil {
+					rootStatus = "no"
+					if *ep.OutputsRootValid {
+						rootStatus = "yes"
+					}
+				}
+				p.field("Outputs Merkle Root",
+					fmt.Sprintf("%s (valid: %s)", ep.OutputsMerkleRoot, rootStatus))
+				p.field("Tournament", ep.Tournament)
+			})
+	}
+}
+
+func (c *chainClient) printClaimHistory(p *printer, h *EpochHistory, cType string) {
+	p.withSection(fmt.Sprintf("Epoch History  (%s, %d events)", cType, len(h.Claims)), func() {})
+
+	for _, cl := range h.Claims {
+		label := cl.EventType
+		ts := formatBlockTime(c.resolveTimestamp(cl.BlockNumber))
+		p.withSection(
+			fmt.Sprintf("%s at block %d%s  tx %s", label, cl.BlockNumber, ts, cl.TxHash), func() {
+				if cl.Submitter != "" {
+					p.field("Submitter", cl.Submitter)
+				}
+				p.field("Last Processed Block", fmt.Sprintf("%d", cl.LastProcessedBlock))
+				p.field("Outputs Merkle Root", cl.OutputsMerkleRoot)
+				if cl.OutputsRootValid != nil {
+					p.field("Root Valid on-chain", fmt.Sprintf("%t", *cl.OutputsRootValid))
+				}
+				if cl.VotesForClaim != nil && cl.VotesNeeded != nil {
+					p.field("Votes",
+						fmt.Sprintf("%d / %d needed", *cl.VotesForClaim, *cl.VotesNeeded))
+				}
+			})
+	}
+}

--- a/cmd/cartesi-rollups-cli/root/contract/epoch_test.go
+++ b/cmd/cartesi-rollups-cli/root/contract/epoch_test.go
@@ -1,0 +1,119 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveBlockRange(t *testing.T) {
+	cc := &chainClient{blockNum: 1000}
+
+	// Ensure globals are reset even if a subtest panics.
+	t.Cleanup(func() {
+		epochFromBlock = -1
+		epochToBlock = -1
+	})
+
+	t.Run("defaults to deploy and pinned block", func(t *testing.T) {
+		epochFromBlock = -1
+		epochToBlock = -1
+		from, to, err := cc.resolveBlockRange(500)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(500), from)
+		assert.Equal(t, uint64(1000), to)
+	})
+
+	t.Run("respects from-block and to-block flags", func(t *testing.T) {
+		epochFromBlock = 600
+		epochToBlock = 800
+		from, to, err := cc.resolveBlockRange(500)
+		require.NoError(t, err)
+		assert.Equal(t, uint64(600), from)
+		assert.Equal(t, uint64(800), to)
+	})
+
+	t.Run("from-block exceeds pinned block", func(t *testing.T) {
+		epochFromBlock = 2000
+		epochToBlock = -1
+		_, _, err := cc.resolveBlockRange(500)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--from-block 2000 exceeds pinned block 1000")
+	})
+
+	t.Run("from-block exceeds to-block", func(t *testing.T) {
+		epochFromBlock = 800
+		epochToBlock = 700
+		_, _, err := cc.resolveBlockRange(500)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--from-block 800 exceeds --to-block 700")
+	})
+}
+
+func TestMergeClaimEvents(t *testing.T) {
+	t.Run("both empty", func(t *testing.T) {
+		result := mergeClaimEvents(nil, nil)
+		assert.Empty(t, result)
+	})
+
+	t.Run("a empty", func(t *testing.T) {
+		b := []ClaimEvent{
+			{EventType: "ClaimAccepted", BlockNumber: 100},
+			{EventType: "ClaimAccepted", BlockNumber: 200},
+		}
+		result := mergeClaimEvents(nil, b)
+		assert.Equal(t, b, result)
+	})
+
+	t.Run("b empty", func(t *testing.T) {
+		a := []ClaimEvent{
+			{EventType: "ClaimSubmitted", BlockNumber: 50},
+		}
+		result := mergeClaimEvents(a, nil)
+		assert.Equal(t, a, result)
+	})
+
+	t.Run("interleaved", func(t *testing.T) {
+		a := []ClaimEvent{
+			{EventType: "ClaimSubmitted", BlockNumber: 10},
+			{EventType: "ClaimSubmitted", BlockNumber: 30},
+			{EventType: "ClaimSubmitted", BlockNumber: 50},
+		}
+		b := []ClaimEvent{
+			{EventType: "ClaimAccepted", BlockNumber: 20},
+			{EventType: "ClaimAccepted", BlockNumber: 40},
+		}
+		result := mergeClaimEvents(a, b)
+		assert.Len(t, result, 5)
+
+		// Verify sorted order.
+		for i := 1; i < len(result); i++ {
+			assert.LessOrEqual(t, result[i-1].BlockNumber, result[i].BlockNumber)
+		}
+
+		// Verify types in expected order.
+		assert.Equal(t, "ClaimSubmitted", result[0].EventType)
+		assert.Equal(t, "ClaimAccepted", result[1].EventType)
+		assert.Equal(t, "ClaimSubmitted", result[2].EventType)
+		assert.Equal(t, "ClaimAccepted", result[3].EventType)
+		assert.Equal(t, "ClaimSubmitted", result[4].EventType)
+	})
+
+	t.Run("same block number preserves order", func(t *testing.T) {
+		a := []ClaimEvent{
+			{EventType: "ClaimSubmitted", BlockNumber: 100},
+		}
+		b := []ClaimEvent{
+			{EventType: "ClaimAccepted", BlockNumber: 100},
+		}
+		result := mergeClaimEvents(a, b)
+		assert.Len(t, result, 2)
+		// a comes first when blocks are equal (a[i].BlockNumber <= b[j].BlockNumber).
+		assert.Equal(t, "ClaimSubmitted", result[0].EventType)
+		assert.Equal(t, "ClaimAccepted", result[1].EventType)
+	})
+}

--- a/cmd/cartesi-rollups-cli/root/contract/format.go
+++ b/cmd/cartesi-rollups-cli/root/contract/format.go
@@ -1,0 +1,119 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"fmt"
+	"io"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type printer struct {
+	w       io.Writer
+	indent  int
+	started bool
+}
+
+// withSection runs fn within an indented section, guaranteeing endSection is always called.
+func (p *printer) withSection(title string, fn func()) {
+	if p.started {
+		fmt.Fprintf(p.w, "\n")
+	}
+	p.started = true
+	fmt.Fprintf(p.w, "%s%s\n", strings.Repeat("\t", p.indent), title)
+	p.indent++
+	fn()
+	p.indent--
+}
+
+func (p *printer) field(name, value string) {
+	padding := strings.Repeat(" ", max(1, 24-len(name))) //nolint:mnd
+	fmt.Fprintf(p.w, "%s%s%s%s\n", strings.Repeat("\t", p.indent), name, padding, value)
+}
+
+func (p *printer) fieldErr(label string, err error) {
+	p.field("ERROR", fmt.Sprintf("%s: %v", label, err))
+}
+
+// footer prints the block, chain ID, and a disclaimer at the end of every output.
+func (p *printer) footer(blockNum, chainID uint64, blockTime ...uint64) {
+	ts := uint64(0)
+	if len(blockTime) > 0 {
+		ts = blockTime[0]
+	}
+	fmt.Fprintf(p.w, "\nState at block            %d (chain ID: %d)%s\n",
+		blockNum, chainID, formatBlockTime(ts))
+	fmt.Fprintf(p.w, "\nNote: this is an experimental diagnostic tool. "+
+		"Values are read directly from on-chain contracts\n"+
+		"and may not reflect finalized state. Verify critical information independently.\n")
+}
+
+func formatAddr(addr common.Address) string {
+	return addr.Hex() // always full: 0x + 40 hex chars
+}
+
+func formatHash(hash [32]byte) string {
+	h := common.BytesToHash(hash[:])
+	return h.Hex() // always full: 0x + 64 hex chars
+}
+
+var weiDivisor = new(big.Float).SetInt(
+	new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil), //nolint:mnd
+)
+
+func weiToETH(wei *big.Int) string {
+	eth := new(big.Float).SetInt(wei)
+	eth.Quo(eth, weiDivisor)
+	return fmt.Sprintf("%s ETH", eth.Text('f', 6)) //nolint:mnd
+}
+
+func tournamentStatus(closed, finished bool) string {
+	switch {
+	case finished:
+		return "FINISHED"
+	case closed:
+		return "CLOSED (matches still running)"
+	default:
+		return "OPEN"
+	}
+}
+
+func matchDeletionReason(reason uint8) string {
+	switch reason {
+	case 0:
+		return "STEP (on-chain proof)"
+	case 1:
+		return "TIMEOUT"
+	case 2: //nolint:mnd
+		return "CHILD_TOURNAMENT"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", reason)
+	}
+}
+
+func matchWinner(winner uint8) string {
+	switch winner {
+	case 0:
+		return "NONE (both eliminated)"
+	case 1:
+		return "ONE"
+	case 2: //nolint:mnd
+		return "TWO"
+	default:
+		return fmt.Sprintf("UNKNOWN(%d)", winner)
+	}
+}
+
+// formatBlockTime returns " (2006-01-02 15:04:05 UTC)" if ts > 0, else "".
+func formatBlockTime(ts uint64) string {
+	if ts == 0 {
+		return ""
+	}
+	t := time.Unix(int64(ts), 0).UTC() //nolint:gosec // timestamp won't overflow int64
+	return fmt.Sprintf(" (%s)", t.Format("2006-01-02 15:04:05 UTC"))
+}

--- a/cmd/cartesi-rollups-cli/root/contract/format_test.go
+++ b/cmd/cartesi-rollups-cli/root/contract/format_test.go
@@ -1,0 +1,216 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"bytes"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		addr common.Address
+		want string
+	}{
+		{
+			name: "zero address",
+			addr: common.Address{},
+			want: "0x0000000000000000000000000000000000000000",
+		},
+		{
+			name: "normal address uses EIP-55 checksum",
+			addr: common.HexToAddress("0xDEADBEEF11112222333344445555666677778888"),
+			want: "0xdeadbeEF11112222333344445555666677778888",
+		},
+		{
+			name: "lowercase input normalizes to checksum",
+			addr: common.HexToAddress("0xdeadbeef11112222333344445555666677778888"),
+			want: "0xdeadbeEF11112222333344445555666677778888",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatAddr(tt.addr)
+			assert.Equal(t, tt.want, got)
+			// Always 42 characters: 0x + 40 hex chars
+			assert.Len(t, got, 42)
+		})
+	}
+}
+
+func TestFormatHash(t *testing.T) {
+	tests := []struct {
+		name string
+		hash [32]byte
+		want string
+	}{
+		{
+			name: "zero hash",
+			hash: [32]byte{},
+			want: "0x0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			name: "normal hash",
+			hash: common.HexToHash(
+				"0xABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"),
+			want: "0xabcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatHash(tt.hash)
+			// Always 66 characters: 0x + 64 hex chars
+			assert.Len(t, got, 66)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestWeiToETH(t *testing.T) {
+	tests := []struct {
+		name string
+		wei  *big.Int
+		want string
+	}{
+		{
+			name: "zero",
+			wei:  big.NewInt(0),
+			want: "0.000000 ETH",
+		},
+		{
+			name: "one wei",
+			wei:  big.NewInt(1),
+			want: "0.000000 ETH", // too small to show at 6 decimal places
+		},
+		{
+			name: "one ETH",
+			wei:  new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil),
+			want: "1.000000 ETH",
+		},
+		{
+			name: "0.05 ETH",
+			wei:  new(big.Int).Mul(big.NewInt(5), new(big.Int).Exp(big.NewInt(10), big.NewInt(16), nil)),
+			want: "0.050000 ETH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := weiToETH(tt.wei)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestTournamentStatus(t *testing.T) {
+	assert.Equal(t, "OPEN", tournamentStatus(false, false))
+	assert.Equal(t, "CLOSED (matches still running)", tournamentStatus(true, false))
+	assert.Equal(t, "FINISHED", tournamentStatus(false, true))
+	assert.Equal(t, "FINISHED", tournamentStatus(true, true))
+}
+
+func TestMatchDeletionReason(t *testing.T) {
+	assert.Equal(t, "STEP (on-chain proof)", matchDeletionReason(0))
+	assert.Equal(t, "TIMEOUT", matchDeletionReason(1))
+	assert.Equal(t, "CHILD_TOURNAMENT", matchDeletionReason(2))
+	assert.Equal(t, "UNKNOWN(42)", matchDeletionReason(42))
+}
+
+func TestMatchWinner(t *testing.T) {
+	assert.Equal(t, "NONE (both eliminated)", matchWinner(0))
+	assert.Equal(t, "ONE", matchWinner(1))
+	assert.Equal(t, "TWO", matchWinner(2))
+	assert.Equal(t, "UNKNOWN(99)", matchWinner(99))
+}
+
+func TestFormatBlockTime(t *testing.T) {
+	assert.Equal(t, "", formatBlockTime(0))
+	// Unix timestamp 1700000000 = 2023-11-14 22:13:20 UTC
+	got := formatBlockTime(1700000000)
+	assert.Contains(t, got, "2023-11-14")
+	assert.Contains(t, got, "UTC")
+	assert.True(t, got[0] == ' ' && got[1] == '(')
+}
+
+func TestPrinterFooter(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.footer(12345, 11155111)
+	out := buf.String()
+	assert.Contains(t, out, "12345")
+	assert.Contains(t, out, "11155111")
+	assert.Contains(t, out, "experimental diagnostic tool")
+}
+
+func TestPrinterFooterWithTimestamp(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.footer(12345, 1, 1700000000)
+	out := buf.String()
+	assert.Contains(t, out, "12345")
+	assert.Contains(t, out, "2023-11-14")
+	assert.Contains(t, out, "UTC")
+	assert.Contains(t, out, "experimental diagnostic tool")
+}
+
+func TestPrinterField(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.field("Name", "Value")
+	out := buf.String()
+	assert.Contains(t, out, "Name")
+	assert.Contains(t, out, "Value")
+}
+
+func TestPrinterWithSection(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.withSection("Section Title", func() {
+		p.field("Key", "Val")
+	})
+
+	out := buf.String()
+	assert.Contains(t, out, "Section Title")
+	assert.Contains(t, out, "Key")
+	// After withSection, indent should be back to 0
+	assert.Equal(t, 0, p.indent)
+}
+
+func TestPrinterNestedSections(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.withSection("Outer", func() {
+		require.Equal(t, 1, p.indent)
+		p.withSection("Inner", func() {
+			require.Equal(t, 2, p.indent)
+			p.field("Deep", "Value")
+		})
+		require.Equal(t, 1, p.indent)
+	})
+	require.Equal(t, 0, p.indent)
+}
+
+func TestPrinterFieldErr(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{w: &buf}
+
+	p.fieldErr("test label", assert.AnError)
+	out := buf.String()
+	assert.Contains(t, out, "ERROR")
+	assert.Contains(t, out, "test label")
+	assert.Contains(t, out, assert.AnError.Error())
+}

--- a/cmd/cartesi-rollups-cli/root/contract/inputbox.go
+++ b/cmd/cartesi-rollups-cli/root/contract/inputbox.go
@@ -1,0 +1,123 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cartesi/rollups-node/internal/config"
+	"github.com/cartesi/rollups-node/pkg/contracts/idaveconsensus"
+	"github.com/cartesi/rollups-node/pkg/contracts/iinputbox"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var inputboxCmd = &cobra.Command{
+	Use:   "inputbox <application-address>",
+	Short: "Query InputBox contract state (total inputs for application)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runInputBox,
+}
+
+func runInputBox(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	result, err := cc.queryInputBox()
+	if err != nil {
+		return err
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection("InputBox", func() {
+		if result.Address != "" {
+			p.field("Address", result.Address)
+		}
+		p.field("Total Inputs", fmt.Sprintf("%d", result.TotalInputs))
+	})
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}
+
+// queryInputBox returns the InputBox state for the application.
+// The InputBox address is auto-discovered from DaveConsensus or provided via --inputbox flag.
+func (c *chainClient) queryInputBox() (*InputBoxResult, error) {
+	inputBoxAddr, err := c.resolveInputBoxAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := c.ensureContract(inputBoxAddr, "InputBox"); err != nil {
+		return nil, err
+	}
+
+	caller, err := iinputbox.NewIInputBoxCaller(inputBoxAddr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IInputBox: %w", err)
+	}
+
+	totalRaw, err := caller.GetNumberOfInputs(c.callOpts, c.appAddr)
+	if err != nil {
+		return nil, fmt.Errorf("GetNumberOfInputs: %w", err)
+	}
+	total, err := safeUint64(totalRaw, "total inputs")
+	if err != nil {
+		return nil, err
+	}
+
+	return &InputBoxResult{
+		Address:     formatAddr(inputBoxAddr),
+		TotalInputs: total,
+	}, nil
+}
+
+// resolveInputBoxAddress discovers the InputBox address.
+// Priority: (1) --inputbox flag / env var, (2) DaveConsensus.GetInputBox().
+func (c *chainClient) resolveInputBoxAddress() (common.Address, error) {
+	// Try config (--inputbox flag or CARTESI_CONTRACTS_INPUT_BOX_ADDRESS env var).
+	addr, err := config.GetContractsInputBoxAddress()
+	if err == nil && addr != (common.Address{}) {
+		return addr, nil
+	}
+
+	// Try auto-discovery from DaveConsensus.
+	consensusAddr, cErr := c.getConsensusAddress()
+	if cErr != nil {
+		return common.Address{}, fmt.Errorf(
+			"cannot determine InputBox address: no --inputbox flag and consensus lookup failed: %w",
+			cErr)
+	}
+
+	cType, _, cErr := c.detectConsensus(consensusAddr)
+	if cErr != nil {
+		return common.Address{}, fmt.Errorf(
+			"cannot determine InputBox address: no --inputbox flag and consensus detection failed: %w",
+			cErr)
+	}
+
+	if cType == consensusDave {
+		daveCaller, dErr := idaveconsensus.NewIDaveConsensusCaller(consensusAddr, c.eth)
+		if dErr != nil {
+			return common.Address{}, fmt.Errorf("bind IDaveConsensus for InputBox discovery: %w", dErr)
+		}
+		inputBox, dErr := daveCaller.GetInputBox(c.callOpts)
+		if dErr != nil {
+			return common.Address{}, fmt.Errorf("IDaveConsensus.GetInputBox: %w", dErr)
+		}
+		return inputBox, nil
+	}
+
+	return common.Address{}, fmt.Errorf(
+		"cannot auto-discover InputBox address for %s consensus; "+
+			"use --inputbox flag or set CARTESI_CONTRACTS_INPUT_BOX_ADDRESS", cType)
+}

--- a/cmd/cartesi-rollups-cli/root/contract/match.go
+++ b/cmd/cartesi-rollups-cli/root/contract/match.go
@@ -1,0 +1,199 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"os"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/itournament"
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+)
+
+var matchCmd = &cobra.Command{
+	Use:   "match <application-address> <match-id-hash>",
+	Short: "Inspect a specific match's bisection state",
+	Args:  cobra.ExactArgs(2), //nolint:mnd
+	RunE:  runMatch,
+}
+
+func runMatch(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	if err := validateHash(args[1], "match ID hash"); err != nil {
+		return err
+	}
+	matchIDHash := common.HexToHash(args[1])
+
+	// Resolve tournament address using the same logic as the tournament subcommand.
+	res, err := cc.resolveTournamentAddress(args[:1])
+	if err != nil {
+		return fmt.Errorf("resolve tournament: %w", err)
+	}
+	tournamentAddr, deployBlock := res.addr, res.deployBlock
+
+	if err := cc.ensureContract(tournamentAddr, "tournament"); err != nil {
+		return err
+	}
+
+	caller, err := itournament.NewITournamentCaller(tournamentAddr, cc.eth)
+	if err != nil {
+		return fmt.Errorf("bind ITournament: %w", err)
+	}
+
+	matchState, err := caller.GetMatch(cc.callOpts, [32]byte(matchIDHash))
+	if err != nil {
+		return fmt.Errorf("GetMatch: %w", err)
+	}
+
+	cycle, err := caller.GetMatchCycle(cc.callOpts, [32]byte(matchIDHash))
+	if err != nil {
+		return fmt.Errorf("GetMatchCycle: %w", err)
+	}
+
+	// Discover commitment hashes for this match from MatchCreated events.
+	// We need the two commitment hashes to call CanWinMatchByTimeout and to show players.
+	commitOne, commitTwo, lookupErr := cc.findMatchCommitments(
+		tournamentAddr, deployBlock, [32]byte(matchIDHash))
+	if lookupErr != nil {
+		slog.Warn("failed to look up match commitments", "error", lookupErr)
+	}
+
+	// Attempt CanWinMatchByTimeout if we have both commitments.
+	var canWinByTimeout bool
+	if commitOne != ([32]byte{}) && commitTwo != ([32]byte{}) {
+		canWinByTimeout, _ = caller.CanWinMatchByTimeout(cc.callOpts,
+			itournament.MatchId{CommitmentOne: commitOne, CommitmentTwo: commitTwo})
+	}
+
+	// Build commitment registry for player address resolution.
+	registry := make(commitmentRegistry)
+	if commitOne != ([32]byte{}) || commitTwo != ([32]byte{}) {
+		events, eErr := cc.fetchTournamentEvents(tournamentAddr, deployBlock)
+		if eErr != nil {
+			slog.Warn("failed to fetch events for address resolution", "error", eErr)
+		} else {
+			for _, cj := range events.commitmentsJoined {
+				registry[cj.commitment] = cj.submitter
+			}
+		}
+	}
+
+	result := &MatchResult{
+		MatchIDHash:         formatHash([32]byte(matchIDHash)),
+		Tournament:          formatAddr(tournamentAddr),
+		CommitmentOne:       formatHash(commitOne),
+		CommitmentTwo:       formatHash(commitTwo),
+		PlayerOneAddr:       registry.resolve(commitOne),
+		PlayerTwoAddr:       registry.resolve(commitTwo),
+		CurrentHeight:       matchState.CurrentHeight,
+		RunningLeafPosition: matchState.RunningLeafPosition.String(),
+		MachineCycle:        cycle.String(),
+		CanWinByTimeout:     canWinByTimeout,
+		LeftNode:            formatHash(matchState.LeftNode),
+		RightNode:           formatHash(matchState.RightNode),
+		OtherParent:         formatHash(matchState.OtherParent),
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Match  %s", result.MatchIDHash), func() {
+		p.field("Tournament", result.Tournament)
+		printMatchPlayer(p, "Player One", result.CommitmentOne, result.PlayerOneAddr)
+		printMatchPlayer(p, "Player Two", result.CommitmentTwo, result.PlayerTwoAddr)
+		p.field("Current Height", fmt.Sprintf("%d", result.CurrentHeight))
+		p.field("Running Leaf Pos", result.RunningLeafPosition)
+		p.field("Machine Cycle", result.MachineCycle)
+		p.field("Can Win by Timeout", fmt.Sprintf("%t", result.CanWinByTimeout))
+		p.field("Left Node", result.LeftNode)
+		p.field("Right Node", result.RightNode)
+		p.field("Other Parent", result.OtherParent)
+	})
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}
+
+func printMatchPlayer(p *printer, label, commitment, addr string) {
+	info := commitment
+	if addr != "" {
+		info += fmt.Sprintf("  (%s)", addr)
+	}
+	p.field(label, info)
+}
+
+// findMatchCommitments looks up the MatchCreated event for the given match ID hash
+// to retrieve the two commitment hashes. Returns zero hashes and an error on failure.
+func (c *chainClient) findMatchCommitments(
+	tournamentAddr common.Address,
+	deployBlock uint64,
+	matchIDHash [32]byte,
+) ([32]byte, [32]byte, error) {
+	filterer, err := itournament.NewITournamentFilterer(tournamentAddr, c.eth)
+	if err != nil {
+		return [32]byte{}, [32]byte{}, fmt.Errorf("bind ITournament filterer: %w", err)
+	}
+	caller, err := itournament.NewITournamentCaller(tournamentAddr, c.eth)
+	if err != nil {
+		return [32]byte{}, [32]byte{}, fmt.Errorf("bind ITournament caller: %w", err)
+	}
+
+	var commitOne, commitTwo [32]byte
+
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		return caller.GetMatchCreatedCount(opts)
+	}
+
+	onHit := func(block uint64) error {
+		q, qErr := buildEventFilterQuery(
+			tournamentAddr, "MatchCreated",
+			itournament.ITournamentMetaData, block, block,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		itr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, q)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range itr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := filterer.ParseMatchCreated(*log)
+			if pErr != nil {
+				return pErr
+			}
+			if ev.MatchIdHash == matchIDHash {
+				commitOne = ev.One
+				commitTwo = ev.Two
+				return errFound
+			}
+		}
+		return nil
+	}
+
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, deployBlock, c.blockNum, big.NewInt(0), oracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errFound) {
+		return [32]byte{}, [32]byte{}, fmt.Errorf("find match commitments: %w", err)
+	}
+	return commitOne, commitTwo, nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/output.go
+++ b/cmd/cartesi-rollups-cli/root/contract/output.go
@@ -1,0 +1,83 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"fmt"
+	"math/big"
+	"os"
+	"strconv"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/iapplication"
+	"github.com/spf13/cobra"
+)
+
+var outputCmd = &cobra.Command{
+	Use:   "output <application-address> [output-index]",
+	Short: "Check output execution status",
+	Args:  cobra.RangeArgs(1, 2), //nolint:mnd
+	RunE:  runOutput,
+}
+
+func runOutput(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	if err := cc.ensureContract(cc.appAddr, "application"); err != nil {
+		return err
+	}
+
+	app, err := iapplication.NewIApplicationCaller(cc.appAddr, cc.eth)
+	if err != nil {
+		return fmt.Errorf("bind IApplication: %w", err)
+	}
+
+	totalRaw, err := app.GetNumberOfExecutedOutputs(cc.callOpts)
+	if err != nil {
+		return fmt.Errorf("GetNumberOfExecutedOutputs: %w", err)
+	}
+	total, err := safeUint64(totalRaw, "executed outputs")
+	if err != nil {
+		return err
+	}
+
+	// Single output mode: check a specific output index.
+	if len(args) > 1 {
+		idx, parseErr := strconv.ParseUint(args[1], 10, 64)
+		if parseErr != nil {
+			return fmt.Errorf("invalid output index: %q", args[1])
+		}
+		executed, execErr := app.WasOutputExecuted(cc.callOpts, new(big.Int).SetUint64(idx))
+		if execErr != nil {
+			return fmt.Errorf("WasOutputExecuted(%d): %w", idx, execErr)
+		}
+
+		result := &OutputResult{OutputIndex: idx, Executed: executed}
+		if jsonParam {
+			return outputJSON(result)
+		}
+
+		p := &printer{w: os.Stdout}
+		p.withSection(fmt.Sprintf("Output #%d", idx), func() {
+			p.field("Executed", fmt.Sprintf("%t", executed))
+		})
+		p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+		return nil
+	}
+
+	// Batch mode: show summary of executed outputs.
+	result := &OutputBatchResult{TotalExecuted: total}
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	p.withSection(fmt.Sprintf("Outputs  (%d executed)", total), func() {})
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/selectors.go
+++ b/cmd/cartesi-rollups-cli/root/contract/selectors.go
@@ -1,0 +1,29 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"errors"
+
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+)
+
+// tournamentFailedNoWinner is the 4-byte error selector for TournamentFailedNoWinner.
+// When ArbitrationResult reverts with this selector, the tournament finished with all
+// participants eliminated.
+const tournamentFailedNoWinner = "0xb3045ef8"
+
+// errFound is a sentinel error used to short-circuit FindTransitions
+// after the target item has been located.
+var errFound = errors.New("found")
+
+// errLimitReached is a sentinel error used to short-circuit FindTransitions
+// after the configured event limit has been reached, avoiding unnecessary
+// RPC calls for remaining transition blocks.
+var errLimitReached = errors.New("limit reached")
+
+// matchesSelector delegates to ethutil.MatchesSelector.
+func matchesSelector(data any, selector string) bool {
+	return ethutil.MatchesSelector(data, selector)
+}

--- a/cmd/cartesi-rollups-cli/root/contract/summary.go
+++ b/cmd/cartesi-rollups-cli/root/contract/summary.go
@@ -1,0 +1,436 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"os"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/iauthority"
+	"github.com/cartesi/rollups-node/pkg/contracts/idaveconsensus"
+	"github.com/cartesi/rollups-node/pkg/contracts/iquorum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+)
+
+var summaryCmd = &cobra.Command{
+	Use:   "summary <application-address>",
+	Short: "Full diagnostic snapshot (composes app + consensus + inputbox + root tournament)",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSummary,
+}
+
+// consensusResult holds the query result for any consensus type.
+type consensusResult struct {
+	cType  string
+	result any // one of *Authority/Quorum/DaveConsensusResult
+	err    error
+}
+
+func runSummary(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	// Pre-resolve consensus address and type once. This avoids duplicate RPC calls
+	// between the consensus and tournament sections.
+	consensusAddr, consensusDetectErr := cc.getConsensusAddress()
+	var cType consensusType
+	var contractVersion string
+	if consensusDetectErr == nil && consensusAddr != (common.Address{}) {
+		cType, contractVersion, consensusDetectErr = cc.detectConsensus(consensusAddr)
+	}
+
+	// Use plain errgroup (NOT WithContext) for partial failure — if one section fails,
+	// the others should continue to completion.
+	var g errgroup.Group
+	g.SetLimit(4) //nolint:mnd
+
+	// Each goroutine writes to its own dedicated variable. g.Wait() provides
+	// the happens-before guarantee, so no mutex is needed.
+	var (
+		appResult      *AppResult
+		appErr         error
+		cr             consensusResult
+		inputBoxResult *InputBoxResult
+		inputBoxErr    error
+		tournResult    *TournamentResult
+		tournErr       error
+	)
+
+	// Section 1: Application.
+	g.Go(func() error {
+		appResult, appErr = cc.queryApp()
+		return nil // always nil — partial failure
+	})
+
+	// Section 2: Consensus query (uses pre-resolved address and type).
+	g.Go(func() error {
+		if consensusDetectErr != nil {
+			cr.err = consensusDetectErr
+			return nil
+		}
+		if consensusAddr == (common.Address{}) {
+			return nil
+		}
+
+		cr.cType = cType.String()
+
+		var cResult any
+		var cErr error
+		switch cType {
+		case consensusAuthority:
+			cResult, cErr = cc.queryAuthority(consensusAddr, contractVersion)
+		case consensusQuorum:
+			cResult, cErr = cc.queryQuorum(consensusAddr)
+		case consensusDave:
+			cResult, cErr = cc.queryDave(consensusAddr)
+		case consensusUnknown:
+			cErr = fmt.Errorf("unknown consensus type at %s", consensusAddr)
+		}
+
+		cr.result, cr.err = cResult, cErr
+		return nil
+	})
+
+	// Section 3: InputBox.
+	g.Go(func() error {
+		inputBoxResult, inputBoxErr = cc.queryInputBox()
+		return nil
+	})
+
+	// Section 4: Root Tournament (only for DaveConsensus).
+	if consensusDetectErr == nil && cType == consensusDave {
+		g.Go(func() error {
+			daveCaller, dErr := idaveconsensus.NewIDaveConsensusCaller(
+				consensusAddr, cc.eth)
+			if dErr != nil {
+				tournErr = dErr
+				return nil
+			}
+
+			sealed, dErr := daveCaller.GetCurrentSealedEpoch(cc.callOpts)
+			if dErr != nil {
+				tournErr = dErr
+				return nil
+			}
+			if sealed.Tournament == (common.Address{}) {
+				return nil // no sealed epoch yet
+			}
+
+			tournResult, tournErr = cc.queryTournament(sealed.Tournament)
+			return nil
+		})
+	}
+
+	_ = g.Wait() // errors are always nil (partial failure)
+
+	if jsonParam {
+		result := &SummaryResult{}
+		if appErr != nil {
+			result.AppError = appErr.Error()
+		} else {
+			result.Application = appResult
+		}
+		if cr.err != nil {
+			result.ConsensusError = cr.err.Error()
+		} else if cr.result != nil {
+			result.Consensus, _ = json.Marshal(cr.result)
+		}
+		if inputBoxErr != nil {
+			result.InputBoxError = inputBoxErr.Error()
+		} else {
+			result.InputBox = inputBoxResult
+		}
+		if tournErr != nil {
+			result.TournamentError = tournErr.Error()
+		} else {
+			result.RootTournament = tournResult
+		}
+		return outputJSON(result)
+	}
+
+	// Text output with partial failure.
+	p := &printer{w: os.Stdout}
+
+	if appErr != nil {
+		p.withSection(fmt.Sprintf("Application  %s", formatAddr(cc.appAddr)), func() {
+			p.fieldErr("application query", appErr)
+		})
+	} else if appResult != nil {
+		p.withSection(fmt.Sprintf("Application  %s", appResult.Address), func() {
+			p.field("Template Hash", appResult.TemplateHash)
+			p.field("Owner", appResult.Owner)
+			p.field("Deployment Block", fmt.Sprintf("%d", appResult.DeploymentBlock))
+			p.field("Executed Outputs", fmt.Sprintf("%d", appResult.ExecutedOutputs))
+			p.field("Consensus",
+				fmt.Sprintf("%s (%s)", appResult.ConsensusAddress, appResult.ConsensusType))
+			p.field("Data Availability", appResult.DataAvailability)
+		})
+	}
+
+	displayConsensusAddr := consensusAddr
+	if appResult != nil {
+		displayConsensusAddr = common.HexToAddress(appResult.ConsensusAddress)
+	}
+
+	if cr.err != nil {
+		label := "Consensus"
+		if cr.cType != "" {
+			label = cr.cType
+		}
+		p.withSection(fmt.Sprintf("%s  %s", label, formatAddr(displayConsensusAddr)), func() {
+			p.fieldErr("consensus query", cr.err)
+		})
+	} else if cr.result != nil {
+		printConsensusSummary(p, cr)
+	}
+
+	// Root Tournament (DaveConsensus only).
+	if tournErr != nil {
+		p.withSection("Root Tournament", func() {
+			p.fieldErr("tournament query", tournErr)
+		})
+	} else if tournResult != nil {
+		printTournamentBasic(p, tournResult)
+	}
+
+	// InputBox.
+	if inputBoxErr != nil {
+		p.withSection("InputBox", func() {
+			p.fieldErr("inputbox query", inputBoxErr)
+		})
+	} else if inputBoxResult != nil {
+		p.withSection("InputBox", func() {
+			p.field("Total Inputs", fmt.Sprintf("%d", inputBoxResult.TotalInputs))
+		})
+	}
+
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}
+
+func printConsensusSummary(p *printer, cr consensusResult) {
+	switch r := cr.result.(type) {
+	case *AuthorityConsensusResult:
+		p.withSection(fmt.Sprintf("Authority  %s", r.Address), func() {
+			p.field("Owner (Validator)", r.Owner)
+			p.field("Epoch Length", fmt.Sprintf("%d blocks", r.EpochLength))
+			p.field("Accepted Claims", fmt.Sprintf("%d", r.AcceptedClaims))
+			p.field("IConsensus Version", r.ContractVersion)
+		})
+	case *QuorumConsensusResult:
+		p.withSection(fmt.Sprintf("Quorum  %s", r.Address), func() {
+			p.field("Validators", fmt.Sprintf("%d", r.NumValidators))
+			p.field("Quorum Threshold",
+				fmt.Sprintf("%d (computed: strict majority)", r.QuorumThreshold))
+			p.field("Epoch Length", fmt.Sprintf("%d blocks", r.EpochLength))
+			p.field("Accepted Claims", fmt.Sprintf("%d", r.AcceptedClaims))
+		})
+	case *DaveConsensusResult:
+		p.withSection(fmt.Sprintf("DaveConsensus  %s", r.Address), func() {
+			p.field("Deployment Block", fmt.Sprintf("%d", r.DeploymentBlock))
+			printTournamentFinished(p, r)
+			p.field("Current Sealed Epoch", fmt.Sprintf("%d", r.CurrentEpochNumber))
+			p.field("Root Tournament", r.RootTournament)
+		})
+	}
+}
+
+// queryAuthority returns a structured Authority result.
+func (c *chainClient) queryAuthority(
+	addr common.Address, contractVersion string,
+) (*AuthorityConsensusResult, error) {
+	if err := c.ensureContract(addr, "Authority"); err != nil {
+		return nil, err
+	}
+	caller, err := iauthority.NewIAuthorityCaller(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IAuthority: %w", err)
+	}
+
+	owner, err := caller.Owner(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("IAuthority.Owner: %w", err)
+	}
+
+	epochLengthRaw, err := caller.GetEpochLength(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetEpochLength: %w", err)
+	}
+	epochLength, err := safeUint64(epochLengthRaw, "epoch length")
+	if err != nil {
+		return nil, err
+	}
+
+	claimsRaw, err := caller.GetNumberOfAcceptedClaims(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetNumberOfAcceptedClaims: %w", err)
+	}
+	claims, err := safeUint64(claimsRaw, "accepted claims")
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthorityConsensusResult{
+		Type:            "Authority",
+		Address:         formatAddr(addr),
+		Owner:           formatAddr(owner),
+		EpochLength:     epochLength,
+		AcceptedClaims:  claims,
+		ContractVersion: contractVersion,
+	}, nil
+}
+
+// queryQuorum returns a structured Quorum result.
+func (c *chainClient) queryQuorum(
+	addr common.Address,
+) (*QuorumConsensusResult, error) {
+	if err := c.ensureContract(addr, "Quorum"); err != nil {
+		return nil, err
+	}
+	caller, err := iquorum.NewIQuorumCaller(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IQuorum: %w", err)
+	}
+
+	epochLengthRaw, err := caller.GetEpochLength(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetEpochLength: %w", err)
+	}
+	epochLength, err := safeUint64(epochLengthRaw, "epoch length")
+	if err != nil {
+		return nil, err
+	}
+
+	claimsRaw, err := caller.GetNumberOfAcceptedClaims(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetNumberOfAcceptedClaims: %w", err)
+	}
+	claims, err := safeUint64(claimsRaw, "accepted claims")
+	if err != nil {
+		return nil, err
+	}
+
+	numValRaw, err := caller.NumOfValidators(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("NumOfValidators: %w", err)
+	}
+	numVal, err := safeUint64(numValRaw, "num validators")
+	if err != nil {
+		return nil, err
+	}
+
+	const maxValidators = 10000
+	if numVal > maxValidators {
+		slog.Warn("validator count exceeds cap, truncating",
+			"reported", numVal, "cap", maxValidators)
+		numVal = maxValidators
+	}
+	validators := make([]string, 0, numVal)
+	for i := uint64(1); i <= numVal; i++ {
+		valAddr, err := caller.ValidatorById(c.callOpts, new(big.Int).SetUint64(i))
+		if err != nil {
+			return nil, fmt.Errorf("ValidatorById(%d): %w", i, err)
+		}
+		validators = append(validators, formatAddr(valAddr))
+	}
+
+	threshold := 1 + numVal/2 //nolint:mnd
+
+	return &QuorumConsensusResult{
+		Type:            "Quorum",
+		Address:         formatAddr(addr),
+		NumValidators:   numVal,
+		QuorumThreshold: threshold,
+		Validators:      validators,
+		EpochLength:     epochLength,
+		AcceptedClaims:  claims,
+	}, nil
+}
+
+// queryDave returns a structured DaveConsensus result.
+func (c *chainClient) queryDave(
+	addr common.Address,
+) (*DaveConsensusResult, error) {
+	if err := c.ensureContract(addr, "DaveConsensus"); err != nil {
+		return nil, err
+	}
+	caller, err := idaveconsensus.NewIDaveConsensusCaller(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind IDaveConsensus: %w", err)
+	}
+
+	settleInfo, err := caller.CanSettle(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("CanSettle: %w", err)
+	}
+
+	sealed, err := caller.GetCurrentSealedEpoch(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetCurrentSealedEpoch: %w", err)
+	}
+
+	epochNumber, err := safeUint64(sealed.EpochNumber, "epoch number")
+	if err != nil {
+		return nil, err
+	}
+
+	inputLower, err := safeUint64(sealed.InputIndexLowerBound, "input lower bound")
+	if err != nil {
+		return nil, err
+	}
+
+	inputUpper, err := safeUint64(sealed.InputIndexUpperBound, "input upper bound")
+	if err != nil {
+		return nil, err
+	}
+
+	deployBlockRaw, err := caller.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deployBlock, err := safeUint64(deployBlockRaw, "deployment block")
+	if err != nil {
+		return nil, err
+	}
+
+	inputBox, err := caller.GetInputBox(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetInputBox: %w", err)
+	}
+
+	factory, err := caller.GetTournamentFactory(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetTournamentFactory: %w", err)
+	}
+
+	result := &DaveConsensusResult{
+		Type:               "DaveConsensus",
+		Address:            formatAddr(addr),
+		InputBox:           formatAddr(inputBox),
+		Factory:            formatAddr(factory),
+		DeploymentBlock:    deployBlock,
+		IsFinished:         settleInfo.IsFinished,
+		CurrentEpochNumber: epochNumber,
+		InputLowerBound:    inputLower,
+		InputUpperBound:    inputUpper,
+		RootTournament:     formatAddr(sealed.Tournament),
+	}
+	if result.IsFinished {
+		hasWinner := settleInfo.WinnerCommitment != [32]byte{}
+		result.HasWinner = &hasWinner
+		if hasWinner {
+			result.WinnerCommitment = formatHash(settleInfo.WinnerCommitment)
+		}
+	}
+	return result, nil
+}

--- a/cmd/cartesi-rollups-cli/root/contract/tournament.go
+++ b/cmd/cartesi-rollups-cli/root/contract/tournament.go
@@ -1,0 +1,1113 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/cartesi/rollups-node/pkg/contracts/idaveconsensus"
+	"github.com/cartesi/rollups-node/pkg/contracts/itournament"
+	"github.com/cartesi/rollups-node/pkg/ethutil"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tournamentTreeFlag     bool
+	tournamentEventsFlag   bool
+	tournamentEpochFlag    int64
+	tournamentLimitFlag    int
+	tournamentMaxNodesFlag int
+)
+
+var tournamentCmd = &cobra.Command{
+	Use:   "tournament <application-address> [tournament-address]",
+	Short: "Query tournament contract state (PRT dispute resolution)",
+	Args:  cobra.RangeArgs(1, 2), //nolint:mnd
+	RunE:  runTournament,
+}
+
+func init() {
+	tournamentCmd.Flags().BoolVar(&tournamentTreeFlag, "tree", false,
+		"Recursively traverse the full tournament hierarchy.\n"+
+			"WARNING: generates many RPC calls (8+ view calls + event discovery\n"+
+			"per node). On rate-limited providers, use --max-nodes and --limit\n"+
+			"to control RPC volume")
+	tournamentCmd.Flags().BoolVar(&tournamentEventsFlag, "events", false,
+		"Show detailed event lists (commitments, matches, advances)")
+	tournamentCmd.Flags().Int64Var(&tournamentEpochFlag, "epoch", -1,
+		"Inspect tournament for a specific epoch number (default: current sealed epoch)")
+	tournamentCmd.Flags().IntVar(&tournamentLimitFlag, "limit", 50, //nolint:mnd
+		"Maximum events per type per tournament")
+	tournamentCmd.Flags().IntVar(&tournamentMaxNodesFlag, "max-nodes", 100, //nolint:mnd
+		"Maximum tournament nodes to visit in --tree traversal")
+}
+
+func runTournament(cmd *cobra.Command, args []string) error {
+	cc, cancel, err := initChainClient(cmd, args)
+	if err != nil {
+		return err
+	}
+	defer cancel()
+	defer cc.eth.Close()
+
+	res, err := cc.resolveTournamentAddress(args)
+	if err != nil {
+		return err
+	}
+
+	if err := cc.ensureContract(res.addr, "tournament"); err != nil {
+		return err
+	}
+
+	if tournamentTreeFlag {
+		// --tree always includes events for commitment registry.
+		tree, tErr := cc.walkTournamentTree(res.addr, res.deployBlock, true)
+		if tErr != nil {
+			return tErr
+		}
+		if jsonParam {
+			return outputJSON(tree.root)
+		}
+		p := &printer{w: os.Stdout}
+		printTournamentContext(p, cc, res)
+		renderTournamentTree(p, tree.root, tree, 0)
+		p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+		return nil
+	}
+
+	result, err := cc.queryTournament(res.addr)
+	if err != nil {
+		return err
+	}
+
+	if tournamentEventsFlag {
+		events, eErr := cc.fetchTournamentEvents(res.addr, res.deployBlock)
+		if eErr != nil {
+			slog.Warn("failed to fetch tournament events", "error", eErr)
+		} else {
+			registry := make(commitmentRegistry)
+			for _, cj := range events.commitmentsJoined {
+				registry[cj.commitment] = cj.submitter
+			}
+			result.Commitments = formatCommitmentEvents(events.commitmentsJoined)
+			result.Matches = formatMatchEvents(events.matchesCreated, events.matchesDeleted, registry)
+			result.Advances = formatAdvanceEvents(events.matchesAdvanced)
+		}
+	}
+
+	if jsonParam {
+		return outputJSON(result)
+	}
+
+	p := &printer{w: os.Stdout}
+	printTournamentContext(p, cc, res)
+	printTournamentBasic(p, result)
+
+	if tournamentEventsFlag {
+		printTournamentEvents(p, result)
+	}
+
+	p.footer(cc.blockNum, cc.chainID, cc.resolveTimestamp(cc.blockNum))
+	return nil
+}
+
+// printTournamentContext prints application and epoch context before tournament details.
+func printTournamentContext(p *printer, cc *chainClient, res tournamentResolution) {
+	p.withSection(fmt.Sprintf("Application  %s", formatAddr(cc.appAddr)), func() {
+		if res.epochNumber >= 0 {
+			p.field("Epoch", fmt.Sprintf("%d", res.epochNumber))
+		}
+	})
+}
+
+// tournamentResolution holds the result of resolving a tournament address.
+type tournamentResolution struct {
+	addr        common.Address
+	deployBlock uint64
+	epochNumber int64 // -1 if unknown (direct address)
+}
+
+// resolveTournamentAddress determines the tournament address from:
+// (1) positional arg, (2) --epoch flag, (3) current sealed epoch.
+func (c *chainClient) resolveTournamentAddress(
+	args []string,
+) (tournamentResolution, error) {
+	consensusAddr, err := c.getConsensusAddress()
+	if err != nil {
+		return tournamentResolution{}, fmt.Errorf("get consensus address: %w", err)
+	}
+
+	// Verify the consensus is DaveConsensus before calling Dave-specific methods.
+	// Authority/Quorum contracts do not have tournaments.
+	cType, _, err := c.detectConsensus(consensusAddr)
+	if err != nil {
+		return tournamentResolution{}, fmt.Errorf("detect consensus type: %w", err)
+	}
+	if cType != consensusDave {
+		return tournamentResolution{}, fmt.Errorf(
+			"tournament is only available for DaveConsensus (PRT); "+
+				"consensus at %s is %s", consensusAddr, cType)
+	}
+
+	daveCaller, err := idaveconsensus.NewIDaveConsensusCaller(consensusAddr, c.eth)
+	if err != nil {
+		return tournamentResolution{}, fmt.Errorf("bind IDaveConsensus: %w", err)
+	}
+
+	deployBlockRaw, err := daveCaller.GetDeploymentBlockNumber(c.callOpts)
+	if err != nil {
+		return tournamentResolution{}, fmt.Errorf("GetDeploymentBlockNumber: %w", err)
+	}
+	deployBlock, err := safeUint64(deployBlockRaw, "deployment block")
+	if err != nil {
+		return tournamentResolution{}, err
+	}
+
+	// (1) Direct tournament address from positional arg.
+	if len(args) > 1 {
+		if !common.IsHexAddress(args[1]) {
+			return tournamentResolution{},
+				fmt.Errorf("invalid tournament address: %q", args[1])
+		}
+		return tournamentResolution{
+			addr: common.HexToAddress(args[1]), deployBlock: deployBlock, epochNumber: -1,
+		}, nil
+	}
+
+	// (2) --epoch flag: find tournament from EpochSealed events.
+	if tournamentEpochFlag >= 0 {
+		addr, fErr := c.findTournamentForEpoch(consensusAddr, daveCaller, deployBlock,
+			uint64(tournamentEpochFlag))
+		if fErr != nil {
+			return tournamentResolution{}, fErr
+		}
+		return tournamentResolution{
+			addr: addr, deployBlock: deployBlock, epochNumber: tournamentEpochFlag,
+		}, nil
+	}
+
+	// (3) Default: current sealed epoch.
+	sealed, err := daveCaller.GetCurrentSealedEpoch(c.callOpts)
+	if err != nil {
+		return tournamentResolution{}, fmt.Errorf("GetCurrentSealedEpoch: %w", err)
+	}
+	if sealed.Tournament == (common.Address{}) {
+		return tournamentResolution{},
+			fmt.Errorf("no sealed epochs yet — tournament not available")
+	}
+	epochNum, err := safeUint64(sealed.EpochNumber, "epoch number")
+	if err != nil {
+		return tournamentResolution{}, err
+	}
+	if epochNum > math.MaxInt64 {
+		return tournamentResolution{},
+			fmt.Errorf("epoch number %d exceeds int64 max", epochNum)
+	}
+	return tournamentResolution{
+		addr: sealed.Tournament, deployBlock: deployBlock, epochNumber: int64(epochNum),
+	}, nil
+}
+
+// findTournamentForEpoch locates the tournament address for a specific epoch
+// using FindTransitions on the sealed epoch counter.
+func (c *chainClient) findTournamentForEpoch(
+	consensusAddr common.Address,
+	daveCaller *idaveconsensus.IDaveConsensusCaller,
+	deployBlock, targetEpoch uint64,
+) (common.Address, error) {
+	filterer, err := idaveconsensus.NewIDaveConsensusFilterer(consensusAddr, c.eth)
+	if err != nil {
+		return common.Address{}, fmt.Errorf("bind IDaveConsensus filterer: %w", err)
+	}
+
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		sealed, sErr := daveCaller.GetCurrentSealedEpoch(opts)
+		if sErr != nil {
+			return nil, sErr
+		}
+		return sealed.EpochNumber, nil
+	}
+
+	var result common.Address
+
+	onHit := func(block uint64) error {
+		q, qErr := buildEventFilterQuery(
+			consensusAddr, "EpochSealed",
+			idaveconsensus.IDaveConsensusMetaData, block, block,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		itr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, q)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range itr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := filterer.ParseEpochSealed(*log)
+			if pErr != nil {
+				return pErr
+			}
+			epochNum, sErr := safeUint64(ev.EpochNumber, "epoch number")
+			if sErr != nil {
+				return sErr
+			}
+			if epochNum == targetEpoch {
+				result = ev.Tournament
+				return errFound
+			}
+		}
+		return nil
+	}
+
+	// Use -1 as prevValue so epoch 0 is detected as a transition from -1→0.
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, deployBlock, c.blockNum, big.NewInt(-1), oracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errFound) {
+		return common.Address{}, fmt.Errorf("find epoch %d tournament: %w", targetEpoch, err)
+	}
+	if result == (common.Address{}) {
+		return common.Address{}, fmt.Errorf("epoch %d not found in EpochSealed events", targetEpoch)
+	}
+	return result, nil
+}
+
+// queryTournament reads ITournament view functions and returns a TournamentResult.
+func (c *chainClient) queryTournament(addr common.Address) (*TournamentResult, error) {
+	if err := c.ensureContract(addr, "tournament"); err != nil {
+		return nil, err
+	}
+	caller, err := itournament.NewITournamentCaller(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind ITournament: %w", err)
+	}
+
+	levelConsts, err := caller.TournamentLevelConstants(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("TournamentLevelConstants: %w", err)
+	}
+
+	closed, err := caller.IsClosed(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("IsClosed: %w", err)
+	}
+
+	finished, err := caller.IsFinished(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("IsFinished: %w", err)
+	}
+
+	bondWei, err := caller.BondValue(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("BondValue: %w", err)
+	}
+
+	commitmentsRaw, err := caller.GetCommitmentJoinedCount(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetCommitmentJoinedCount: %w", err)
+	}
+	commitments, err := safeUint64(commitmentsRaw, "commitments joined")
+	if err != nil {
+		return nil, err
+	}
+
+	matchesCreatedRaw, err := caller.GetMatchCreatedCount(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetMatchCreatedCount: %w", err)
+	}
+	matchesCreated, err := safeUint64(matchesCreatedRaw, "matches created")
+	if err != nil {
+		return nil, err
+	}
+
+	matchesAdvancedRaw, err := caller.GetMatchAdvancedCount(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetMatchAdvancedCount: %w", err)
+	}
+	matchesAdvanced, err := safeUint64(matchesAdvancedRaw, "matches advanced")
+	if err != nil {
+		return nil, err
+	}
+
+	matchesDeletedRaw, err := caller.GetMatchDeletedCount(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetMatchDeletedCount: %w", err)
+	}
+	matchesDeleted, err := safeUint64(matchesDeletedRaw, "matches deleted")
+	if err != nil {
+		return nil, err
+	}
+
+	innerRaw, err := caller.GetNewInnerTournamentCount(c.callOpts)
+	if err != nil {
+		return nil, fmt.Errorf("GetNewInnerTournamentCount: %w", err)
+	}
+	inner, err := safeUint64(innerRaw, "inner tournaments")
+	if err != nil {
+		return nil, err
+	}
+
+	result := &TournamentResult{
+		Address:           formatAddr(addr),
+		Level:             levelConsts.Level,
+		MaxLevel:          levelConsts.MaxLevel,
+		Log2Step:          levelConsts.Log2step,
+		Height:            levelConsts.Height,
+		Closed:            closed,
+		Finished:          finished,
+		BondWei:           bondWei.String(),
+		BondETH:           weiToETH(bondWei),
+		CommitmentsJoined: commitments,
+		MatchesCreated:    matchesCreated,
+		MatchesAdvanced:   matchesAdvanced,
+		MatchesDeleted:    matchesDeleted,
+		InnerTournaments:  inner,
+	}
+
+	// Query finish details if tournament is finished.
+	if finished {
+		isFinished, finBlock, tErr := caller.TimeFinished(c.callOpts)
+		if tErr == nil && isFinished {
+			result.FinishedAtBlock = &finBlock
+		}
+
+		isRoot := levelConsts.Level == 0
+		tFinished, hasWin, winner, finalState, tErr := c.tournamentResult(caller, isRoot)
+		if tErr == nil && tFinished {
+			result.HasWinner = &hasWin
+			if hasWin {
+				result.WinnerCommitment = formatHash(winner)
+				if finalState != [32]byte{} {
+					result.FinalMachineHash = formatHash(finalState)
+				}
+			}
+		}
+	}
+
+	// CanBeEliminated for non-root tournaments.
+	if levelConsts.Level > 0 {
+		canElim, cErr := caller.CanBeEliminated(c.callOpts)
+		if cErr == nil {
+			result.CanBeEliminated = &canElim
+		}
+	}
+
+	return result, nil
+}
+
+// tournamentResult handles ArbitrationResult (root) or InnerTournamentWinner (non-root)
+// with TournamentFailedNoWinner revert detection.
+func (c *chainClient) tournamentResult(
+	caller *itournament.ITournamentCaller,
+	isRoot bool,
+) (finished bool, hasWinner bool, winner [32]byte, finalState [32]byte, err error) {
+	if !isRoot {
+		isFinished, _, winnerCommitment, _, iErr := caller.InnerTournamentWinner(c.callOpts)
+		if iErr != nil {
+			return false, false, [32]byte{}, [32]byte{}, iErr
+		}
+		return isFinished, isFinished && winnerCommitment != [32]byte{},
+			winnerCommitment, [32]byte{}, nil
+	}
+
+	result, err := caller.ArbitrationResult(c.callOpts)
+	if err != nil {
+		if info, ok := ethutil.ExtractJSONErrorInfo(err); ok && info.HasData {
+			if matchesSelector(info.Data, tournamentFailedNoWinner) {
+				return true, false, [32]byte{}, [32]byte{}, nil
+			}
+		}
+		return false, false, [32]byte{}, [32]byte{}, err
+	}
+	hasWin := result.WinnerCommitment != [32]byte{}
+	return result.Finished, hasWin, result.WinnerCommitment, result.FinalState, nil
+}
+
+// commitmentRegistry maps commitment hashes to submitter addresses.
+type commitmentRegistry map[[32]byte]common.Address
+
+func (r commitmentRegistry) resolve(commitment [32]byte) string {
+	if addr, ok := r[commitment]; ok {
+		return addr.Hex()
+	}
+	return ""
+}
+
+// tournamentEvents holds raw event data from a single tournament.
+type tournamentEvents struct {
+	commitmentsJoined []rawCommitmentJoined
+	matchesCreated    []rawMatchCreated
+	matchesAdvanced   []rawMatchAdvanced
+	matchesDeleted    []rawMatchDeleted
+}
+
+type rawCommitmentJoined struct {
+	commitment     [32]byte
+	finalStateHash [32]byte
+	submitter      common.Address
+	blockNumber    uint64
+	txHash         common.Hash
+}
+
+type rawMatchCreated struct {
+	matchIDHash [32]byte
+	one         [32]byte
+	two         [32]byte
+	leftOfTwo   [32]byte
+	blockNumber uint64
+	txHash      common.Hash
+}
+
+type rawMatchAdvanced struct {
+	matchIDHash [32]byte
+	otherParent [32]byte
+	leftNode    [32]byte
+	blockNumber uint64
+	txHash      common.Hash
+}
+
+type rawMatchDeleted struct {
+	matchIDHash      [32]byte
+	one              [32]byte
+	two              [32]byte
+	reason           uint8
+	winnerCommitment uint8
+	blockNumber      uint64
+	txHash           common.Hash
+}
+
+// fetchTournamentEvents retrieves events using FindTransitions per counter.
+func (c *chainClient) fetchTournamentEvents(
+	addr common.Address,
+	fromBlock uint64,
+) (*tournamentEvents, error) {
+	caller, err := itournament.NewITournamentCaller(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind ITournament caller: %w", err)
+	}
+	filterer, err := itournament.NewITournamentFilterer(addr, c.eth)
+	if err != nil {
+		return nil, fmt.Errorf("bind ITournament filterer: %w", err)
+	}
+
+	events := &tournamentEvents{}
+	limit := tournamentLimitFlag
+
+	// CommitmentJoined
+	if err := c.findAndCollectEvents(addr, fromBlock, "CommitmentJoined",
+		func(ctx context.Context, block uint64) (*big.Int, error) {
+			opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+			return caller.GetCommitmentJoinedCount(opts)
+		},
+		func(log *types.Log) (bool, error) {
+			if limit > 0 && len(events.commitmentsJoined) >= limit {
+				return true, nil
+			}
+			ev, pErr := filterer.ParseCommitmentJoined(*log)
+			if pErr != nil {
+				return false, pErr
+			}
+			events.commitmentsJoined = append(events.commitmentsJoined, rawCommitmentJoined{
+				commitment:     ev.Commitment,
+				finalStateHash: ev.FinalStateHash,
+				submitter:      ev.Submitter,
+				blockNumber:    log.BlockNumber,
+				txHash:         log.TxHash,
+			})
+			return false, nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	// MatchCreated
+	if err := c.findAndCollectEvents(addr, fromBlock, "MatchCreated",
+		func(ctx context.Context, block uint64) (*big.Int, error) {
+			opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+			return caller.GetMatchCreatedCount(opts)
+		},
+		func(log *types.Log) (bool, error) {
+			if limit > 0 && len(events.matchesCreated) >= limit {
+				return true, nil
+			}
+			ev, pErr := filterer.ParseMatchCreated(*log)
+			if pErr != nil {
+				return false, pErr
+			}
+			events.matchesCreated = append(events.matchesCreated, rawMatchCreated{
+				matchIDHash: ev.MatchIdHash,
+				one:         ev.One,
+				two:         ev.Two,
+				leftOfTwo:   ev.LeftOfTwo,
+				blockNumber: log.BlockNumber,
+				txHash:      log.TxHash,
+			})
+			return false, nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	// MatchAdvanced
+	if err := c.findAndCollectEvents(addr, fromBlock, "MatchAdvanced",
+		func(ctx context.Context, block uint64) (*big.Int, error) {
+			opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+			return caller.GetMatchAdvancedCount(opts)
+		},
+		func(log *types.Log) (bool, error) {
+			if limit > 0 && len(events.matchesAdvanced) >= limit {
+				return true, nil
+			}
+			ev, pErr := filterer.ParseMatchAdvanced(*log)
+			if pErr != nil {
+				return false, pErr
+			}
+			events.matchesAdvanced = append(events.matchesAdvanced, rawMatchAdvanced{
+				matchIDHash: ev.MatchIdHash,
+				otherParent: ev.OtherParent,
+				leftNode:    ev.LeftNode,
+				blockNumber: log.BlockNumber,
+				txHash:      log.TxHash,
+			})
+			return false, nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	// MatchDeleted
+	if err := c.findAndCollectEvents(addr, fromBlock, "MatchDeleted",
+		func(ctx context.Context, block uint64) (*big.Int, error) {
+			opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+			return caller.GetMatchDeletedCount(opts)
+		},
+		func(log *types.Log) (bool, error) {
+			if limit > 0 && len(events.matchesDeleted) >= limit {
+				return true, nil
+			}
+			ev, pErr := filterer.ParseMatchDeleted(*log)
+			if pErr != nil {
+				return false, pErr
+			}
+			events.matchesDeleted = append(events.matchesDeleted, rawMatchDeleted{
+				matchIDHash:      ev.MatchIdHash,
+				one:              ev.One,
+				two:              ev.Two,
+				reason:           ev.Reason,
+				winnerCommitment: ev.WinnerCommitment,
+				blockNumber:      log.BlockNumber,
+				txHash:           log.TxHash,
+			})
+			return false, nil
+		},
+	); err != nil {
+		return nil, err
+	}
+
+	return events, nil
+}
+
+// findAndCollectEvents uses FindTransitions to discover transition blocks,
+// then queries and processes events at each block. Processing stops when
+// the process callback returns done=true.
+func (c *chainClient) findAndCollectEvents(
+	addr common.Address,
+	fromBlock uint64,
+	eventName string,
+	oracle ethutil.TransitionQueryFn,
+	process func(*types.Log) (done bool, err error),
+) error {
+	onHit := func(block uint64) error {
+		q, qErr := buildEventFilterQuery(
+			addr, eventName, itournament.ITournamentMetaData, block, block,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		itr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, q)
+		if fErr != nil {
+			return fErr
+		}
+		for log, logErr := range itr {
+			if logErr != nil {
+				return logErr
+			}
+			done, pErr := process(log)
+			if pErr != nil {
+				return pErr
+			}
+			if done {
+				return errLimitReached
+			}
+		}
+		return nil
+	}
+
+	// Wrap oracle to handle contracts that don't exist at fromBlock yet
+	// (e.g., inner tournaments created after the DaveConsensus deploy block).
+	safeOracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		val, oErr := oracle(ctx, block)
+		if oErr != nil && errors.Is(oErr, bind.ErrNoCode) {
+			return big.NewInt(0), nil
+		}
+		return val, oErr
+	}
+
+	_, err := ethutil.FindTransitions(
+		c.callOpts.Context, fromBlock, c.blockNum, big.NewInt(0), safeOracle, onHit,
+	)
+	if err != nil && !errors.Is(err, errLimitReached) {
+		return fmt.Errorf("find %s transitions: %w", eventName, err)
+	}
+	return nil
+}
+
+// tournamentTree holds the BFS traversal result.
+type tournamentTree struct {
+	root     *TournamentResult
+	nodes    []*TournamentResult
+	children map[common.Address][]*TournamentResult
+	registry commitmentRegistry
+}
+
+// walkTournamentTree performs BFS across the tournament hierarchy.
+func (c *chainClient) walkTournamentTree(
+	rootAddr common.Address,
+	fromBlock uint64,
+	includeEvents bool,
+) (*tournamentTree, error) {
+	tree := &tournamentTree{
+		children: make(map[common.Address][]*TournamentResult),
+		registry: make(commitmentRegistry),
+	}
+
+	type queueItem struct {
+		addr   common.Address
+		parent *common.Address
+	}
+
+	queue := []queueItem{{addr: rootAddr}}
+	visited := make(map[common.Address]bool)
+	maxNodes := tournamentMaxNodesFlag
+
+	for len(queue) > 0 && len(tree.nodes) < maxNodes {
+		item := queue[0]
+		queue[0] = queueItem{} // avoid retaining references in the backing array
+		queue = queue[1:]
+
+		if visited[item.addr] {
+			continue
+		}
+		visited[item.addr] = true
+
+		info, err := c.queryTournament(item.addr)
+		if err != nil {
+			return nil, fmt.Errorf("query tournament %s: %w", item.addr, err)
+		}
+
+		if includeEvents {
+			events, eErr := c.fetchTournamentEvents(item.addr, fromBlock)
+			if eErr != nil {
+				slog.Warn("failed to fetch events", "tournament", item.addr, "error", eErr)
+			} else {
+				for _, cj := range events.commitmentsJoined {
+					tree.registry[cj.commitment] = cj.submitter
+				}
+				info.Commitments = formatCommitmentEvents(events.commitmentsJoined)
+				info.Matches = formatMatchEvents(
+					events.matchesCreated, events.matchesDeleted, tree.registry)
+				info.Advances = formatAdvanceEvents(events.matchesAdvanced)
+			}
+		}
+
+		tree.nodes = append(tree.nodes, info)
+		if tree.root == nil {
+			tree.root = info
+		}
+		if item.parent != nil {
+			tree.children[*item.parent] = append(tree.children[*item.parent], info)
+		}
+
+		// Discover child tournaments.
+		if info.Level < info.MaxLevel && info.InnerTournaments > 0 {
+			children, dErr := c.discoverChildTournaments(item.addr, fromBlock)
+			if dErr != nil {
+				slog.Warn("failed to discover children", "tournament", item.addr, "error", dErr)
+				continue
+			}
+			for _, child := range children {
+				parentAddr := item.addr
+				queue = append(queue, queueItem{addr: child, parent: &parentAddr})
+			}
+		}
+	}
+
+	if len(queue) > 0 {
+		slog.Warn("tournament tree truncated",
+			"max_nodes", maxNodes, "remaining_in_queue", len(queue))
+	}
+
+	// Second pass: annotate winner addresses and populate Children.
+	for _, node := range tree.nodes {
+		if node.WinnerCommitment != "" {
+			winnerHash := common.HexToHash(node.WinnerCommitment)
+			node.WinnerAddress = tree.registry.resolve([32]byte(winnerHash))
+		}
+		addr := common.HexToAddress(node.Address)
+		if kids, ok := tree.children[addr]; ok {
+			node.Children = kids
+		}
+	}
+
+	return tree, nil
+}
+
+// discoverChildTournaments uses FindTransitions with GetNewInnerTournamentCount.
+func (c *chainClient) discoverChildTournaments(
+	tournamentAddr common.Address,
+	fromBlock uint64,
+) ([]common.Address, error) {
+	caller, err := itournament.NewITournamentCaller(tournamentAddr, c.eth)
+	if err != nil {
+		return nil, err
+	}
+	filterer, err := itournament.NewITournamentFilterer(tournamentAddr, c.eth)
+	if err != nil {
+		return nil, err
+	}
+
+	var children []common.Address
+
+	oracle := func(ctx context.Context, block uint64) (*big.Int, error) {
+		opts := &bind.CallOpts{Context: ctx, BlockNumber: new(big.Int).SetUint64(block)}
+		return caller.GetNewInnerTournamentCount(opts)
+	}
+
+	onHit := func(block uint64) error {
+		q, qErr := buildEventFilterQuery(
+			tournamentAddr, "NewInnerTournament",
+			itournament.ITournamentMetaData, block, block,
+		)
+		if qErr != nil {
+			return qErr
+		}
+		itr, fErr := c.filter.ChunkedFilterLogs(c.callOpts.Context, c.eth, q)
+		if fErr != nil {
+			return fmt.Errorf("filter NewInnerTournament at block %d: %w", block, fErr)
+		}
+		for log, logErr := range itr {
+			if logErr != nil {
+				return logErr
+			}
+			ev, pErr := filterer.ParseNewInnerTournament(*log)
+			if pErr != nil {
+				return pErr
+			}
+			children = append(children, ev.ChildTournament)
+		}
+		return nil
+	}
+
+	_, err = ethutil.FindTransitions(
+		c.callOpts.Context, fromBlock, c.blockNum, big.NewInt(0), oracle, onHit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("find child tournament transitions: %w", err)
+	}
+	return children, nil
+}
+
+// buildEventFilterQuery constructs a FilterQuery for the named event.
+// Each indexedTopic corresponds to an indexed event parameter in order.
+// Use nil for a wildcard (match any value at that position).
+func buildEventFilterQuery(
+	contractAddr common.Address,
+	eventName string,
+	metaData *bind.MetaData,
+	fromBlock, toBlock uint64,
+	indexedTopics ...*common.Hash,
+) (ethereum.FilterQuery, error) {
+	contractABI, err := metaData.GetAbi()
+	if err != nil {
+		return ethereum.FilterQuery{}, fmt.Errorf("get ABI: %w", err)
+	}
+
+	ev, ok := contractABI.Events[eventName]
+	if !ok {
+		return ethereum.FilterQuery{}, fmt.Errorf("event %q not found in ABI", eventName)
+	}
+
+	topicSets := [][]any{{ev.ID}}
+	for _, t := range indexedTopics {
+		if t == nil {
+			topicSets = append(topicSets, nil)
+		} else {
+			topicSets = append(topicSets, []any{*t})
+		}
+	}
+
+	topics, err := abi.MakeTopics(topicSets...)
+	if err != nil {
+		return ethereum.FilterQuery{}, fmt.Errorf("make topics for %s: %w", eventName, err)
+	}
+
+	return ethereum.FilterQuery{
+		Addresses: []common.Address{contractAddr},
+		FromBlock: new(big.Int).SetUint64(fromBlock),
+		ToBlock:   new(big.Int).SetUint64(toBlock),
+		Topics:    topics,
+	}, nil
+}
+
+// Format helpers: convert raw events to JSON output types.
+
+func formatCommitmentEvents(raw []rawCommitmentJoined) []CommitmentEvent {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]CommitmentEvent, len(raw))
+	for i, r := range raw {
+		out[i] = CommitmentEvent{
+			Commitment:     formatHash(r.commitment),
+			FinalStateHash: formatHash(r.finalStateHash),
+			Submitter:      formatAddr(r.submitter),
+			BlockNumber:    r.blockNumber,
+			TxHash:         r.txHash.Hex(),
+		}
+	}
+	return out
+}
+
+func formatMatchEvents(
+	created []rawMatchCreated,
+	deleted []rawMatchDeleted,
+	registry commitmentRegistry,
+) []MatchEvent {
+	if len(created) == 0 {
+		return nil
+	}
+
+	// Build deletion map keyed by match ID hash.
+	deletionMap := make(map[[32]byte]rawMatchDeleted, len(deleted))
+	for _, d := range deleted {
+		deletionMap[d.matchIDHash] = d
+	}
+
+	out := make([]MatchEvent, len(created))
+	for i, r := range created {
+		me := MatchEvent{
+			MatchIDHash:   formatHash(r.matchIDHash),
+			CommitmentOne: formatHash(r.one),
+			CommitmentTwo: formatHash(r.two),
+			PlayerOneAddr: registry.resolve(r.one),
+			PlayerTwoAddr: registry.resolve(r.two),
+			LeftOfTwo:     formatHash(r.leftOfTwo),
+			BlockNumber:   r.blockNumber,
+			TxHash:        r.txHash.Hex(),
+		}
+
+		if d, ok := deletionMap[r.matchIDHash]; ok {
+			me.DeletionReason = matchDeletionReason(d.reason)
+			me.Winner = matchWinner(d.winnerCommitment)
+			block := d.blockNumber
+			me.DeletionBlock = &block
+			me.DeletionTxHash = d.txHash.Hex()
+
+			// Resolve winner address from commitment.
+			switch d.winnerCommitment {
+			case 1:
+				me.WinnerAddr = registry.resolve(d.one)
+			case 2: //nolint:mnd
+				me.WinnerAddr = registry.resolve(d.two)
+			}
+		}
+
+		out[i] = me
+	}
+	return out
+}
+
+func formatAdvanceEvents(raw []rawMatchAdvanced) []MatchAdvanceEvent {
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]MatchAdvanceEvent, len(raw))
+	for i, r := range raw {
+		out[i] = MatchAdvanceEvent{
+			MatchIDHash: formatHash(r.matchIDHash),
+			OtherParent: formatHash(r.otherParent),
+			LeftNode:    formatHash(r.leftNode),
+			BlockNumber: r.blockNumber,
+			TxHash:      r.txHash.Hex(),
+		}
+	}
+	return out
+}
+
+// Text output helpers.
+
+func printTournamentBasic(p *printer, r *TournamentResult) {
+	levelName := "Root"
+	if r.Level == r.MaxLevel {
+		levelName = "Leaf"
+	} else if r.Level > 0 {
+		levelName = "Inner"
+	}
+
+	p.withSection(fmt.Sprintf("%s Tournament  %s  (level %d/%d)",
+		levelName, r.Address, r.Level, r.MaxLevel), func() {
+		p.field("Status", tournamentStatus(r.Closed, r.Finished))
+		if r.Finished && r.FinishedAtBlock != nil {
+			p.field("Finished", fmt.Sprintf("yes (block %d)", *r.FinishedAtBlock))
+		}
+		if r.HasWinner != nil {
+			if *r.HasWinner {
+				winInfo := r.WinnerCommitment
+				if r.WinnerAddress != "" {
+					winInfo += fmt.Sprintf("  (%s)", r.WinnerAddress)
+				}
+				p.field("Winner", winInfo)
+				if r.FinalMachineHash != "" {
+					p.field("Final Machine Hash", r.FinalMachineHash)
+				}
+			} else {
+				p.field("Winner", "NONE (all commitments eliminated)")
+			}
+		}
+		p.field("Bond", r.BondETH)
+		p.field("Commitments Joined", fmt.Sprintf("%d", r.CommitmentsJoined))
+		p.field("Matches Created", fmt.Sprintf("%d", r.MatchesCreated))
+		p.field("Matches Advanced", fmt.Sprintf("%d", r.MatchesAdvanced))
+		p.field("Matches Deleted", fmt.Sprintf("%d", r.MatchesDeleted))
+		p.field("Inner Tournaments", fmt.Sprintf("%d", r.InnerTournaments))
+		if r.CanBeEliminated != nil {
+			p.field("Can Be Eliminated", fmt.Sprintf("%t", *r.CanBeEliminated))
+		}
+	})
+}
+
+func printTournamentEvents(p *printer, r *TournamentResult) {
+	if len(r.Commitments) > 0 {
+		p.withSection("Commitments Joined:", func() {
+			for i, c := range r.Commitments {
+				p.withSection(fmt.Sprintf("[%d] Commitment  %s", i+1, c.Commitment), func() {
+					p.field("Submitter", c.Submitter)
+					p.field("Final State", c.FinalStateHash)
+					p.field("Block", fmt.Sprintf("%d", c.BlockNumber))
+					p.field("Tx", c.TxHash)
+				})
+			}
+		})
+	}
+
+	if len(r.Matches) > 0 {
+		p.withSection("Matches:", func() {
+			for i, m := range r.Matches {
+				p.withSection(fmt.Sprintf("[%d] Match  %s", i+1, m.MatchIDHash), func() {
+					oneInfo := m.CommitmentOne
+					if m.PlayerOneAddr != "" {
+						oneInfo += fmt.Sprintf("  (%s)", m.PlayerOneAddr)
+					}
+					p.field("Player One", oneInfo)
+					twoInfo := m.CommitmentTwo
+					if m.PlayerTwoAddr != "" {
+						twoInfo += fmt.Sprintf("  (%s)", m.PlayerTwoAddr)
+					}
+					p.field("Player Two", twoInfo)
+					p.field("Block", fmt.Sprintf("%d", m.BlockNumber))
+					p.field("Tx", m.TxHash)
+					if m.DeletionReason != "" {
+						p.field("Outcome", fmt.Sprintf("%s → %s", m.DeletionReason, m.Winner))
+						if m.WinnerAddr != "" {
+							p.field("Winner Address", m.WinnerAddr)
+						}
+					}
+				})
+			}
+		})
+	}
+
+	if len(r.Advances) > 0 {
+		p.withSection("Match Advances:", func() {
+			for i, a := range r.Advances {
+				p.withSection(fmt.Sprintf("[%d] Match  %s", i+1, a.MatchIDHash), func() {
+					p.field("Block", fmt.Sprintf("%d", a.BlockNumber))
+					p.field("Tx", a.TxHash)
+				})
+			}
+		})
+	}
+}
+
+func renderTournamentTree(
+	p *printer,
+	root *TournamentResult,
+	tree *tournamentTree,
+	depth int,
+) {
+	prefix := ""
+	if depth > 0 {
+		prefix = strings.Repeat("\t", depth-1) + "└─ "
+	}
+
+	levelName := "Root"
+	if root.Level == root.MaxLevel {
+		levelName = "Leaf"
+	} else if root.Level > 0 {
+		levelName = "Inner"
+	}
+
+	if depth > 0 {
+		fmt.Fprintf(p.w, "\n")
+	}
+	fmt.Fprintf(p.w, "%s%s Tournament  %s  (level %d/%d)\n",
+		prefix, levelName, root.Address,
+		root.Level, root.MaxLevel)
+
+	indent := strings.Repeat("\t", depth+1)
+	fmt.Fprintf(p.w, "%sStatus               %s\n",
+		indent, tournamentStatus(root.Closed, root.Finished))
+
+	if root.Finished && root.FinishedAtBlock != nil {
+		fmt.Fprintf(p.w, "%sFinished             yes (block %d)\n",
+			indent, *root.FinishedAtBlock)
+	}
+	if root.HasWinner != nil {
+		if *root.HasWinner {
+			winInfo := root.WinnerCommitment
+			if root.WinnerAddress != "" {
+				winInfo += fmt.Sprintf("  (%s)", root.WinnerAddress)
+			}
+			fmt.Fprintf(p.w, "%sWinner               %s\n", indent, winInfo)
+		} else {
+			fmt.Fprintf(p.w, "%sWinner               NONE (all commitments eliminated)\n", indent)
+		}
+	}
+	fmt.Fprintf(p.w,
+		"%sCommitments: %d  |  Matches: %d created, %d advanced, %d deleted  |  Inner: %d\n",
+		indent, root.CommitmentsJoined, root.MatchesCreated,
+		root.MatchesAdvanced, root.MatchesDeleted, root.InnerTournaments)
+
+	// Recurse into children.
+	addr := common.HexToAddress(root.Address)
+	for _, child := range tree.children[addr] {
+		renderTournamentTree(p, child, tree, depth+1)
+	}
+}

--- a/cmd/cartesi-rollups-cli/root/contract/tournament_test.go
+++ b/cmd/cartesi-rollups-cli/root/contract/tournament_test.go
@@ -1,0 +1,211 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommitmentRegistryResolve(t *testing.T) {
+	addr := common.HexToAddress("0xABCDEF0000000000000000000000000000000001")
+	commitment := [32]byte{0x01, 0x02, 0x03}
+
+	registry := make(commitmentRegistry)
+	registry[commitment] = addr
+
+	// Known key returns address.
+	got := registry.resolve(commitment)
+	assert.Equal(t, addr.Hex(), got)
+
+	// Unknown key returns empty string.
+	unknown := [32]byte{0xFF}
+	assert.Equal(t, "", registry.resolve(unknown))
+
+	// Empty registry returns empty string.
+	empty := make(commitmentRegistry)
+	assert.Equal(t, "", empty.resolve(commitment))
+}
+
+func TestFormatCommitmentEvents(t *testing.T) {
+	// Empty input returns nil.
+	assert.Nil(t, formatCommitmentEvents(nil))
+	assert.Nil(t, formatCommitmentEvents([]rawCommitmentJoined{}))
+
+	raw := []rawCommitmentJoined{
+		{
+			commitment:     [32]byte{0xAA},
+			finalStateHash: [32]byte{0xBB},
+			submitter:      common.HexToAddress("0x1111111111111111111111111111111111111111"),
+			blockNumber:    100,
+			txHash:         common.HexToHash("0xCC"),
+		},
+		{
+			commitment:     [32]byte{0xDD},
+			finalStateHash: [32]byte{0xEE},
+			submitter:      common.HexToAddress("0x2222222222222222222222222222222222222222"),
+			blockNumber:    200,
+			txHash:         common.HexToHash("0xFF"),
+		},
+	}
+
+	result := formatCommitmentEvents(raw)
+	assert.Len(t, result, 2)
+	assert.Equal(t, formatHash(raw[0].commitment), result[0].Commitment)
+	assert.Equal(t, formatHash(raw[0].finalStateHash), result[0].FinalStateHash)
+	assert.Equal(t, "0x1111111111111111111111111111111111111111", result[0].Submitter)
+	assert.Equal(t, uint64(100), result[0].BlockNumber)
+	assert.Equal(t, raw[0].txHash.Hex(), result[0].TxHash)
+
+	assert.Equal(t, formatHash(raw[1].commitment), result[1].Commitment)
+	assert.Equal(t, uint64(200), result[1].BlockNumber)
+}
+
+func TestFormatMatchEvents(t *testing.T) {
+	// Empty input returns nil.
+	assert.Nil(t, formatMatchEvents(nil, nil, nil))
+	assert.Nil(t, formatMatchEvents([]rawMatchCreated{}, nil, nil))
+
+	commitOne := [32]byte{0x01}
+	commitTwo := [32]byte{0x02}
+	matchID := [32]byte{0xAA}
+	matchID2 := [32]byte{0xBB}
+
+	registry := make(commitmentRegistry)
+	registry[commitOne] = common.HexToAddress("0x1111111111111111111111111111111111111111")
+	registry[commitTwo] = common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	created := []rawMatchCreated{
+		{
+			matchIDHash: matchID,
+			one:         commitOne,
+			two:         commitTwo,
+			leftOfTwo:   [32]byte{0x33},
+			blockNumber: 100,
+			txHash:      common.HexToHash("0xC1"),
+		},
+		{
+			matchIDHash: matchID2,
+			one:         commitOne,
+			two:         [32]byte{0x99}, // unknown in registry
+			leftOfTwo:   [32]byte{0x44},
+			blockNumber: 200,
+			txHash:      common.HexToHash("0xC2"),
+		},
+	}
+
+	deleted := []rawMatchDeleted{
+		{
+			matchIDHash:      matchID,
+			one:              commitOne,
+			two:              commitTwo,
+			reason:           1, // TIMEOUT
+			winnerCommitment: 1, // ONE
+			blockNumber:      150,
+			txHash:           common.HexToHash("0xD1"),
+		},
+	}
+
+	result := formatMatchEvents(created, deleted, registry)
+	assert.Len(t, result, 2)
+
+	// First match: has deletion info.
+	m0 := result[0]
+	assert.Equal(t, formatHash(matchID), m0.MatchIDHash)
+	assert.Equal(t, "0x1111111111111111111111111111111111111111", m0.PlayerOneAddr)
+	assert.Equal(t, "0x2222222222222222222222222222222222222222", m0.PlayerTwoAddr)
+	assert.Equal(t, "TIMEOUT", m0.DeletionReason)
+	assert.Equal(t, "ONE", m0.Winner)
+	assert.NotNil(t, m0.DeletionBlock)
+	assert.Equal(t, uint64(150), *m0.DeletionBlock)
+	// Winner is player ONE -> resolve commitOne.
+	assert.Equal(t, "0x1111111111111111111111111111111111111111", m0.WinnerAddr)
+
+	// Second match: no deletion.
+	m1 := result[1]
+	assert.Equal(t, formatHash(matchID2), m1.MatchIDHash)
+	assert.Equal(t, "0x1111111111111111111111111111111111111111", m1.PlayerOneAddr)
+	assert.Equal(t, "", m1.PlayerTwoAddr) // unknown commitment
+	assert.Equal(t, "", m1.DeletionReason)
+	assert.Nil(t, m1.DeletionBlock)
+}
+
+func TestFormatMatchEventsWinnerTwo(t *testing.T) {
+	commitOne := [32]byte{0x01}
+	commitTwo := [32]byte{0x02}
+	matchID := [32]byte{0xAA}
+
+	registry := make(commitmentRegistry)
+	registry[commitOne] = common.HexToAddress("0x1111111111111111111111111111111111111111")
+	registry[commitTwo] = common.HexToAddress("0x2222222222222222222222222222222222222222")
+
+	created := []rawMatchCreated{
+		{matchIDHash: matchID, one: commitOne, two: commitTwo, blockNumber: 100},
+	}
+	deleted := []rawMatchDeleted{
+		{matchIDHash: matchID, one: commitOne, two: commitTwo,
+			reason: 2, winnerCommitment: 2, blockNumber: 200},
+	}
+
+	result := formatMatchEvents(created, deleted, registry)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "TWO", result[0].Winner)
+	assert.Equal(t, "0x2222222222222222222222222222222222222222", result[0].WinnerAddr)
+	assert.Equal(t, "CHILD_TOURNAMENT", result[0].DeletionReason)
+}
+
+func TestFormatMatchEventsNoWinner(t *testing.T) {
+	matchID := [32]byte{0xAA}
+	commitOne := [32]byte{0x01}
+	commitTwo := [32]byte{0x02}
+
+	created := []rawMatchCreated{
+		{matchIDHash: matchID, one: commitOne, two: commitTwo, blockNumber: 100},
+	}
+	deleted := []rawMatchDeleted{
+		{matchIDHash: matchID, one: commitOne, two: commitTwo,
+			reason: 0, winnerCommitment: 0, blockNumber: 200},
+	}
+
+	result := formatMatchEvents(created, deleted, nil)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "NONE (both eliminated)", result[0].Winner)
+	assert.Equal(t, "STEP (on-chain proof)", result[0].DeletionReason)
+	assert.Equal(t, "", result[0].WinnerAddr) // winner=0 -> no resolution
+}
+
+func TestFormatAdvanceEvents(t *testing.T) {
+	// Empty input returns nil.
+	assert.Nil(t, formatAdvanceEvents(nil))
+	assert.Nil(t, formatAdvanceEvents([]rawMatchAdvanced{}))
+
+	raw := []rawMatchAdvanced{
+		{
+			matchIDHash: [32]byte{0xAA},
+			otherParent: [32]byte{0xBB},
+			leftNode:    [32]byte{0xCC},
+			blockNumber: 100,
+			txHash:      common.HexToHash("0xDD"),
+		},
+		{
+			matchIDHash: [32]byte{0xEE},
+			otherParent: [32]byte{0xFF},
+			leftNode:    [32]byte{0x11},
+			blockNumber: 200,
+			txHash:      common.HexToHash("0x22"),
+		},
+	}
+
+	result := formatAdvanceEvents(raw)
+	assert.Len(t, result, 2)
+	assert.Equal(t, formatHash(raw[0].matchIDHash), result[0].MatchIDHash)
+	assert.Equal(t, formatHash(raw[0].otherParent), result[0].OtherParent)
+	assert.Equal(t, formatHash(raw[0].leftNode), result[0].LeftNode)
+	assert.Equal(t, uint64(100), result[0].BlockNumber)
+	assert.Equal(t, raw[0].txHash.Hex(), result[0].TxHash)
+
+	assert.Equal(t, uint64(200), result[1].BlockNumber)
+}

--- a/cmd/cartesi-rollups-cli/root/contract/types.go
+++ b/cmd/cartesi-rollups-cli/root/contract/types.go
@@ -1,0 +1,212 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package contract
+
+import "encoding/json"
+
+// AppResult is the JSON output of "contract app".
+type AppResult struct {
+	Address          string `json:"address"`
+	Owner            string `json:"owner"`
+	TemplateHash     string `json:"template_hash"`
+	DeploymentBlock  uint64 `json:"deployment_block"`
+	ExecutedOutputs  uint64 `json:"executed_outputs"`
+	ConsensusAddress string `json:"consensus_address"`
+	ConsensusType    string `json:"consensus_type"`
+	DataAvailability string `json:"data_availability"`
+}
+
+// AuthorityConsensusResult is the JSON output for Authority consensus.
+type AuthorityConsensusResult struct {
+	Type            string `json:"type"`
+	Address         string `json:"address"`
+	Owner           string `json:"owner"`
+	EpochLength     uint64 `json:"epoch_length"`
+	AcceptedClaims  uint64 `json:"accepted_claims"`
+	ContractVersion string `json:"contract_version"`
+}
+
+// QuorumConsensusResult is the JSON output for Quorum consensus.
+type QuorumConsensusResult struct {
+	Type            string   `json:"type"`
+	Address         string   `json:"address"`
+	NumValidators   uint64   `json:"num_validators"`
+	QuorumThreshold uint64   `json:"quorum_threshold"`
+	Validators      []string `json:"validators"`
+	EpochLength     uint64   `json:"epoch_length"`
+	AcceptedClaims  uint64   `json:"accepted_claims"`
+}
+
+// DaveConsensusResult is the JSON output for DaveConsensus.
+// CurrentEpochNumber is the index of the currently sealed epoch (the one with an active
+// tournament). Epochs 0..CurrentEpochNumber-1 have been settled; epoch CurrentEpochNumber
+// is sealed but not yet settled.
+type DaveConsensusResult struct {
+	Type               string `json:"type"`
+	Address            string `json:"address"`
+	InputBox           string `json:"inputbox"`
+	Factory            string `json:"factory"`
+	DeploymentBlock    uint64 `json:"deployment_block"`
+	IsFinished         bool   `json:"is_finished"`
+	HasWinner          *bool  `json:"has_winner,omitempty"`
+	WinnerCommitment   string `json:"winner_commitment,omitempty"`
+	CurrentEpochNumber uint64 `json:"current_epoch_number"`
+	InputLowerBound    uint64 `json:"input_lower_bound"`
+	InputUpperBound    uint64 `json:"input_upper_bound"`
+	RootTournament     string `json:"root_tournament"`
+}
+
+// InputBoxResult is the JSON output for InputBox state.
+type InputBoxResult struct {
+	Address     string `json:"address,omitempty"`
+	TotalInputs uint64 `json:"total_inputs"`
+}
+
+// CommitmentEvent is a commitment joined event.
+type CommitmentEvent struct {
+	Commitment     string `json:"commitment"`
+	FinalStateHash string `json:"final_state_hash"`
+	Submitter      string `json:"submitter"`
+	BlockNumber    uint64 `json:"block_number"`
+	TxHash         string `json:"tx_hash"`
+}
+
+// MatchEvent is a match created event.
+type MatchEvent struct {
+	MatchIDHash    string  `json:"match_id_hash"`
+	CommitmentOne  string  `json:"commitment_one"`
+	CommitmentTwo  string  `json:"commitment_two"`
+	PlayerOneAddr  string  `json:"player_one_addr,omitempty"`
+	PlayerTwoAddr  string  `json:"player_two_addr,omitempty"`
+	LeftOfTwo      string  `json:"left_of_two"`
+	BlockNumber    uint64  `json:"block_number"`
+	TxHash         string  `json:"tx_hash"`
+	DeletionReason string  `json:"deletion_reason,omitempty"`
+	Winner         string  `json:"winner,omitempty"`
+	WinnerAddr     string  `json:"winner_addr,omitempty"`
+	DeletionBlock  *uint64 `json:"deletion_block,omitempty"`
+	DeletionTxHash string  `json:"deletion_tx_hash,omitempty"`
+}
+
+// MatchAdvanceEvent is a match advance (bisection step) event.
+type MatchAdvanceEvent struct {
+	MatchIDHash string `json:"match_id_hash"`
+	OtherParent string `json:"other_parent"`
+	LeftNode    string `json:"left_node"`
+	BlockNumber uint64 `json:"block_number"`
+	TxHash      string `json:"tx_hash"`
+}
+
+// TournamentResult is the JSON output for a tournament.
+type TournamentResult struct {
+	Address           string              `json:"address"`
+	Level             uint64              `json:"level"`
+	MaxLevel          uint64              `json:"max_level"`
+	Log2Step          uint64              `json:"log2step"`
+	Height            uint64              `json:"height"`
+	Closed            bool                `json:"closed"`
+	Finished          bool                `json:"finished"`
+	FinishedAtBlock   *uint64             `json:"finished_at_block,omitempty"`
+	HasWinner         *bool               `json:"has_winner,omitempty"`
+	WinnerCommitment  string              `json:"winner_commitment,omitempty"`
+	WinnerAddress     string              `json:"winner_address,omitempty"`
+	FinalMachineHash  string              `json:"final_machine_hash,omitempty"`
+	BondWei           string              `json:"bond_wei"`
+	BondETH           string              `json:"bond_eth"`
+	CommitmentsJoined uint64              `json:"commitments_joined"`
+	MatchesCreated    uint64              `json:"matches_created"`
+	MatchesAdvanced   uint64              `json:"matches_advanced"`
+	MatchesDeleted    uint64              `json:"matches_deleted"`
+	InnerTournaments  uint64              `json:"inner_tournaments"`
+	CanBeEliminated   *bool               `json:"can_be_eliminated,omitempty"`
+	Commitments       []CommitmentEvent   `json:"commitments,omitempty"`
+	Matches           []MatchEvent        `json:"matches,omitempty"`
+	Advances          []MatchAdvanceEvent `json:"advances,omitempty"`
+	Children          []*TournamentResult `json:"children,omitempty"`
+}
+
+// ClaimEvent is a claim event in the epoch history.
+type ClaimEvent struct {
+	EventType          string  `json:"event_type"`
+	BlockNumber        uint64  `json:"block_number"`
+	TxHash             string  `json:"tx_hash"`
+	Submitter          string  `json:"submitter,omitempty"`
+	LastProcessedBlock uint64  `json:"last_processed_block"`
+	OutputsMerkleRoot  string  `json:"outputs_merkle_root"`
+	OutputsRootValid   *bool   `json:"outputs_root_valid,omitempty"`
+	VotesForClaim      *uint64 `json:"votes_for_claim,omitempty"`
+	VotesNeeded        *uint64 `json:"votes_needed,omitempty"`
+}
+
+// EpochEvent is a single sealed epoch event (DaveConsensus).
+type EpochEvent struct {
+	EpochNumber        uint64 `json:"epoch_number"`
+	BlockNumber        uint64 `json:"block_number"`
+	TxHash             string `json:"tx_hash"`
+	InputLowerBound    uint64 `json:"input_lower_bound"`
+	InputUpperBound    uint64 `json:"input_upper_bound"`
+	InitialMachineHash string `json:"initial_machine_hash"`
+	OutputsMerkleRoot  string `json:"outputs_merkle_root"`
+	OutputsRootValid   *bool  `json:"outputs_root_valid,omitempty"`
+	Tournament         string `json:"tournament"`
+}
+
+// EpochHistory is the full epoch history output.
+type EpochHistory struct {
+	ConsensusType string       `json:"consensus_type"`
+	TemplateHash  string       `json:"template_hash,omitempty"`
+	Epochs        []EpochEvent `json:"epochs,omitempty"`
+	Claims        []ClaimEvent `json:"claims,omitempty"`
+}
+
+// SummaryResult is the JSON output of "contract summary".
+type SummaryResult struct {
+	Application     *AppResult        `json:"application,omitempty"`
+	AppError        string            `json:"app_error,omitempty"`
+	Consensus       json.RawMessage   `json:"consensus,omitempty"`
+	ConsensusError  string            `json:"consensus_error,omitempty"`
+	InputBox        *InputBoxResult   `json:"inputbox,omitempty"`
+	InputBoxError   string            `json:"inputbox_error,omitempty"`
+	RootTournament  *TournamentResult `json:"root_tournament,omitempty"`
+	TournamentError string            `json:"tournament_error,omitempty"`
+}
+
+// OutputResult is the JSON output for a single output execution check.
+type OutputResult struct {
+	OutputIndex uint64 `json:"output_index"`
+	Executed    bool   `json:"executed"`
+}
+
+// OutputBatchResult is the JSON output for batch output execution status.
+type OutputBatchResult struct {
+	TotalExecuted uint64         `json:"total_executed"`
+	Outputs       []OutputResult `json:"outputs,omitempty"`
+}
+
+// CommitmentResult is the JSON output for a commitment's on-chain state.
+type CommitmentResult struct {
+	Commitment       string `json:"commitment"`
+	Tournament       string `json:"tournament"`
+	TournamentLevel  string `json:"tournament_level"`
+	ClockAllowance   uint64 `json:"clock_allowance"`
+	ClockStartBlock  uint64 `json:"clock_start_block"`
+	FinalMachineHash string `json:"final_machine_hash"`
+}
+
+// MatchResult is the JSON output for a match's bisection state.
+type MatchResult struct {
+	MatchIDHash         string `json:"match_id_hash"`
+	Tournament          string `json:"tournament"`
+	CommitmentOne       string `json:"commitment_one"`
+	CommitmentTwo       string `json:"commitment_two"`
+	PlayerOneAddr       string `json:"player_one_addr,omitempty"`
+	PlayerTwoAddr       string `json:"player_two_addr,omitempty"`
+	CurrentHeight       uint64 `json:"current_height"`
+	RunningLeafPosition string `json:"running_leaf_position"`
+	MachineCycle        string `json:"machine_cycle"`
+	CanWinByTimeout     bool   `json:"can_win_by_timeout"`
+	LeftNode            string `json:"left_node"`
+	RightNode           string `json:"right_node"`
+	OtherParent         string `json:"other_parent"`
+}

--- a/cmd/cartesi-rollups-cli/root/root.go
+++ b/cmd/cartesi-rollups-cli/root/root.go
@@ -5,6 +5,7 @@ package root
 
 import (
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/app"
+	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/contract"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/db"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/deploy"
 	"github.com/cartesi/rollups-node/cmd/cartesi-rollups-cli/root/execute"
@@ -65,5 +66,6 @@ func init() {
 	Cmd.AddCommand(app.Cmd)
 	Cmd.AddCommand(db.Cmd)
 	Cmd.AddCommand(deploy.Cmd)
+	Cmd.AddCommand(contract.Cmd)
 	Cmd.DisableAutoGenTag = true
 }

--- a/pkg/contracts/generate/main.go
+++ b/pkg/contracts/generate/main.go
@@ -34,8 +34,16 @@ var bindings = []contractBinding{
 		typeName: "IAuthorityFactory",
 	},
 	{
+		jsonPath: rollupsContractsPath + "IAuthority.sol/IAuthority.json",
+		typeName: "IAuthority",
+	},
+	{
 		jsonPath: rollupsContractsPath + "IConsensus.sol/IConsensus.json",
 		typeName: "IConsensus",
+	},
+	{
+		jsonPath: rollupsContractsPath + "IQuorum.sol/IQuorum.json",
+		typeName: "IQuorum",
 	},
 	{
 		jsonPath: rollupsContractsPath + "IApplication.sol/IApplication.json",

--- a/pkg/contracts/iauthority/iauthority.go
+++ b/pkg/contracts/iauthority/iauthority.go
@@ -1,0 +1,700 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package iauthority
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IAuthorityMetaData contains all meta data concerning the IAuthority contract.
+var IAuthorityMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"getEpochLength\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNumberOfAcceptedClaims\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOutputsMerkleRootValid\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"owner\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"renounceOwnership\",\"inputs\":[],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"submitClaim\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"transferOwnership\",\"inputs\":[{\"name\":\"newOwner\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"event\",\"name\":\"ClaimAccepted\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ClaimSubmitted\",\"inputs\":[{\"name\":\"submitter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appContract\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"NotEpochFinalBlock\",\"inputs\":[{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"epochLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotFirstClaim\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotPastBlock\",\"inputs\":[{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}]",
+}
+
+// IAuthorityABI is the input ABI used to generate the binding from.
+// Deprecated: Use IAuthorityMetaData.ABI instead.
+var IAuthorityABI = IAuthorityMetaData.ABI
+
+// IAuthority is an auto generated Go binding around an Ethereum contract.
+type IAuthority struct {
+	IAuthorityCaller     // Read-only binding to the contract
+	IAuthorityTransactor // Write-only binding to the contract
+	IAuthorityFilterer   // Log filterer for contract events
+}
+
+// IAuthorityCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IAuthorityCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAuthorityTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IAuthorityTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAuthorityFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IAuthorityFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IAuthoritySession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IAuthoritySession struct {
+	Contract     *IAuthority       // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IAuthorityCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IAuthorityCallerSession struct {
+	Contract *IAuthorityCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts     // Call options to use throughout this session
+}
+
+// IAuthorityTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IAuthorityTransactorSession struct {
+	Contract     *IAuthorityTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts     // Transaction auth options to use throughout this session
+}
+
+// IAuthorityRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IAuthorityRaw struct {
+	Contract *IAuthority // Generic contract binding to access the raw methods on
+}
+
+// IAuthorityCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IAuthorityCallerRaw struct {
+	Contract *IAuthorityCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IAuthorityTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IAuthorityTransactorRaw struct {
+	Contract *IAuthorityTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIAuthority creates a new instance of IAuthority, bound to a specific deployed contract.
+func NewIAuthority(address common.Address, backend bind.ContractBackend) (*IAuthority, error) {
+	contract, err := bindIAuthority(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthority{IAuthorityCaller: IAuthorityCaller{contract: contract}, IAuthorityTransactor: IAuthorityTransactor{contract: contract}, IAuthorityFilterer: IAuthorityFilterer{contract: contract}}, nil
+}
+
+// NewIAuthorityCaller creates a new read-only instance of IAuthority, bound to a specific deployed contract.
+func NewIAuthorityCaller(address common.Address, caller bind.ContractCaller) (*IAuthorityCaller, error) {
+	contract, err := bindIAuthority(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthorityCaller{contract: contract}, nil
+}
+
+// NewIAuthorityTransactor creates a new write-only instance of IAuthority, bound to a specific deployed contract.
+func NewIAuthorityTransactor(address common.Address, transactor bind.ContractTransactor) (*IAuthorityTransactor, error) {
+	contract, err := bindIAuthority(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthorityTransactor{contract: contract}, nil
+}
+
+// NewIAuthorityFilterer creates a new log filterer instance of IAuthority, bound to a specific deployed contract.
+func NewIAuthorityFilterer(address common.Address, filterer bind.ContractFilterer) (*IAuthorityFilterer, error) {
+	contract, err := bindIAuthority(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthorityFilterer{contract: contract}, nil
+}
+
+// bindIAuthority binds a generic wrapper to an already deployed contract.
+func bindIAuthority(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IAuthorityMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IAuthority *IAuthorityRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IAuthority.Contract.IAuthorityCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IAuthority *IAuthorityRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IAuthority.Contract.IAuthorityTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IAuthority *IAuthorityRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IAuthority.Contract.IAuthorityTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IAuthority *IAuthorityCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IAuthority.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IAuthority *IAuthorityTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IAuthority.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IAuthority *IAuthorityTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IAuthority.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IAuthority *IAuthorityCaller) GetEpochLength(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _IAuthority.contract.Call(opts, &out, "getEpochLength")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IAuthority *IAuthoritySession) GetEpochLength() (*big.Int, error) {
+	return _IAuthority.Contract.GetEpochLength(&_IAuthority.CallOpts)
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IAuthority *IAuthorityCallerSession) GetEpochLength() (*big.Int, error) {
+	return _IAuthority.Contract.GetEpochLength(&_IAuthority.CallOpts)
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IAuthority *IAuthorityCaller) GetNumberOfAcceptedClaims(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _IAuthority.contract.Call(opts, &out, "getNumberOfAcceptedClaims")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IAuthority *IAuthoritySession) GetNumberOfAcceptedClaims() (*big.Int, error) {
+	return _IAuthority.Contract.GetNumberOfAcceptedClaims(&_IAuthority.CallOpts)
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IAuthority *IAuthorityCallerSession) GetNumberOfAcceptedClaims() (*big.Int, error) {
+	return _IAuthority.Contract.GetNumberOfAcceptedClaims(&_IAuthority.CallOpts)
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IAuthority *IAuthorityCaller) IsOutputsMerkleRootValid(opts *bind.CallOpts, appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	var out []interface{}
+	err := _IAuthority.contract.Call(opts, &out, "isOutputsMerkleRootValid", appContract, outputsMerkleRoot)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IAuthority *IAuthoritySession) IsOutputsMerkleRootValid(appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	return _IAuthority.Contract.IsOutputsMerkleRootValid(&_IAuthority.CallOpts, appContract, outputsMerkleRoot)
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IAuthority *IAuthorityCallerSession) IsOutputsMerkleRootValid(appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	return _IAuthority.Contract.IsOutputsMerkleRootValid(&_IAuthority.CallOpts, appContract, outputsMerkleRoot)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IAuthority *IAuthorityCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _IAuthority.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IAuthority *IAuthoritySession) Owner() (common.Address, error) {
+	return _IAuthority.Contract.Owner(&_IAuthority.CallOpts)
+}
+
+// Owner is a free data retrieval call binding the contract method 0x8da5cb5b.
+//
+// Solidity: function owner() view returns(address)
+func (_IAuthority *IAuthorityCallerSession) Owner() (common.Address, error) {
+	return _IAuthority.Contract.Owner(&_IAuthority.CallOpts)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IAuthority *IAuthorityCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IAuthority.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IAuthority *IAuthoritySession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IAuthority.Contract.SupportsInterface(&_IAuthority.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IAuthority *IAuthorityCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IAuthority.Contract.SupportsInterface(&_IAuthority.CallOpts, interfaceId)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_IAuthority *IAuthorityTransactor) RenounceOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IAuthority.contract.Transact(opts, "renounceOwnership")
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_IAuthority *IAuthoritySession) RenounceOwnership() (*types.Transaction, error) {
+	return _IAuthority.Contract.RenounceOwnership(&_IAuthority.TransactOpts)
+}
+
+// RenounceOwnership is a paid mutator transaction binding the contract method 0x715018a6.
+//
+// Solidity: function renounceOwnership() returns()
+func (_IAuthority *IAuthorityTransactorSession) RenounceOwnership() (*types.Transaction, error) {
+	return _IAuthority.Contract.RenounceOwnership(&_IAuthority.TransactOpts)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IAuthority *IAuthorityTransactor) SubmitClaim(opts *bind.TransactOpts, appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IAuthority.contract.Transact(opts, "submitClaim", appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IAuthority *IAuthoritySession) SubmitClaim(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IAuthority.Contract.SubmitClaim(&_IAuthority.TransactOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IAuthority *IAuthorityTransactorSession) SubmitClaim(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IAuthority.Contract.SubmitClaim(&_IAuthority.TransactOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IAuthority *IAuthorityTransactor) TransferOwnership(opts *bind.TransactOpts, newOwner common.Address) (*types.Transaction, error) {
+	return _IAuthority.contract.Transact(opts, "transferOwnership", newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IAuthority *IAuthoritySession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _IAuthority.Contract.TransferOwnership(&_IAuthority.TransactOpts, newOwner)
+}
+
+// TransferOwnership is a paid mutator transaction binding the contract method 0xf2fde38b.
+//
+// Solidity: function transferOwnership(address newOwner) returns()
+func (_IAuthority *IAuthorityTransactorSession) TransferOwnership(newOwner common.Address) (*types.Transaction, error) {
+	return _IAuthority.Contract.TransferOwnership(&_IAuthority.TransactOpts, newOwner)
+}
+
+// IAuthorityClaimAcceptedIterator is returned from FilterClaimAccepted and is used to iterate over the raw logs and unpacked data for ClaimAccepted events raised by the IAuthority contract.
+type IAuthorityClaimAcceptedIterator struct {
+	Event *IAuthorityClaimAccepted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IAuthorityClaimAcceptedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IAuthorityClaimAccepted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IAuthorityClaimAccepted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IAuthorityClaimAcceptedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IAuthorityClaimAcceptedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IAuthorityClaimAccepted represents a ClaimAccepted event raised by the IAuthority contract.
+type IAuthorityClaimAccepted struct {
+	AppContract              common.Address
+	LastProcessedBlockNumber *big.Int
+	OutputsMerkleRoot        [32]byte
+	Raw                      types.Log // Blockchain specific contextual infos
+}
+
+// FilterClaimAccepted is a free log retrieval operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) FilterClaimAccepted(opts *bind.FilterOpts, appContract []common.Address) (*IAuthorityClaimAcceptedIterator, error) {
+
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IAuthority.contract.FilterLogs(opts, "ClaimAccepted", appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthorityClaimAcceptedIterator{contract: _IAuthority.contract, event: "ClaimAccepted", logs: logs, sub: sub}, nil
+}
+
+// WatchClaimAccepted is a free log subscription operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) WatchClaimAccepted(opts *bind.WatchOpts, sink chan<- *IAuthorityClaimAccepted, appContract []common.Address) (event.Subscription, error) {
+
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IAuthority.contract.WatchLogs(opts, "ClaimAccepted", appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IAuthorityClaimAccepted)
+				if err := _IAuthority.contract.UnpackLog(event, "ClaimAccepted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseClaimAccepted is a log parse operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) ParseClaimAccepted(log types.Log) (*IAuthorityClaimAccepted, error) {
+	event := new(IAuthorityClaimAccepted)
+	if err := _IAuthority.contract.UnpackLog(event, "ClaimAccepted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IAuthorityClaimSubmittedIterator is returned from FilterClaimSubmitted and is used to iterate over the raw logs and unpacked data for ClaimSubmitted events raised by the IAuthority contract.
+type IAuthorityClaimSubmittedIterator struct {
+	Event *IAuthorityClaimSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IAuthorityClaimSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IAuthorityClaimSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IAuthorityClaimSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IAuthorityClaimSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IAuthorityClaimSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IAuthorityClaimSubmitted represents a ClaimSubmitted event raised by the IAuthority contract.
+type IAuthorityClaimSubmitted struct {
+	Submitter                common.Address
+	AppContract              common.Address
+	LastProcessedBlockNumber *big.Int
+	OutputsMerkleRoot        [32]byte
+	Raw                      types.Log // Blockchain specific contextual infos
+}
+
+// FilterClaimSubmitted is a free log retrieval operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) FilterClaimSubmitted(opts *bind.FilterOpts, submitter []common.Address, appContract []common.Address) (*IAuthorityClaimSubmittedIterator, error) {
+
+	var submitterRule []interface{}
+	for _, submitterItem := range submitter {
+		submitterRule = append(submitterRule, submitterItem)
+	}
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IAuthority.contract.FilterLogs(opts, "ClaimSubmitted", submitterRule, appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IAuthorityClaimSubmittedIterator{contract: _IAuthority.contract, event: "ClaimSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchClaimSubmitted is a free log subscription operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) WatchClaimSubmitted(opts *bind.WatchOpts, sink chan<- *IAuthorityClaimSubmitted, submitter []common.Address, appContract []common.Address) (event.Subscription, error) {
+
+	var submitterRule []interface{}
+	for _, submitterItem := range submitter {
+		submitterRule = append(submitterRule, submitterItem)
+	}
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IAuthority.contract.WatchLogs(opts, "ClaimSubmitted", submitterRule, appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IAuthorityClaimSubmitted)
+				if err := _IAuthority.contract.UnpackLog(event, "ClaimSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseClaimSubmitted is a log parse operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IAuthority *IAuthorityFilterer) ParseClaimSubmitted(log types.Log) (*IAuthorityClaimSubmitted, error) {
+	event := new(IAuthorityClaimSubmitted)
+	if err := _IAuthority.contract.UnpackLog(event, "ClaimSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}

--- a/pkg/contracts/iquorum/iquorum.go
+++ b/pkg/contracts/iquorum/iquorum.go
@@ -1,0 +1,844 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package iquorum
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// IQuorumMetaData contains all meta data concerning the IQuorum contract.
+var IQuorumMetaData = &bind.MetaData{
+	ABI: "[{\"type\":\"function\",\"name\":\"getEpochLength\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"getNumberOfAcceptedClaims\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isOutputsMerkleRootValid\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorInFavorOf\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"},{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"isValidatorInFavorOfAnyClaimInEpoch\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"numOfValidators\",\"inputs\":[],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"numOfValidatorsInFavorOf\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"numOfValidatorsInFavorOfAnyClaimInEpoch\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"submitClaim\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"internalType\":\"bytes32\"}],\"outputs\":[],\"stateMutability\":\"nonpayable\"},{\"type\":\"function\",\"name\":\"supportsInterface\",\"inputs\":[{\"name\":\"interfaceId\",\"type\":\"bytes4\",\"internalType\":\"bytes4\"}],\"outputs\":[{\"name\":\"\",\"type\":\"bool\",\"internalType\":\"bool\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"validatorById\",\"inputs\":[{\"name\":\"id\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"outputs\":[{\"name\":\"\",\"type\":\"address\",\"internalType\":\"address\"}],\"stateMutability\":\"view\"},{\"type\":\"function\",\"name\":\"validatorId\",\"inputs\":[{\"name\":\"validator\",\"type\":\"address\",\"internalType\":\"address\"}],\"outputs\":[{\"name\":\"\",\"type\":\"uint256\",\"internalType\":\"uint256\"}],\"stateMutability\":\"view\"},{\"type\":\"event\",\"name\":\"ClaimAccepted\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"event\",\"name\":\"ClaimSubmitted\",\"inputs\":[{\"name\":\"submitter\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"appContract\",\"type\":\"address\",\"indexed\":true,\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"indexed\":false,\"internalType\":\"uint256\"},{\"name\":\"outputsMerkleRoot\",\"type\":\"bytes32\",\"indexed\":false,\"internalType\":\"bytes32\"}],\"anonymous\":false},{\"type\":\"error\",\"name\":\"NotEpochFinalBlock\",\"inputs\":[{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"epochLength\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotFirstClaim\",\"inputs\":[{\"name\":\"appContract\",\"type\":\"address\",\"internalType\":\"address\"},{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]},{\"type\":\"error\",\"name\":\"NotPastBlock\",\"inputs\":[{\"name\":\"lastProcessedBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"},{\"name\":\"currentBlockNumber\",\"type\":\"uint256\",\"internalType\":\"uint256\"}]}]",
+}
+
+// IQuorumABI is the input ABI used to generate the binding from.
+// Deprecated: Use IQuorumMetaData.ABI instead.
+var IQuorumABI = IQuorumMetaData.ABI
+
+// IQuorum is an auto generated Go binding around an Ethereum contract.
+type IQuorum struct {
+	IQuorumCaller     // Read-only binding to the contract
+	IQuorumTransactor // Write-only binding to the contract
+	IQuorumFilterer   // Log filterer for contract events
+}
+
+// IQuorumCaller is an auto generated read-only Go binding around an Ethereum contract.
+type IQuorumCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IQuorumTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type IQuorumTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IQuorumFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type IQuorumFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// IQuorumSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type IQuorumSession struct {
+	Contract     *IQuorum          // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// IQuorumCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type IQuorumCallerSession struct {
+	Contract *IQuorumCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts  // Call options to use throughout this session
+}
+
+// IQuorumTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type IQuorumTransactorSession struct {
+	Contract     *IQuorumTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts  // Transaction auth options to use throughout this session
+}
+
+// IQuorumRaw is an auto generated low-level Go binding around an Ethereum contract.
+type IQuorumRaw struct {
+	Contract *IQuorum // Generic contract binding to access the raw methods on
+}
+
+// IQuorumCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type IQuorumCallerRaw struct {
+	Contract *IQuorumCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// IQuorumTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type IQuorumTransactorRaw struct {
+	Contract *IQuorumTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewIQuorum creates a new instance of IQuorum, bound to a specific deployed contract.
+func NewIQuorum(address common.Address, backend bind.ContractBackend) (*IQuorum, error) {
+	contract, err := bindIQuorum(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorum{IQuorumCaller: IQuorumCaller{contract: contract}, IQuorumTransactor: IQuorumTransactor{contract: contract}, IQuorumFilterer: IQuorumFilterer{contract: contract}}, nil
+}
+
+// NewIQuorumCaller creates a new read-only instance of IQuorum, bound to a specific deployed contract.
+func NewIQuorumCaller(address common.Address, caller bind.ContractCaller) (*IQuorumCaller, error) {
+	contract, err := bindIQuorum(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorumCaller{contract: contract}, nil
+}
+
+// NewIQuorumTransactor creates a new write-only instance of IQuorum, bound to a specific deployed contract.
+func NewIQuorumTransactor(address common.Address, transactor bind.ContractTransactor) (*IQuorumTransactor, error) {
+	contract, err := bindIQuorum(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorumTransactor{contract: contract}, nil
+}
+
+// NewIQuorumFilterer creates a new log filterer instance of IQuorum, bound to a specific deployed contract.
+func NewIQuorumFilterer(address common.Address, filterer bind.ContractFilterer) (*IQuorumFilterer, error) {
+	contract, err := bindIQuorum(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorumFilterer{contract: contract}, nil
+}
+
+// bindIQuorum binds a generic wrapper to an already deployed contract.
+func bindIQuorum(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := IQuorumMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IQuorum *IQuorumRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IQuorum.Contract.IQuorumCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IQuorum *IQuorumRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IQuorum.Contract.IQuorumTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IQuorum *IQuorumRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IQuorum.Contract.IQuorumTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_IQuorum *IQuorumCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _IQuorum.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_IQuorum *IQuorumTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _IQuorum.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_IQuorum *IQuorumTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _IQuorum.Contract.contract.Transact(opts, method, params...)
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IQuorum *IQuorumCaller) GetEpochLength(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "getEpochLength")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IQuorum *IQuorumSession) GetEpochLength() (*big.Int, error) {
+	return _IQuorum.Contract.GetEpochLength(&_IQuorum.CallOpts)
+}
+
+// GetEpochLength is a free data retrieval call binding the contract method 0xcfe8a73b.
+//
+// Solidity: function getEpochLength() view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) GetEpochLength() (*big.Int, error) {
+	return _IQuorum.Contract.GetEpochLength(&_IQuorum.CallOpts)
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IQuorum *IQuorumCaller) GetNumberOfAcceptedClaims(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "getNumberOfAcceptedClaims")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IQuorum *IQuorumSession) GetNumberOfAcceptedClaims() (*big.Int, error) {
+	return _IQuorum.Contract.GetNumberOfAcceptedClaims(&_IQuorum.CallOpts)
+}
+
+// GetNumberOfAcceptedClaims is a free data retrieval call binding the contract method 0xd574f4d7.
+//
+// Solidity: function getNumberOfAcceptedClaims() view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) GetNumberOfAcceptedClaims() (*big.Int, error) {
+	return _IQuorum.Contract.GetNumberOfAcceptedClaims(&_IQuorum.CallOpts)
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IQuorum *IQuorumCaller) IsOutputsMerkleRootValid(opts *bind.CallOpts, appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "isOutputsMerkleRootValid", appContract, outputsMerkleRoot)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IQuorum *IQuorumSession) IsOutputsMerkleRootValid(appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	return _IQuorum.Contract.IsOutputsMerkleRootValid(&_IQuorum.CallOpts, appContract, outputsMerkleRoot)
+}
+
+// IsOutputsMerkleRootValid is a free data retrieval call binding the contract method 0xe5cc8664.
+//
+// Solidity: function isOutputsMerkleRootValid(address appContract, bytes32 outputsMerkleRoot) view returns(bool)
+func (_IQuorum *IQuorumCallerSession) IsOutputsMerkleRootValid(appContract common.Address, outputsMerkleRoot [32]byte) (bool, error) {
+	return _IQuorum.Contract.IsOutputsMerkleRootValid(&_IQuorum.CallOpts, appContract, outputsMerkleRoot)
+}
+
+// IsValidatorInFavorOf is a free data retrieval call binding the contract method 0x4b84231c.
+//
+// Solidity: function isValidatorInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumCaller) IsValidatorInFavorOf(opts *bind.CallOpts, appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte, id *big.Int) (bool, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "isValidatorInFavorOf", appContract, lastProcessedBlockNumber, outputsMerkleRoot, id)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorInFavorOf is a free data retrieval call binding the contract method 0x4b84231c.
+//
+// Solidity: function isValidatorInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumSession) IsValidatorInFavorOf(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte, id *big.Int) (bool, error) {
+	return _IQuorum.Contract.IsValidatorInFavorOf(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot, id)
+}
+
+// IsValidatorInFavorOf is a free data retrieval call binding the contract method 0x4b84231c.
+//
+// Solidity: function isValidatorInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumCallerSession) IsValidatorInFavorOf(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte, id *big.Int) (bool, error) {
+	return _IQuorum.Contract.IsValidatorInFavorOf(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot, id)
+}
+
+// IsValidatorInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x4b53459c.
+//
+// Solidity: function isValidatorInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumCaller) IsValidatorInFavorOfAnyClaimInEpoch(opts *bind.CallOpts, appContract common.Address, lastProcessedBlockNumber *big.Int, id *big.Int) (bool, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "isValidatorInFavorOfAnyClaimInEpoch", appContract, lastProcessedBlockNumber, id)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// IsValidatorInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x4b53459c.
+//
+// Solidity: function isValidatorInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumSession) IsValidatorInFavorOfAnyClaimInEpoch(appContract common.Address, lastProcessedBlockNumber *big.Int, id *big.Int) (bool, error) {
+	return _IQuorum.Contract.IsValidatorInFavorOfAnyClaimInEpoch(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, id)
+}
+
+// IsValidatorInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x4b53459c.
+//
+// Solidity: function isValidatorInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber, uint256 id) view returns(bool)
+func (_IQuorum *IQuorumCallerSession) IsValidatorInFavorOfAnyClaimInEpoch(appContract common.Address, lastProcessedBlockNumber *big.Int, id *big.Int) (bool, error) {
+	return _IQuorum.Contract.IsValidatorInFavorOfAnyClaimInEpoch(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, id)
+}
+
+// NumOfValidators is a free data retrieval call binding the contract method 0x1e526e45.
+//
+// Solidity: function numOfValidators() view returns(uint256)
+func (_IQuorum *IQuorumCaller) NumOfValidators(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "numOfValidators")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NumOfValidators is a free data retrieval call binding the contract method 0x1e526e45.
+//
+// Solidity: function numOfValidators() view returns(uint256)
+func (_IQuorum *IQuorumSession) NumOfValidators() (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidators(&_IQuorum.CallOpts)
+}
+
+// NumOfValidators is a free data retrieval call binding the contract method 0x1e526e45.
+//
+// Solidity: function numOfValidators() view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) NumOfValidators() (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidators(&_IQuorum.CallOpts)
+}
+
+// NumOfValidatorsInFavorOf is a free data retrieval call binding the contract method 0x7051bfd5.
+//
+// Solidity: function numOfValidatorsInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) view returns(uint256)
+func (_IQuorum *IQuorumCaller) NumOfValidatorsInFavorOf(opts *bind.CallOpts, appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "numOfValidatorsInFavorOf", appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NumOfValidatorsInFavorOf is a free data retrieval call binding the contract method 0x7051bfd5.
+//
+// Solidity: function numOfValidatorsInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) view returns(uint256)
+func (_IQuorum *IQuorumSession) NumOfValidatorsInFavorOf(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidatorsInFavorOf(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// NumOfValidatorsInFavorOf is a free data retrieval call binding the contract method 0x7051bfd5.
+//
+// Solidity: function numOfValidatorsInFavorOf(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) NumOfValidatorsInFavorOf(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidatorsInFavorOf(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// NumOfValidatorsInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x446ccbf0.
+//
+// Solidity: function numOfValidatorsInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber) view returns(uint256)
+func (_IQuorum *IQuorumCaller) NumOfValidatorsInFavorOfAnyClaimInEpoch(opts *bind.CallOpts, appContract common.Address, lastProcessedBlockNumber *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "numOfValidatorsInFavorOfAnyClaimInEpoch", appContract, lastProcessedBlockNumber)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// NumOfValidatorsInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x446ccbf0.
+//
+// Solidity: function numOfValidatorsInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber) view returns(uint256)
+func (_IQuorum *IQuorumSession) NumOfValidatorsInFavorOfAnyClaimInEpoch(appContract common.Address, lastProcessedBlockNumber *big.Int) (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidatorsInFavorOfAnyClaimInEpoch(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber)
+}
+
+// NumOfValidatorsInFavorOfAnyClaimInEpoch is a free data retrieval call binding the contract method 0x446ccbf0.
+//
+// Solidity: function numOfValidatorsInFavorOfAnyClaimInEpoch(address appContract, uint256 lastProcessedBlockNumber) view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) NumOfValidatorsInFavorOfAnyClaimInEpoch(appContract common.Address, lastProcessedBlockNumber *big.Int) (*big.Int, error) {
+	return _IQuorum.Contract.NumOfValidatorsInFavorOfAnyClaimInEpoch(&_IQuorum.CallOpts, appContract, lastProcessedBlockNumber)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IQuorum *IQuorumCaller) SupportsInterface(opts *bind.CallOpts, interfaceId [4]byte) (bool, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "supportsInterface", interfaceId)
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IQuorum *IQuorumSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IQuorum.Contract.SupportsInterface(&_IQuorum.CallOpts, interfaceId)
+}
+
+// SupportsInterface is a free data retrieval call binding the contract method 0x01ffc9a7.
+//
+// Solidity: function supportsInterface(bytes4 interfaceId) view returns(bool)
+func (_IQuorum *IQuorumCallerSession) SupportsInterface(interfaceId [4]byte) (bool, error) {
+	return _IQuorum.Contract.SupportsInterface(&_IQuorum.CallOpts, interfaceId)
+}
+
+// ValidatorById is a free data retrieval call binding the contract method 0x1c45396a.
+//
+// Solidity: function validatorById(uint256 id) view returns(address)
+func (_IQuorum *IQuorumCaller) ValidatorById(opts *bind.CallOpts, id *big.Int) (common.Address, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "validatorById", id)
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+// ValidatorById is a free data retrieval call binding the contract method 0x1c45396a.
+//
+// Solidity: function validatorById(uint256 id) view returns(address)
+func (_IQuorum *IQuorumSession) ValidatorById(id *big.Int) (common.Address, error) {
+	return _IQuorum.Contract.ValidatorById(&_IQuorum.CallOpts, id)
+}
+
+// ValidatorById is a free data retrieval call binding the contract method 0x1c45396a.
+//
+// Solidity: function validatorById(uint256 id) view returns(address)
+func (_IQuorum *IQuorumCallerSession) ValidatorById(id *big.Int) (common.Address, error) {
+	return _IQuorum.Contract.ValidatorById(&_IQuorum.CallOpts, id)
+}
+
+// ValidatorId is a free data retrieval call binding the contract method 0x0a6f1fe8.
+//
+// Solidity: function validatorId(address validator) view returns(uint256)
+func (_IQuorum *IQuorumCaller) ValidatorId(opts *bind.CallOpts, validator common.Address) (*big.Int, error) {
+	var out []interface{}
+	err := _IQuorum.contract.Call(opts, &out, "validatorId", validator)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+// ValidatorId is a free data retrieval call binding the contract method 0x0a6f1fe8.
+//
+// Solidity: function validatorId(address validator) view returns(uint256)
+func (_IQuorum *IQuorumSession) ValidatorId(validator common.Address) (*big.Int, error) {
+	return _IQuorum.Contract.ValidatorId(&_IQuorum.CallOpts, validator)
+}
+
+// ValidatorId is a free data retrieval call binding the contract method 0x0a6f1fe8.
+//
+// Solidity: function validatorId(address validator) view returns(uint256)
+func (_IQuorum *IQuorumCallerSession) ValidatorId(validator common.Address) (*big.Int, error) {
+	return _IQuorum.Contract.ValidatorId(&_IQuorum.CallOpts, validator)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IQuorum *IQuorumTransactor) SubmitClaim(opts *bind.TransactOpts, appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IQuorum.contract.Transact(opts, "submitClaim", appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IQuorum *IQuorumSession) SubmitClaim(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IQuorum.Contract.SubmitClaim(&_IQuorum.TransactOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// SubmitClaim is a paid mutator transaction binding the contract method 0x6470af00.
+//
+// Solidity: function submitClaim(address appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot) returns()
+func (_IQuorum *IQuorumTransactorSession) SubmitClaim(appContract common.Address, lastProcessedBlockNumber *big.Int, outputsMerkleRoot [32]byte) (*types.Transaction, error) {
+	return _IQuorum.Contract.SubmitClaim(&_IQuorum.TransactOpts, appContract, lastProcessedBlockNumber, outputsMerkleRoot)
+}
+
+// IQuorumClaimAcceptedIterator is returned from FilterClaimAccepted and is used to iterate over the raw logs and unpacked data for ClaimAccepted events raised by the IQuorum contract.
+type IQuorumClaimAcceptedIterator struct {
+	Event *IQuorumClaimAccepted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IQuorumClaimAcceptedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IQuorumClaimAccepted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IQuorumClaimAccepted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IQuorumClaimAcceptedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IQuorumClaimAcceptedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IQuorumClaimAccepted represents a ClaimAccepted event raised by the IQuorum contract.
+type IQuorumClaimAccepted struct {
+	AppContract              common.Address
+	LastProcessedBlockNumber *big.Int
+	OutputsMerkleRoot        [32]byte
+	Raw                      types.Log // Blockchain specific contextual infos
+}
+
+// FilterClaimAccepted is a free log retrieval operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) FilterClaimAccepted(opts *bind.FilterOpts, appContract []common.Address) (*IQuorumClaimAcceptedIterator, error) {
+
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IQuorum.contract.FilterLogs(opts, "ClaimAccepted", appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorumClaimAcceptedIterator{contract: _IQuorum.contract, event: "ClaimAccepted", logs: logs, sub: sub}, nil
+}
+
+// WatchClaimAccepted is a free log subscription operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) WatchClaimAccepted(opts *bind.WatchOpts, sink chan<- *IQuorumClaimAccepted, appContract []common.Address) (event.Subscription, error) {
+
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IQuorum.contract.WatchLogs(opts, "ClaimAccepted", appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IQuorumClaimAccepted)
+				if err := _IQuorum.contract.UnpackLog(event, "ClaimAccepted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseClaimAccepted is a log parse operation binding the contract event 0x0f2cd00a405c0d1a66050307b6722c4788db6ed57aa3589a5c38da535cc3ce63.
+//
+// Solidity: event ClaimAccepted(address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) ParseClaimAccepted(log types.Log) (*IQuorumClaimAccepted, error) {
+	event := new(IQuorumClaimAccepted)
+	if err := _IQuorum.contract.UnpackLog(event, "ClaimAccepted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+// IQuorumClaimSubmittedIterator is returned from FilterClaimSubmitted and is used to iterate over the raw logs and unpacked data for ClaimSubmitted events raised by the IQuorum contract.
+type IQuorumClaimSubmittedIterator struct {
+	Event *IQuorumClaimSubmitted // Event containing the contract specifics and raw log
+
+	contract *bind.BoundContract // Generic contract to use for unpacking event data
+	event    string              // Event name to use for unpacking event data
+
+	logs chan types.Log        // Log channel receiving the found contract events
+	sub  ethereum.Subscription // Subscription for errors, completion and termination
+	done bool                  // Whether the subscription completed delivering logs
+	fail error                 // Occurred error to stop iteration
+}
+
+// Next advances the iterator to the subsequent event, returning whether there
+// are any more events found. In case of a retrieval or parsing error, false is
+// returned and Error() can be queried for the exact failure.
+func (it *IQuorumClaimSubmittedIterator) Next() bool {
+	// If the iterator failed, stop iterating
+	if it.fail != nil {
+		return false
+	}
+	// If the iterator completed, deliver directly whatever's available
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(IQuorumClaimSubmitted)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+	// Iterator still in progress, wait for either a data or an error event
+	select {
+	case log := <-it.logs:
+		it.Event = new(IQuorumClaimSubmitted)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+// Error returns any retrieval or parsing error occurred during filtering.
+func (it *IQuorumClaimSubmittedIterator) Error() error {
+	return it.fail
+}
+
+// Close terminates the iteration process, releasing any pending underlying
+// resources.
+func (it *IQuorumClaimSubmittedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+// IQuorumClaimSubmitted represents a ClaimSubmitted event raised by the IQuorum contract.
+type IQuorumClaimSubmitted struct {
+	Submitter                common.Address
+	AppContract              common.Address
+	LastProcessedBlockNumber *big.Int
+	OutputsMerkleRoot        [32]byte
+	Raw                      types.Log // Blockchain specific contextual infos
+}
+
+// FilterClaimSubmitted is a free log retrieval operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) FilterClaimSubmitted(opts *bind.FilterOpts, submitter []common.Address, appContract []common.Address) (*IQuorumClaimSubmittedIterator, error) {
+
+	var submitterRule []interface{}
+	for _, submitterItem := range submitter {
+		submitterRule = append(submitterRule, submitterItem)
+	}
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IQuorum.contract.FilterLogs(opts, "ClaimSubmitted", submitterRule, appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return &IQuorumClaimSubmittedIterator{contract: _IQuorum.contract, event: "ClaimSubmitted", logs: logs, sub: sub}, nil
+}
+
+// WatchClaimSubmitted is a free log subscription operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) WatchClaimSubmitted(opts *bind.WatchOpts, sink chan<- *IQuorumClaimSubmitted, submitter []common.Address, appContract []common.Address) (event.Subscription, error) {
+
+	var submitterRule []interface{}
+	for _, submitterItem := range submitter {
+		submitterRule = append(submitterRule, submitterItem)
+	}
+	var appContractRule []interface{}
+	for _, appContractItem := range appContract {
+		appContractRule = append(appContractRule, appContractItem)
+	}
+
+	logs, sub, err := _IQuorum.contract.WatchLogs(opts, "ClaimSubmitted", submitterRule, appContractRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+				// New log arrived, parse the event and forward to the user
+				event := new(IQuorumClaimSubmitted)
+				if err := _IQuorum.contract.UnpackLog(event, "ClaimSubmitted", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+// ParseClaimSubmitted is a log parse operation binding the contract event 0xf4ff953641f10e17dd93c0bc51334cb1f711fdcb4e37992021a5973f7a958f09.
+//
+// Solidity: event ClaimSubmitted(address indexed submitter, address indexed appContract, uint256 lastProcessedBlockNumber, bytes32 outputsMerkleRoot)
+func (_IQuorum *IQuorumFilterer) ParseClaimSubmitted(log types.Log) (*IQuorumClaimSubmitted, error) {
+	event := new(IQuorumClaimSubmitted)
+	if err := _IQuorum.contract.UnpackLog(event, "ClaimSubmitted", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}


### PR DESCRIPTION
  Read-only CLI tool that queries Ethereum contracts directly via eth_call
  and eth_getLogs — no database required.

  Nine subcommands: summary, app, consensus, inputbox, tournament, epoch,
  output, commitment, match. Auto-discovers contract tree from application
  address, detects consensus type via ERC-165, uses FindTransitions for
  efficient event discovery, and supports --tree for recursive tournament
  traversal.
