### PR TITLE
Refactor/service framework method shadowing

### DIFF
--- a/cmd/cartesi-rollups-advancer/root/root.go
+++ b/cmd/cartesi-rollups-advancer/root/root.go
@@ -101,7 +101,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	advancerService, err := advancer.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	advancerService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, advancerService.Serve())
 }

--- a/cmd/cartesi-rollups-advancer/root/root.go
+++ b/cmd/cartesi-rollups-advancer/root/root.go
@@ -80,19 +80,21 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := advancer.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceAdvancer,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceAdvancer, cfg.LogLevel),
-			LogColor:             cfg.LogColor,
-			EnableSignalHandling: true,
-			TelemetryCreate:      true,
-			TelemetryAddress:     cfg.AdvancerTelemetryAddress,
-			PollInterval:         cfg.AdvancerPollingInterval,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   cfg.AdvancerPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceAdvancer,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceAdvancer, cfg.LogLevel),
+				LogColor:             cfg.LogColor,
+				EnableSignalHandling: true,
+				TelemetryCreate:      true,
+				TelemetryAddress:     cfg.AdvancerTelemetryAddress,
+			},
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	createInfo.Repository, err = factory.NewRepositoryFromConnectionString(ctx, cfg.DatabaseConnection.Raw())

--- a/cmd/cartesi-rollups-claimer/root/root.go
+++ b/cmd/cartesi-rollups-claimer/root/root.go
@@ -112,7 +112,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	claimerService, err := claimer.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	claimerService.LogConfig(createInfo.Config)
 
 	err = claimerService.Serve()
 	cli.CheckErr(logger, err)

--- a/cmd/cartesi-rollups-claimer/root/root.go
+++ b/cmd/cartesi-rollups-claimer/root/root.go
@@ -81,19 +81,21 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := claimer.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceClaimer,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceClaimer, cfg.LogLevel),
-			LogColor:             cfg.LogColor,
-			EnableSignalHandling: true,
-			TelemetryCreate:      true,
-			TelemetryAddress:     cfg.ClaimerTelemetryAddress,
-			PollInterval:         cfg.ClaimerPollingInterval,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   cfg.ClaimerPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceClaimer,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceClaimer, cfg.LogLevel),
+				LogColor:             cfg.LogColor,
+				EnableSignalHandling: true,
+				TelemetryCreate:      true,
+				TelemetryAddress:     cfg.ClaimerTelemetryAddress,
+			},
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	authOpt, err := config.HTTPAuthorizationOption()
 	cli.CheckErr(logger, err)

--- a/cmd/cartesi-rollups-evm-reader/root/root.go
+++ b/cmd/cartesi-rollups-evm-reader/root/root.go
@@ -82,7 +82,7 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := evmreader.CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:                 config.ServiceEvmReader,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceEvmReader, cfg.LogLevel),
 			LogColor:             cfg.LogColor,
@@ -92,8 +92,8 @@ func run(cmd *cobra.Command, args []string) {
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	authOpt, err := config.HTTPAuthorizationOption()

--- a/cmd/cartesi-rollups-evm-reader/root/root.go
+++ b/cmd/cartesi-rollups-evm-reader/root/root.go
@@ -117,7 +117,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	readerService, err := evmreader.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	readerService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, readerService.Serve())
 }

--- a/cmd/cartesi-rollups-jsonrpc-api/root/root.go
+++ b/cmd/cartesi-rollups-jsonrpc-api/root/root.go
@@ -68,7 +68,7 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := jsonrpc.CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:                 config.ServiceJsonrpc,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceJsonrpc, cfg.LogLevel),
 			LogColor:             cfg.LogColor,
@@ -78,8 +78,8 @@ func run(cmd *cobra.Command, args []string) {
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	createInfo.Repository, err = factory.NewRepositoryFromConnectionString(ctx, cfg.DatabaseConnection.Raw())

--- a/cmd/cartesi-rollups-jsonrpc-api/root/root.go
+++ b/cmd/cartesi-rollups-jsonrpc-api/root/root.go
@@ -88,7 +88,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	jsonrpcService, err := jsonrpc.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	jsonrpcService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, jsonrpcService.Serve())
 }

--- a/cmd/cartesi-rollups-node/root/root.go
+++ b/cmd/cartesi-rollups-node/root/root.go
@@ -150,7 +150,7 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := node.CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:                 config.ServiceNode,
 			LogLevel:             cfg.LogLevel,
 			LogColor:             cfg.LogColor,
@@ -160,8 +160,8 @@ func run(cmd *cobra.Command, args []string) {
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	createInfo.ReaderClient, err = newEthClient(ctx, config.ServiceEvmReader)

--- a/cmd/cartesi-rollups-node/root/root.go
+++ b/cmd/cartesi-rollups-node/root/root.go
@@ -183,7 +183,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	nodeService, err := node.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	nodeService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, nodeService.Serve())
 }

--- a/cmd/cartesi-rollups-prt/root/root.go
+++ b/cmd/cartesi-rollups-prt/root/root.go
@@ -101,7 +101,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	prtService, err := prt.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	prtService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, prtService.Serve())
 }

--- a/cmd/cartesi-rollups-prt/root/root.go
+++ b/cmd/cartesi-rollups-prt/root/root.go
@@ -69,19 +69,21 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := prt.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServicePrt,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServicePrt, cfg.LogLevel),
-			LogColor:             cfg.LogColor,
-			EnableSignalHandling: true,
-			TelemetryCreate:      true,
-			TelemetryAddress:     cfg.PrtTelemetryAddress,
-			PollInterval:         cfg.PrtPollingInterval,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   cfg.PrtPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServicePrt,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServicePrt, cfg.LogLevel),
+				LogColor:             cfg.LogColor,
+				EnableSignalHandling: true,
+				TelemetryCreate:      true,
+				TelemetryAddress:     cfg.PrtTelemetryAddress,
+			},
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	authOpt, err := config.HTTPAuthorizationOption()

--- a/cmd/cartesi-rollups-validator/root/root.go
+++ b/cmd/cartesi-rollups-validator/root/root.go
@@ -68,19 +68,21 @@ func run(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	createInfo := validator.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceValidator,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceValidator, cfg.LogLevel),
-			LogColor:             cfg.LogColor,
-			EnableSignalHandling: true,
-			TelemetryCreate:      true,
-			TelemetryAddress:     cfg.ValidatorTelemetryAddress,
+		TickServiceConfigs: service.TickServiceConfigs{
 			PollInterval:         cfg.ValidatorPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceValidator,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceValidator, cfg.LogLevel),
+				LogColor:             cfg.LogColor,
+				EnableSignalHandling: true,
+				TelemetryCreate:      true,
+				TelemetryAddress:     cfg.ValidatorTelemetryAddress,
+			},
 		},
 		Config: *cfg,
 	}
-	logger := service.NewServiceLogger(&createInfo.CreateInfo)
-	createInfo.CreateInfo.Logger = logger
+	logger := service.NewServiceLogger(&createInfo.ServiceConfigs)
+	createInfo.ServiceConfigs.Logger = logger
 
 	var err error
 	createInfo.Repository, err = factory.NewRepositoryFromConnectionString(ctx, cfg.DatabaseConnection.Raw())

--- a/cmd/cartesi-rollups-validator/root/root.go
+++ b/cmd/cartesi-rollups-validator/root/root.go
@@ -89,7 +89,6 @@ func run(cmd *cobra.Command, args []string) {
 
 	validatorService, err := validator.Create(ctx, &createInfo)
 	cli.CheckErr(logger, err)
-	validatorService.LogConfig(createInfo.Config)
 
 	cli.CheckErr(logger, validatorService.Serve())
 }

--- a/internal/advancer/advancer.go
+++ b/internal/advancer/advancer.go
@@ -306,7 +306,7 @@ func (s *Service) processInputs(ctx context.Context, app *Application, inputs []
 				"epoch", input.EpochIndex,
 				"index", input.Index,
 				"error", err)
-			s.Cancel() // triggers graceful shutdown of all services
+			s.Stop(true) // triggers graceful shutdown of all services
 			return err
 		}
 

--- a/internal/advancer/advancer.go
+++ b/internal/advancer/advancer.go
@@ -70,14 +70,10 @@ func getUnprocessedInputs(
 // potentially has more work. Callers use this to decide whether to re-tick immediately
 // (via the Reschedule channel) or wait for the next timer/event.
 func (s *Service) Step(ctx context.Context) (bool, error) {
-	// Check for context cancellation or shutdown in progress.
-	// The framework sets Stopping before calling Impl.Stop(), so this
+	// Check for context cancellation or shutdown in progress. This
 	// prevents starting new work while the machine manager is being torn down.
 	if err := ctx.Err(); err != nil {
 		return false, err
-	}
-	if s.IsStopping() {
-		return false, nil
 	}
 
 	// Update the machine manager with any new or disabled applications

--- a/internal/advancer/advancer_test.go
+++ b/internal/advancer/advancer_test.go
@@ -73,7 +73,6 @@ func newMockAdvancerServiceWithContextAndBatchSize(
 			Context: ctx,
 			Cancel: cancelCtx,
 		},
-		EnableReschedule: true,
 	}
 	err := service.InitTickServiceTemplate(serviceArgs, &s.TickServiceTemplate, s, s)
 	if err != nil {
@@ -126,12 +125,12 @@ func (s *AdvancerSuite) TestServiceInterface() {
 		repository.GetEpochsReturn = map[common.Address][]*Epoch{
 			machineManager.Map[1].application.IApplicationAddress: {},
 		}
-		tickErrors := advancer.Tick(context.Background())
+		_, tickErrors := advancer.Tick(context.Background())
 		require.Empty(tickErrors)
 
 		// Test Tick with error
 		repository.GetEpochsError = errors.New("list epochs error")
-		tickErrors = advancer.Tick(context.Background())
+		_, tickErrors = advancer.Tick(context.Background())
 		require.NotEmpty(tickErrors)
 		require.Contains(tickErrors[0].Error(), "list epochs error")
 
@@ -1597,10 +1596,10 @@ func (s *AdvancerSuite) TestSelfWakeOnSuccess() {
 	require.NoError(err)
 
 	// Call Tick() which internally calls Step() and signals reschedule.
-	svc.Tick(context.Background())
+	reschedule, _ := svc.Tick(context.Background())
 
 	// The reschedule channel should have a pending signal.
-	require.True(svc.DrainReschedule(),
+	require.True(reschedule,
 		"reschedule channel should have a pending signal after Tick with work")
 }
 
@@ -1621,9 +1620,9 @@ func (s *AdvancerSuite) TestNoSelfWakeWhenIdle() {
 	svc, err := newMockAdvancerService(mm, repo)
 	require.NoError(err)
 
-	svc.Tick(context.Background())
+	reschedule, _ := svc.Tick(context.Background())
 
-	require.False(svc.DrainReschedule(),
+	require.False(reschedule,
 		"reschedule channel should be empty when no work exists")
 }
 
@@ -1640,10 +1639,10 @@ func (s *AdvancerSuite) TestNoSelfWakeOnError() {
 	svc, err := newMockAdvancerService(mm, repo)
 	require.NoError(err)
 
-	errs := svc.Tick(context.Background())
+	reschedule, errs := svc.Tick(context.Background())
 	require.NotEmpty(errs)
 
-	require.False(svc.DrainReschedule(),
+	require.False(reschedule,
 		"reschedule should NOT be signaled on error")
 }
 
@@ -1681,12 +1680,12 @@ func (s *AdvancerSuite) TestPartialSuccessStillReschedules() {
 
 	// Call Tick — app1 fails, app2 succeeds with more work remaining (batch limit hit).
 	// Tick should surface the error AND signal reschedule for app2's pending work.
-	errs := svc.Tick(context.Background())
+	reschedule, errs := svc.Tick(context.Background())
 	require.NotEmpty(errs, "Tick should surface app1's error")
 
 	// Reschedule SHOULD fire: app2 had work, and one failing app must not
 	// delay healthy apps by suppressing the reschedule signal.
-	require.True(svc.DrainReschedule(),
+	require.True(reschedule,
 		"reschedule should be signaled when hadWork is true, even with errors")
 }
 

--- a/internal/advancer/advancer_test.go
+++ b/internal/advancer/advancer_test.go
@@ -67,14 +67,15 @@ func newMockAdvancerServiceWithContextAndBatchSize(
 		machineManager: machineManager,
 		repository:     repo,
 	}
-	serviceArgs := &service.CreateInfo{
-		Name: "advancer",
-		Impl: s,
-		Context: ctx,
-		Cancel: cancelCtx,
+	serviceArgs := &service.TickServiceConfigs{
+			ServiceConfigs: service.ServiceConfigs{
+			Name: "advancer",
+			Context: ctx,
+			Cancel: cancelCtx,
+		},
 		EnableReschedule: true,
 	}
-	err := service.NewTickService(serviceArgs, &s.TickService)
+	err := service.InitTickServiceTemplate(serviceArgs, &s.TickServiceTemplate, s, s)
 	if err != nil {
 		return nil, err
 	}
@@ -1052,8 +1053,8 @@ func (s *AdvancerSuite) TestRemoveSnapshot() {
 
 		tmpDir := s.T().TempDir()
 		advancer := &Service{snapshotsDir: tmpDir}
-		serviceArgs := &service.CreateInfo{Name: "advancer", Impl: advancer}
-		require.Nil(service.Create(context.Background(), serviceArgs, &advancer.Service))
+		serviceArgs := &service.TickServiceConfigs{ServiceConfigs: service.ServiceConfigs{Name: "advancer"}}
+		require.Nil(service.InitTickServiceTemplate(serviceArgs, &advancer.TickServiceTemplate, advancer, advancer))
 
 		// Create a snapshot directory
 		snapshotPath := filepath.Join(tmpDir, "myapp_epoch0_input0")
@@ -1071,8 +1072,8 @@ func (s *AdvancerSuite) TestRemoveSnapshot() {
 
 		tmpDir := s.T().TempDir()
 		advancer := &Service{snapshotsDir: tmpDir}
-		serviceArgs := &service.CreateInfo{Name: "advancer", Impl: advancer}
-		require.Nil(service.Create(context.Background(), serviceArgs, &advancer.Service))
+		serviceArgs := &service.TickServiceConfigs{ServiceConfigs: service.ServiceConfigs{Name: "advancer"}}
+		require.Nil(service.InitTickServiceTemplate(serviceArgs, &advancer.TickServiceTemplate, advancer, advancer))
 
 		snapshotPath := filepath.Join(tmpDir, "myapp_epoch0_input0")
 		err := advancer.removeSnapshot(snapshotPath, "myapp")
@@ -1084,8 +1085,8 @@ func (s *AdvancerSuite) TestRemoveSnapshot() {
 
 		tmpDir := s.T().TempDir()
 		advancer := &Service{snapshotsDir: tmpDir}
-		serviceArgs := &service.CreateInfo{Name: "advancer", Impl: advancer}
-		require.Nil(service.Create(context.Background(), serviceArgs, &advancer.Service))
+		serviceArgs := &service.TickServiceConfigs{ServiceConfigs: service.ServiceConfigs{Name: "advancer"}}
+		require.Nil(service.InitTickServiceTemplate(serviceArgs, &advancer.TickServiceTemplate, advancer, advancer))
 
 		// Try to traverse outside snapshotsDir
 		maliciousPath := filepath.Join(tmpDir, "..", "outside", "myapp_evil")
@@ -1099,8 +1100,8 @@ func (s *AdvancerSuite) TestRemoveSnapshot() {
 
 		tmpDir := s.T().TempDir()
 		advancer := &Service{snapshotsDir: tmpDir}
-		serviceArgs := &service.CreateInfo{Name: "advancer", Impl: advancer}
-		require.Nil(service.Create(context.Background(), serviceArgs, &advancer.Service))
+		serviceArgs := &service.TickServiceConfigs{ServiceConfigs: service.ServiceConfigs{Name: "advancer"}}
+		require.Nil(service.InitTickServiceTemplate(serviceArgs, &advancer.TickServiceTemplate, advancer, advancer))
 
 		snapshotPath := filepath.Join(tmpDir, "otherapp_epoch0_input0")
 		err := advancer.removeSnapshot(snapshotPath, "myapp")

--- a/internal/advancer/advancer_test.go
+++ b/internal/advancer/advancer_test.go
@@ -49,7 +49,7 @@ func newMockAdvancerServiceWithBatchSize(
 		repository:     repo,
 	}
 	serviceArgs := &service.CreateInfo{Name: "advancer", Impl: s, EnableReschedule: true}
-	err := service.Create(context.Background(), serviceArgs, &s.Service)
+	err := service.NewTickService(serviceArgs, &s.TickService)
 	if err != nil {
 		return nil, err
 	}
@@ -98,12 +98,12 @@ func (s *AdvancerSuite) TestServiceInterface() {
 		repository.GetEpochsReturn = map[common.Address][]*Epoch{
 			machineManager.Map[1].application.IApplicationAddress: {},
 		}
-		tickErrors := advancer.Tick()
+		tickErrors := advancer.Tick(context.Background())
 		require.Empty(tickErrors)
 
 		// Test Tick with error
 		repository.GetEpochsError = errors.New("list epochs error")
-		tickErrors = advancer.Tick()
+		tickErrors = advancer.Tick(context.Background())
 		require.NotEmpty(tickErrors)
 		require.Contains(tickErrors[0].Error(), "list epochs error")
 
@@ -1569,7 +1569,7 @@ func (s *AdvancerSuite) TestSelfWakeOnSuccess() {
 	require.NoError(err)
 
 	// Call Tick() which internally calls Step() and signals reschedule.
-	svc.Tick()
+	svc.Tick(context.Background())
 
 	// The reschedule channel should have a pending signal.
 	require.True(svc.DrainReschedule(),
@@ -1593,7 +1593,7 @@ func (s *AdvancerSuite) TestNoSelfWakeWhenIdle() {
 	svc, err := newMockAdvancerService(mm, repo)
 	require.NoError(err)
 
-	svc.Tick()
+	svc.Tick(context.Background())
 
 	require.False(svc.DrainReschedule(),
 		"reschedule channel should be empty when no work exists")
@@ -1612,7 +1612,7 @@ func (s *AdvancerSuite) TestNoSelfWakeOnError() {
 	svc, err := newMockAdvancerService(mm, repo)
 	require.NoError(err)
 
-	errs := svc.Tick()
+	errs := svc.Tick(context.Background())
 	require.NotEmpty(errs)
 
 	require.False(svc.DrainReschedule(),
@@ -1653,7 +1653,7 @@ func (s *AdvancerSuite) TestPartialSuccessStillReschedules() {
 
 	// Call Tick — app1 fails, app2 succeeds with more work remaining (batch limit hit).
 	// Tick should surface the error AND signal reschedule for app2's pending work.
-	errs := svc.Tick()
+	errs := svc.Tick(context.Background())
 	require.NotEmpty(errs, "Tick should surface app1's error")
 
 	// Reschedule SHOULD fire: app2 had work, and one failing app must not

--- a/internal/advancer/advancer_test.go
+++ b/internal/advancer/advancer_test.go
@@ -34,11 +34,30 @@ func TestAdvancer(t *testing.T) {
 
 type AdvancerSuite struct{ suite.Suite }
 
+const defaultBatchSize = 500
+
 func newMockAdvancerService(machineManager *MockMachineManager, repo *MockRepository) (*Service, error) {
-	return newMockAdvancerServiceWithBatchSize(machineManager, repo, 500)
+	return newMockAdvancerServiceWithBatchSize(machineManager, repo, defaultBatchSize)
 }
 
 func newMockAdvancerServiceWithBatchSize(
+	machineManager *MockMachineManager,
+	repo *MockRepository,
+	batchSize uint64,
+) (*Service, error) {
+	ctx, cf := context.WithCancel(context.Background())
+	return newMockAdvancerServiceWithContextAndBatchSize(
+		ctx,
+		cf,
+		machineManager,
+		repo,
+		batchSize,
+	)
+}
+
+func newMockAdvancerServiceWithContextAndBatchSize(
+	ctx context.Context,
+	cancelCtx context.CancelFunc,
 	machineManager *MockMachineManager,
 	repo *MockRepository,
 	batchSize uint64,
@@ -48,7 +67,13 @@ func newMockAdvancerServiceWithBatchSize(
 		machineManager: machineManager,
 		repository:     repo,
 	}
-	serviceArgs := &service.CreateInfo{Name: "advancer", Impl: s, EnableReschedule: true}
+	serviceArgs := &service.CreateInfo{
+		Name: "advancer",
+		Impl: s,
+		Context: ctx,
+		Cancel: cancelCtx,
+		EnableReschedule: true,
+	}
 	err := service.NewTickService(serviceArgs, &s.TickService)
 	if err != nil {
 		return nil, err
@@ -60,6 +85,7 @@ func newMockAdvancerServiceWithBatchSize(
 // the mock machine manager, and the mock repository.
 type testEnv struct {
 	service *Service
+	ctx     context.Context
 	app     *MockMachineImpl
 	mm      *MockMachineManager
 	repo    *MockRepository
@@ -68,13 +94,14 @@ type testEnv struct {
 // setupOneApp creates a standard test environment with one application.
 // The repository is empty; callers can configure it after the call.
 func (s *AdvancerSuite) setupOneApp() testEnv {
+	ctx, cf := context.WithCancel(context.Background())
 	mm := newMockMachineManager()
 	app := newMockMachine(1)
 	mm.Map[1] = newMockInstance(app)
 	repo := &MockRepository{}
-	svc, err := newMockAdvancerService(mm, repo)
+	svc, err := newMockAdvancerServiceWithContextAndBatchSize(ctx, cf, mm, repo, defaultBatchSize)
 	s.Require().NoError(err)
-	return testEnv{service: svc, app: app, mm: mm, repo: repo}
+	return testEnv{service: svc, ctx: ctx, app: app, mm: mm, repo: repo}
 }
 
 func (s *AdvancerSuite) TestServiceInterface() {
@@ -406,7 +433,7 @@ func (s *AdvancerSuite) TestProcess() {
 			require.Len(env.repo.StoredResults, 1)
 
 			// Verify that the node shutdown was triggered (context cancelled)
-			require.Error(env.service.Context.Err(), "shared context should be cancelled")
+			require.Error(env.ctx.Err(), "shared context should be cancelled")
 		})
 	})
 }
@@ -504,7 +531,7 @@ func (s *AdvancerSuite) TestErrorRecovery() {
 		err := env.service.processInputs(context.Background(), env.app.Application, inputs)
 		require.Error(err)
 		require.Contains(err.Error(), "temporary failure")
-		require.Error(env.service.Context.Err(), "shared context should be cancelled")
+		require.Error(env.ctx.Err(), "shared context should be cancelled")
 	})
 }
 

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -125,7 +125,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 	}
 	// During shutdown, the machine manager is closed and GetMachine() may
 	// return ErrNoApp. Suppress this to avoid spurious ERR log entries.
-	if errors.Is(err, ErrNoApp) && s.IsStopping() {
+	if errors.Is(err, ErrNoApp) && ctx.Err() != nil {
 		s.Logger.Warn("Tick interrupted by shutdown", "error", err)
 		return nil
 	}

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -45,7 +45,7 @@ type CreateInfo struct {
 }
 
 // Create initializes a new advancer service
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 	if err = ctx.Err(); err != nil {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
@@ -101,6 +101,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 	}
 
 	s.snapshotsDir = c.Config.SnapshotsDir
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -24,7 +24,7 @@ const httpShutdownTimeout = 10 * time.Second
 
 // Service is the main advancer service that processes inputs through Cartesi machines
 type Service struct {
-	service.Service
+	service.TickService
 	inputBatchSize uint64
 	snapshotsDir   string
 	repository     AdvancerRepository
@@ -52,10 +52,11 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
+	s.TickImpl = s
 	c.Impl = s
 	c.EnableReschedule = true
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.NewTickService(&c.CreateInfo, &s.TickService)
 	if err != nil {
 		return nil, err
 	}
@@ -108,8 +109,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 }
 
 // Service interface implementation
-func (s *Service) Tick() []error {
-	hadWork, err := s.Step(s.Context)
+func (s *Service) Tick(ctx context.Context) []error {
+	hadWork, err := s.Step(ctx)
 
 	// Signal reschedule whenever work was done, even if some apps errored.
 	// Failed apps are marked Failed and removed by the machine manager,
@@ -132,17 +133,6 @@ func (s *Service) Tick() []error {
 }
 
 func (s *Service) OnStop(b bool) []error {
-	// CAS achieves once-semantics: the second caller returns immediately
-	// (fire-and-forget) rather than blocking like sync.Once. This is safe
-	// because the orchestrator calls Cancel() after Stop() and waits for
-	// the Serve goroutine to exit.
-	if !s.cleanedUp.CompareAndSwap(false, true) {
-		return nil // already stopped
-	}
-	// This method shadows service.Service.Stop(), so set the stopping flag
-	// explicitly. Without this, a concurrent Tick that observes closed
-	// resources would not see IsStopping() == true.
-	s.SetStopping()
 	var errs []error
 	if s.inspector != nil {
 		s.Logger.Info("Shutting down inspect HTTP server")
@@ -158,9 +148,9 @@ func (s *Service) OnStop(b bool) []error {
 			errs = append(errs, fmt.Errorf("failed to close machine manager: %w", err))
 		}
 	}
-	return append(errs, s.TickServiceTemplate.OnStop(b)...)
+	return append(errs, s.TickService.OnStop(b)...)
 }
-func (s *Service) Serve() error {
+func (s *Service) OnServe(ctx context.Context) error {
 	if s.inspector != nil {
 		go func() {
 			if err := s.inspector.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -169,5 +159,5 @@ func (s *Service) Serve() error {
 			}
 		}()
 	}
-	return s.Service.Serve()
+	return s.TickService.OnServe(ctx)
 }

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -24,7 +24,7 @@ const httpShutdownTimeout = 10 * time.Second
 
 // Service is the main advancer service that processes inputs through Cartesi machines
 type Service struct {
-	service.TickService
+	service.TickServiceTemplate
 	inputBatchSize uint64
 	snapshotsDir   string
 	repository     AdvancerRepository
@@ -39,7 +39,7 @@ type Service struct {
 
 // CreateInfo contains the configuration for creating an advancer service
 type CreateInfo struct {
-	service.CreateInfo
+	service.TickServiceConfigs
 	Config     config.AdvancerConfig
 	Repository repository.Repository
 }
@@ -52,11 +52,9 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	s.TickImpl = s
-	c.Impl = s
 	c.EnableReschedule = true
 
-	err = service.NewTickService(&c.CreateInfo, &s.TickService)
+	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +146,7 @@ func (s *Service) OnStop(b bool) []error {
 			errs = append(errs, fmt.Errorf("failed to close machine manager: %w", err))
 		}
 	}
-	return append(errs, s.TickService.OnStop(b)...)
+	return append(errs, s.TickServiceTemplate.OnStop(b)...)
 }
 func (s *Service) OnServe(ctx context.Context) error {
 	if s.inspector != nil {
@@ -159,5 +157,5 @@ func (s *Service) OnServe(ctx context.Context) error {
 			}
 		}()
 	}
-	return s.TickService.OnServe(ctx)
+	return s.TickServiceTemplate.OnServe(ctx)
 }

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -108,9 +108,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 }
 
 // Service interface implementation
-func (s *Service) Alive() bool     { return true }
-func (s *Service) Ready() bool     { return true }
-func (s *Service) Reload() []error { return nil }
 func (s *Service) Tick() []error {
 	hadWork, err := s.Step(s.Context)
 
@@ -134,7 +131,7 @@ func (s *Service) Tick() []error {
 	return []error{err}
 }
 
-func (s *Service) Stop(b bool) []error {
+func (s *Service) OnStop(b bool) []error {
 	// CAS achieves once-semantics: the second caller returns immediately
 	// (fire-and-forget) rather than blocking like sync.Once. This is safe
 	// because the orchestrator calls Cancel() after Stop() and waits for
@@ -161,7 +158,7 @@ func (s *Service) Stop(b bool) []error {
 			errs = append(errs, fmt.Errorf("failed to close machine manager: %w", err))
 		}
 	}
-	return errs
+	return append(errs, s.TickServiceTemplate.OnStop(b)...)
 }
 func (s *Service) Serve() error {
 	if s.inspector != nil {
@@ -173,7 +170,4 @@ func (s *Service) Serve() error {
 		}()
 	}
 	return s.Service.Serve()
-}
-func (s *Service) String() string {
-	return s.Name
 }

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -155,7 +155,7 @@ func (s *Service) OnServe(ctx context.Context) error {
 		go func() {
 			if err := s.inspector.Serve(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 				s.Logger.Error("Inspect HTTP server failed — shutting down", "error", err)
-				s.Cancel()
+				s.Stop(true)
 			}
 		}()
 	}

--- a/internal/advancer/service.go
+++ b/internal/advancer/service.go
@@ -52,7 +52,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	c.EnableReschedule = true
 
 	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
@@ -107,27 +106,23 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 }
 
 // Service interface implementation
-func (s *Service) Tick(ctx context.Context) []error {
-	hadWork, err := s.Step(ctx)
-
+func (s *Service) Tick(ctx context.Context) (bool, []error) {
 	// Signal reschedule whenever work was done, even if some apps errored.
 	// Failed apps are marked Failed and removed by the machine manager,
 	// so they won't cause amplified retries on the next tick.
 	// Without this, one failing app delays all healthy apps by a full poll interval.
-	if hadWork {
-		s.SignalReschedule()
-	}
+	hadWork, err := s.Step(ctx)
 
 	if err == nil {
-		return nil
+		return hadWork, nil
 	}
 	// During shutdown, the machine manager is closed and GetMachine() may
 	// return ErrNoApp. Suppress this to avoid spurious ERR log entries.
 	if errors.Is(err, ErrNoApp) && ctx.Err() != nil {
 		s.Logger.Warn("Tick interrupted by shutdown", "error", err)
-		return nil
+		return hadWork, nil
 	}
-	return []error{err}
+	return hadWork, []error{err}
 }
 
 func (s *Service) OnStop(b bool) []error {

--- a/internal/claimer/claimer.go
+++ b/internal/claimer/claimer.go
@@ -110,6 +110,7 @@ func hashToHex(h *common.Hash) string {
 // database. The epoch is now "submitted" and no longer "computed".
 // Returns the number of confirmed transitions and any error.
 func (s *Service) checkClaimsInFlight(
+	ctx context.Context,
 	computedEpochs map[int64]*model.Epoch,
 	apps map[int64]*model.Application,
 	endBlock *big.Int,
@@ -117,7 +118,7 @@ func (s *Service) checkClaimsInFlight(
 	confirmed := 0
 	// check claims in flight. NOTE: map mutation + iteration is safe in Go
 	for key, txHash := range s.claimsInFlight {
-		ready, receipt, err := s.blockchain.pollTransaction(s.Context, txHash, endBlock)
+		ready, receipt, err := s.blockchain.pollTransaction(ctx, txHash, endBlock)
 		if err != nil {
 			s.Logger.Warn("Claim submission failed, retrying.",
 				"txHash", txHash,
@@ -139,7 +140,7 @@ func (s *Service) checkClaimsInFlight(
 		}
 		if computedEpoch, ok := computedEpochs[key]; ok {
 			err = s.repository.UpdateEpochWithSubmittedClaim(
-				s.Context,
+				ctx,
 				computedEpoch.ApplicationID,
 				computedEpoch.Index,
 				receipt.TxHash,
@@ -168,7 +169,7 @@ func (s *Service) checkClaimsInFlight(
 			// Parse the receipt to transition directly to accepted, saving a
 			// full tick round-trip. Quorum waits for a separate acceptance scan.
 			if app != nil && app.ConsensusType == model.Consensus_Authority {
-				if accepted := s.tryAcceptFromReceipt(receipt, app, computedEpoch); accepted {
+				if accepted := s.tryAcceptFromReceipt(ctx, receipt, app, computedEpoch); accepted {
 					confirmed++
 				}
 			}
@@ -194,6 +195,7 @@ func (s *Service) checkClaimsInFlight(
 // Errors are logged but not propagated — the normal acceptance scan on the
 // next tick will handle the transition if this fast path fails.
 func (s *Service) tryAcceptFromReceipt(
+	ctx context.Context,
 	receipt *types.Receipt,
 	app *model.Application,
 	epoch *model.Epoch,
@@ -213,7 +215,7 @@ func (s *Service) tryAcceptFromReceipt(
 			continue
 		}
 		err = s.repository.UpdateEpochWithAcceptedClaim(
-			s.Context, epoch.ApplicationID, epoch.Index)
+			ctx, epoch.ApplicationID, epoch.Index)
 		if err != nil {
 			s.Logger.Warn("Authority fast-accept: DB update failed, "+
 				"will retry via normal acceptance scan",
@@ -252,7 +254,7 @@ func (s *Service) findClaimSubmittedEventAndSucc(
 	err := checkEpochSequenceConstraint(prevEpoch, currEpoch)
 	if err != nil {
 		err = s.setApplicationInoperable(
-			s.Context,
+			ctx,
 			app,
 			"%v. epoch: %v (%v).",
 			err,
@@ -270,7 +272,7 @@ func (s *Service) findClaimSubmittedEventAndSucc(
 
 	if prevClaimSubmissionEvent == nil {
 		err = s.setApplicationInoperable(
-			s.Context,
+			ctx,
 			app,
 			"application has an invalid epoch: %v (%v). No claim submission event to match.",
 			prevEpoch.Index,
@@ -281,7 +283,7 @@ func (s *Service) findClaimSubmittedEventAndSucc(
 
 	if !claimSubmittedEventMatches(app, prevEpoch, prevClaimSubmissionEvent) {
 		err = s.setApplicationInoperable(
-			s.Context,
+			ctx,
 			app,
 			"application has an invalid epoch: %v (%v), missing claim submitted event (%v).",
 			prevEpoch.Index,
@@ -296,12 +298,13 @@ func (s *Service) findClaimSubmittedEventAndSucc(
 // transition epoch claims from computed to submitted.
 // Returns the number of successful transitions and any errors.
 func (s *Service) submitClaimsAndUpdateDatabase(
+	ctx context.Context,
 	acceptedOrSubmittedEpochs map[int64]*model.Epoch,
 	computedEpochs map[int64]*model.Epoch,
 	apps map[int64]*model.Application,
 	defaultBlockNumber *big.Int,
 ) (int, []error) {
-	confirmed, err := s.checkClaimsInFlight(computedEpochs, apps, defaultBlockNumber)
+	confirmed, err := s.checkClaimsInFlight(ctx, computedEpochs, apps, defaultBlockNumber)
 	if err != nil {
 		return confirmed, []error{err}
 	}
@@ -321,18 +324,18 @@ func (s *Service) submitClaimsAndUpdateDatabase(
 		prevEpoch, prevEpochExists := acceptedOrSubmittedEpochs[key]
 
 		// check address for changes
-		if err := s.checkConsensusForAddressChange(app); err != nil {
+		if err := s.checkConsensusForAddressChange(ctx, app); err != nil {
 			delete(computedEpochs, key)
 			errs = append(errs, err)
 			continue
 		}
 		if prevEpochExists {
 			ic, _, currEvent, err = s.findClaimSubmittedEventAndSucc(
-				s.Context, app, prevEpoch, currEpoch, prevEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
+				ctx, app, prevEpoch, currEpoch, prevEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
 			)
 		} else {
 			ic, currEvent, _, err = s.blockchain.findClaimSubmittedEventAndSucc(
-				s.Context, app, currEpoch, currEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
+				ctx, app, currEpoch, currEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
 			)
 		}
 		if err != nil {
@@ -349,7 +352,7 @@ func (s *Service) submitClaimsAndUpdateDatabase(
 			)
 			if !claimSubmittedEventMatches(app, currEpoch, currEvent) {
 				err = s.setApplicationInoperable(
-					s.Context,
+					ctx,
 					app,
 					"computed claim does not match event. computed_claim=%v, current_event=%v",
 					currEpoch, currEvent,
@@ -365,7 +368,7 @@ func (s *Service) submitClaimsAndUpdateDatabase(
 			)
 			txHash := currEvent.Raw.TxHash
 			err = s.repository.UpdateEpochWithSubmittedClaim(
-				s.Context,
+				ctx,
 				currEpoch.ApplicationID,
 				currEpoch.Index,
 				txHash,
@@ -439,7 +442,7 @@ func (s *Service) submitClaimsAndUpdateDatabase(
 							// to be deterministic, so recomputing
 							// will produce the same divergent hash.
 							err = s.setApplicationInoperable(
-								s.Context,
+								ctx,
 								app,
 								"NotFirstClaim from Quorum consensus: "+
 									"computed claim hash %s differs from "+
@@ -535,6 +538,7 @@ func (s *Service) findClaimAcceptedEventAndSucc(
 // transition claims from submitted to accepted.
 // Returns the number of successful transitions and any errors.
 func (s *Service) acceptClaimsAndUpdateDatabase(
+	ctx context.Context,
 	acceptedEpochs map[int64]*model.Epoch,
 	submittedEpochs map[int64]*model.Epoch,
 	apps map[int64]*model.Application,
@@ -551,7 +555,7 @@ func (s *Service) acceptClaimsAndUpdateDatabase(
 		app := apps[key]
 		prevEpoch, prevEpochExists := acceptedEpochs[key]
 		// check address for changes
-		if err := s.checkConsensusForAddressChange(app); err != nil {
+		if err := s.checkConsensusForAddressChange(ctx, app); err != nil {
 			delete(submittedEpochs, key)
 			errs = append(errs, err)
 			continue
@@ -559,11 +563,11 @@ func (s *Service) acceptClaimsAndUpdateDatabase(
 
 		if prevEpochExists {
 			_, _, currEvent, err = s.findClaimAcceptedEventAndSucc(
-				s.Context, app, prevEpoch, currEpoch, prevEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
+				ctx, app, prevEpoch, currEpoch, prevEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
 			)
 		} else {
 			_, currEvent, _, err = s.blockchain.findClaimAcceptedEventAndSucc(
-				s.Context, app, currEpoch, currEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
+				ctx, app, currEpoch, currEpoch.LastBlock+1, defaultBlockNumber.Uint64(),
 			)
 		}
 		if err != nil {
@@ -585,7 +589,7 @@ func (s *Service) acceptClaimsAndUpdateDatabase(
 					"err", ErrEventMismatch,
 				)
 				err := s.setApplicationInoperable(
-					s.Context,
+					ctx,
 					app,
 					"event mismatch for epoch %v, event tx_hash: %v",
 					currEpoch.Index,
@@ -601,7 +605,7 @@ func (s *Service) acceptClaimsAndUpdateDatabase(
 				"last_block", currEpoch.LastBlock,
 			)
 			txHash := currEvent.Raw.TxHash
-			err = s.repository.UpdateEpochWithAcceptedClaim(s.Context, currEpoch.ApplicationID, currEpoch.Index)
+			err = s.repository.UpdateEpochWithAcceptedClaim(ctx, currEpoch.ApplicationID, currEpoch.Index)
 			if err != nil {
 				delete(submittedEpochs, key)
 				errs = append(errs, err)
@@ -630,15 +634,16 @@ func (s *Service) setApplicationInoperable(
 }
 
 func (s *Service) checkConsensusForAddressChange(
+	ctx context.Context,
 	app *model.Application,
 ) error {
-	newConsensusAddress, err := s.blockchain.getConsensusAddress(s.Context, app)
+	newConsensusAddress, err := s.blockchain.getConsensusAddress(ctx, app)
 	if err != nil {
 		return fmt.Errorf("getting consensus address for app %v: %w", app.IApplicationAddress, err)
 	}
 	if app.IConsensusAddress != newConsensusAddress {
 		err = s.setApplicationInoperable(
-			s.Context,
+			ctx,
 			app,
 			"consensus change detected. application: %v.",
 			app.IApplicationAddress,

--- a/internal/claimer/claimer_test.go
+++ b/internal/claimer/claimer_test.go
@@ -188,8 +188,8 @@ func newServiceMock() (*Service, *claimerRepositoryMock, *claimerBlockchainMock)
 	blockchain := &claimerBlockchainMock{}
 
 	claimer := &Service{
-		TickService: service.TickService{
-			Service: service.Service{
+		TickServiceTemplate: service.TickServiceTemplate{
+			ServiceTemplate: service.ServiceTemplate{
 				Logger: slog.New(handler),
 			},
 		},

--- a/internal/claimer/claimer_test.go
+++ b/internal/claimer/claimer_test.go
@@ -188,8 +188,10 @@ func newServiceMock() (*Service, *claimerRepositoryMock, *claimerBlockchainMock)
 	blockchain := &claimerBlockchainMock{}
 
 	claimer := &Service{
-		Service: service.Service{
-			Logger: slog.New(handler),
+		TickService: service.TickService{
+			Service: service.Service{
+				Logger: slog.New(handler),
+			},
 		},
 		submissionEnabled: true,
 		claimsInFlight:    map[int64]common.Hash{},

--- a/internal/claimer/claimer_test.go
+++ b/internal/claimer/claimer_test.go
@@ -333,7 +333,7 @@ func TestDoNothing(t *testing.T) {
 	prevEpochs := makeEpochMap()
 	currEpochs := makeEpochMap()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(prevEpochs, currEpochs, makeApplicationMap(), big.NewInt(0))
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), prevEpochs, currEpochs, makeApplicationMap(), big.NewInt(0))
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 0, transitions, "no transitions when no epochs to process")
 }
@@ -356,7 +356,7 @@ func TestSubmitFirstClaim(t *testing.T) {
 	b.On("submitClaimToBlockchain", mock.Anything, app, currEpoch).
 		Return(common.HexToHash("0x10"), nil).Once()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 1, len(m.claimsInFlight))
 	assert.Equal(t, 1, transitions, "submitting a claim counts as a transition")
@@ -381,7 +381,7 @@ func TestSubmitClaimWithAntecessor(t *testing.T) {
 	b.On("submitClaimToBlockchain", mock.Anything, app, currEpoch).
 		Return(common.HexToHash("0x10"), nil).Once()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 1, len(m.claimsInFlight))
 	assert.Equal(t, 1, transitions, "submitting a claim counts as a transition")
@@ -404,7 +404,7 @@ func TestSkipSubmitFirstClaim(t *testing.T) {
 	b.On("findClaimSubmittedEventAndSucc", mock.Anything, app, currEpoch, currEpoch.LastBlock+1, endBlock.Uint64()).
 		Return(&iconsensus.IConsensus{}, prevEvent, currEvent, nil).Once()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 0, len(m.claimsInFlight))
 	assert.Equal(t, 0, transitions, "no transition when submission is disabled")
@@ -428,7 +428,7 @@ func TestSkipSubmitClaimWithAntecessor(t *testing.T) {
 	b.On("findClaimSubmittedEventAndSucc", mock.Anything, app, prevEpoch, prevEpoch.LastBlock+1, endBlock.Uint64()).
 		Return(&iconsensus.IConsensus{}, prevEvent, currEvent, nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 0)
 	assert.Equal(t, len(m.claimsInFlight), 0)
 }
@@ -462,7 +462,7 @@ func TestInFlightCompleted(t *testing.T) {
 	r.On("UpdateEpochWithAcceptedClaim", mock.Anything, app.ID, currEpoch.Index).
 		Return(nil).Once()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 0, len(m.claimsInFlight))
 	// Authority fast path: submitted (1) + accepted (1) = 2 transitions.
@@ -499,7 +499,7 @@ func TestInFlightReverted(t *testing.T) {
 	b.On("submitClaimToBlockchain", mock.Anything, app, currEpoch).
 		Return(common.HexToHash("0x10"), nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 0)
 	assert.Equal(t, len(m.claimsInFlight), 1)
 }
@@ -522,7 +522,7 @@ func TestUpdateFirstClaim(t *testing.T) {
 	r.On("UpdateEpochWithSubmittedClaim", mock.Anything, app.ID, currEpoch.Index, currEvent.Raw.TxHash).
 		Return(nil).Once()
 
-	transitions, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 0, len(m.claimsInFlight))
 	assert.Equal(t, 1, transitions, "finding on-chain event counts as a transition")
@@ -547,7 +547,7 @@ func TestUpdateClaimWithAntecessor(t *testing.T) {
 	r.On("UpdateEpochWithSubmittedClaim", mock.Anything, app.ID, currEpoch.Index, currEvent.Raw.TxHash).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 0)
 	assert.Equal(t, len(m.claimsInFlight), 0)
 }
@@ -568,7 +568,7 @@ func TestAcceptFirstClaim(t *testing.T) {
 	b.On("getConsensusAddress", mock.Anything, app).
 		Return(app.IConsensusAddress, nil).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 0)
 }
 
@@ -591,7 +591,7 @@ func TestAcceptClaimWithAntecessor(t *testing.T) {
 	r.On("UpdateEpochWithAcceptedClaim", mock.Anything, app.ID, currEpoch.Index).
 		Return(nil).Once()
 
-	transitions, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	transitions, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 1, transitions, "accepting a claim counts as a transition")
 }
@@ -615,7 +615,7 @@ func TestClaimInFlightMissingFromCurrClaims(t *testing.T) {
 	b.On("pollTransaction", mock.Anything, reqHash, endBlock).
 		Return(true, receipt, nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 0)
 }
 
@@ -647,7 +647,7 @@ func TestSubmitFailedClaim(t *testing.T) {
 	b.On("submitClaimToBlockchain", mock.Anything, app, currEpoch).
 		Return(common.HexToHash("0x10"), nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 }
 
@@ -675,7 +675,7 @@ func TestNotFirstClaimHandledGracefully(t *testing.T) {
 		Return(common.Hash{}, notFirstClaimError()).Once()
 
 	_, errs := m.submitClaimsAndUpdateDatabase(
-		makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+		context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 0, len(errs))
 	assert.Equal(t, 0, len(m.claimsInFlight))
 }
@@ -706,7 +706,7 @@ func TestNotFirstClaimQuorumSetsInoperable(t *testing.T) {
 		Return(nil).Once()
 
 	_, errs := m.submitClaimsAndUpdateDatabase(
-		makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+		context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 	assert.Equal(t, 0, len(m.claimsInFlight))
 }
@@ -739,7 +739,7 @@ func TestSubmitClaimWithAntecessorMismatch(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, int64(0), model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -763,7 +763,7 @@ func TestSubmitClaimWithEventMismatch(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, int64(0), model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -782,7 +782,7 @@ func TestSubmitClaimWithAntecessorOutOfOrder(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, int64(0), model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), big.NewInt(0))
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), big.NewInt(0))
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -805,7 +805,7 @@ func TestErrSubmittedMissingEvent(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, int64(0), model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -826,7 +826,7 @@ func TestConsensusAddressChangedOnSubmittedClaims(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, int64(0), model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.submitClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.submitClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 1)
 }
 
@@ -850,7 +850,7 @@ func TestFindClaimAcceptedEventAndSuccFailure0(t *testing.T) {
 	b.On("findClaimAcceptedEventAndSucc", mock.Anything, app, currEpoch, currEpoch.LastBlock+1, endBlock.Uint64()).
 		Return(&iconsensus.IConsensus{}, prevEvent, currEvent, expectedErr).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -873,7 +873,7 @@ func TestFindClaimAcceptedEventAndSuccFailure1(t *testing.T) {
 	b.On("findClaimAcceptedEventAndSucc", mock.Anything, app, prevEpoch, prevEpoch.LastBlock+1, endBlock.Uint64()).
 		Return(&iconsensus.IConsensus{}, prevEvent, currEvent, expectedErr).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -902,7 +902,7 @@ func TestAcceptClaimWithAntecessorMismatch(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, mock.Anything, model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -927,7 +927,7 @@ func TestAcceptClaimWithEventMismatch(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, mock.Anything, model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -947,7 +947,7 @@ func TestAcceptClaimWithAntecessorOutOfOrder(t *testing.T) {
 		Return(nil).
 		Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(wrongEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), big.NewInt(0))
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(wrongEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), big.NewInt(0))
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -970,7 +970,7 @@ func TestErrAcceptedMissingEvent(t *testing.T) {
 	r.On("UpdateApplicationState", mock.Anything, mock.Anything, model.ApplicationState_Inoperable, mock.Anything).
 		Return(nil).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -995,7 +995,7 @@ func TestUpdateEpochWithAcceptedClaimFailed(t *testing.T) {
 	r.On("UpdateEpochWithAcceptedClaim", mock.Anything, app.ID, currEpoch.Index).
 		Return(expectedErr).Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(prevEpoch), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, 1, len(errs))
 }
 
@@ -1017,6 +1017,6 @@ func TestConsensusAddressChangedOnAcceptedClaims(t *testing.T) {
 		Return(nil).
 		Once()
 
-	_, errs := m.acceptClaimsAndUpdateDatabase(makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
+	_, errs := m.acceptClaimsAndUpdateDatabase(context.Background(), makeEpochMap(), makeEpochMap(currEpoch), makeApplicationMap(app), endBlock)
 	assert.Equal(t, len(errs), 1)
 }

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -30,7 +30,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.Service
+	service.TickService
 
 	repository iclaimerRepository
 	blockchain iclaimerBlockchain
@@ -68,10 +68,11 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
+	s.TickImpl = s
 	c.Impl = s
 	c.EnableReschedule = true
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.NewTickService(&c.CreateInfo, &s.TickService)
 	if err != nil {
 		return nil, fmt.Errorf("creating base service: %w", err)
 	}
@@ -118,19 +119,19 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 }
 
 // NOTE: tick is not re-entrant!
-func (s *Service) Tick() []error {
+func (s *Service) Tick(ctx context.Context) []error {
 	errs := []error{}
 
 	// gather epochs pairs with open claims, either:
 	// - computed but not yet submitted
-	acceptedOrSubmittedEpochs, computedEpochs, computedApps, errSubmitted := s.repository.SelectSubmittedClaimPairsPerApp(s.Context)
+	acceptedOrSubmittedEpochs, computedEpochs, computedApps, errSubmitted := s.repository.SelectSubmittedClaimPairsPerApp(ctx)
 	if errSubmitted != nil {
 		errs = append(errs, errSubmitted)
 		return errs
 	}
 
 	// - submitted but not yet accepted.
-	acceptedEpochs, submittedEpochs, submittedApps, errAccepted := s.repository.SelectAcceptedClaimPairsPerApp(s.Context)
+	acceptedEpochs, submittedEpochs, submittedApps, errAccepted := s.repository.SelectAcceptedClaimPairsPerApp(ctx)
 	if errAccepted != nil {
 		errs = append(errs, errAccepted)
 		return errs
@@ -147,7 +148,7 @@ func (s *Service) Tick() []error {
 	}
 
 	// we have claims to check. Get the latest/safe/finalized, etc. block
-	defaultBlockNumber, err := s.blockchain.getDefaultBlockNumber(s.Context)
+	defaultBlockNumber, err := s.blockchain.getDefaultBlockNumber(ctx)
 	if err != nil {
 		errs = append(errs, err)
 		return errs

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -154,8 +154,8 @@ func (s *Service) Tick(ctx context.Context) []error {
 		return errs
 	}
 
-	submitted, submitErrs := s.submitClaimsAndUpdateDatabase(acceptedOrSubmittedEpochs, computedEpochs, computedApps, defaultBlockNumber)
-	accepted, acceptErrs := s.acceptClaimsAndUpdateDatabase(acceptedEpochs, submittedEpochs, submittedApps, defaultBlockNumber)
+	submitted, submitErrs := s.submitClaimsAndUpdateDatabase(ctx, acceptedOrSubmittedEpochs, computedEpochs, computedApps, defaultBlockNumber)
+	accepted, acceptErrs := s.acceptClaimsAndUpdateDatabase(ctx, acceptedEpochs, submittedEpochs, submittedApps, defaultBlockNumber)
 	errs = append(errs, submitErrs...)
 	errs = append(errs, acceptErrs...)
 

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -117,23 +117,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	return s, nil
 }
 
-func (s *Service) Alive() bool {
-	return true
-}
-
-func (s *Service) Ready() bool {
-	return true
-}
-
-func (s *Service) Reload() []error {
-	return nil
-}
-
-func (s *Service) Stop(bool) []error {
-	s.SetStopping()
-	return nil
-}
-
 // NOTE: tick is not re-entrant!
 func (s *Service) Tick() []error {
 	errs := []error{}

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -68,7 +68,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	c.EnableReschedule = true
 
 	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
@@ -117,7 +116,7 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 }
 
 // NOTE: tick is not re-entrant!
-func (s *Service) Tick(ctx context.Context) []error {
+func (s *Service) Tick(ctx context.Context) (bool, []error) {
 	errs := []error{}
 
 	// gather epochs pairs with open claims, either:
@@ -125,14 +124,14 @@ func (s *Service) Tick(ctx context.Context) []error {
 	acceptedOrSubmittedEpochs, computedEpochs, computedApps, errSubmitted := s.repository.SelectSubmittedClaimPairsPerApp(ctx)
 	if errSubmitted != nil {
 		errs = append(errs, errSubmitted)
-		return errs
+		return false, errs
 	}
 
 	// - submitted but not yet accepted.
 	acceptedEpochs, submittedEpochs, submittedApps, errAccepted := s.repository.SelectAcceptedClaimPairsPerApp(ctx)
 	if errAccepted != nil {
 		errs = append(errs, errAccepted)
-		return errs
+		return false, errs
 	}
 
 	s.Logger.Debug("Processing claims for epochs",
@@ -142,14 +141,14 @@ func (s *Service) Tick(ctx context.Context) []error {
 
 	// return early if there is nothing to do
 	if len(computedEpochs) == 0 && len(submittedEpochs) == 0 {
-		return nil
+		return false, nil
 	}
 
 	// we have claims to check. Get the latest/safe/finalized, etc. block
 	defaultBlockNumber, err := s.blockchain.getDefaultBlockNumber(ctx)
 	if err != nil {
 		errs = append(errs, err)
-		return errs
+		return false, errs
 	}
 
 	submitted, submitErrs := s.submitClaimsAndUpdateDatabase(ctx, acceptedOrSubmittedEpochs, computedEpochs, computedApps, defaultBlockNumber)
@@ -162,10 +161,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 	// Confirming a submission enables the acceptance scan on the next tick.
 	// Erring apps are retried on the next tick regardless; suppressing
 	// reschedule would delay healthy apps by a full poll interval.
-	if submitted > 0 || accepted > 0 {
-		s.SignalReschedule()
-	}
-	return errs
+	return submitted > 0 || accepted > 0, errs
 }
 
 func setupPersistentConfig(

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -21,7 +21,7 @@ import (
 )
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.TickServiceConfigs
 
 	Config config.ClaimerConfig
 
@@ -30,7 +30,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.TickService
+	service.TickServiceTemplate
 
 	repository iclaimerRepository
 	blockchain iclaimerBlockchain
@@ -68,11 +68,9 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	s.TickImpl = s
-	c.Impl = s
 	c.EnableReschedule = true
 
-	err = service.NewTickService(&c.CreateInfo, &s.TickService)
+	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
 		return nil, fmt.Errorf("creating base service: %w", err)
 	}

--- a/internal/claimer/service.go
+++ b/internal/claimer/service.go
@@ -51,7 +51,7 @@ type PersistentConfig struct {
 	ChainID                uint64
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 
 	if c == nil {
@@ -111,6 +111,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 		txOpts:       txOpts,
 		defaultBlock: c.Config.BlockchainDefaultBlock,
 	}
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/evmreader/evmreader.go
+++ b/internal/evmreader/evmreader.go
@@ -94,7 +94,7 @@ func (r *Service) Run(ctx context.Context, ready chan struct{}) error {
 	for {
 		headersProcessed, err := r.watchForNewBlocks(ctx, ready)
 		if ctx.Err() != nil {
-			return ctx.Err()
+			return nil
 		}
 		r.Logger.Error("watchForNewBlocks exited",
 			"error", err, "headers_processed", headersProcessed)
@@ -123,7 +123,7 @@ func (r *Service) Run(ctx context.Context, ready chan struct{}) error {
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil
 		case <-time.After(r.blockchainSubscriptionRetryInterval):
 		}
 	}

--- a/internal/evmreader/evmreader_test.go
+++ b/internal/evmreader/evmreader_test.go
@@ -73,8 +73,8 @@ func (s *EvmReaderSuite) SetupTest() {
 	logLevel, err := config.GetLogLevel()
 	s.Require().NoError(err)
 
-	serviceArgs := &service.CreateInfo{Name: "evm-reader", Impl: s.evmReader, LogLevel: logLevel}
-	err = service.Create(context.Background(), serviceArgs, &s.evmReader.Service)
+	serviceArgs := &service.ServiceConfigs{Name: "evm-reader", LogLevel: logLevel}
+	err = service.InitServiceTemplate(serviceArgs, &s.evmReader.ServiceTemplate, s.evmReader)
 	s.Require().NoError(err)
 }
 
@@ -89,7 +89,7 @@ func (s *EvmReaderSuite) TestItStopsWhenContextIsCanceled() {
 	cancel()
 
 	err := <-errChannel
-	s.Require().Equal(context.Canceled, err, "stopped for the wrong reason")
+	s.Require().Nil(err, "stopped with an error when canceled")
 }
 
 func (s *EvmReaderSuite) TestItEventuallyBecomesReady() {
@@ -192,7 +192,7 @@ func (s *EvmReaderSuite) TestRunStopsDuringRetryWhenContextCanceled() {
 		Return(sub, fmt.Errorf("connection refused"))
 
 	err := s.evmReader.Run(ctx, make(chan struct{}, 1))
-	s.Require().ErrorIs(err, context.Canceled)
+	s.Require().Nil(err)
 }
 
 func (s *EvmReaderSuite) TestItFailsToSubscribeForNewInputsOnStart() {

--- a/internal/evmreader/output_test.go
+++ b/internal/evmreader/output_test.go
@@ -4,7 +4,6 @@
 package evmreader
 
 import (
-	"context"
 	"errors"
 	"math/big"
 	"time"
@@ -475,8 +474,8 @@ func (s *EvmReaderSuite) setupOutputMismatchTest() {
 	logLevel, err := config.GetLogLevel()
 	s.Require().NoError(err)
 
-	serviceArgs := &service.CreateInfo{Name: "evm-reader", Impl: s.evmReader, LogLevel: logLevel}
-	err = service.Create(context.Background(), serviceArgs, &s.evmReader.Service)
+	serviceArgs := &service.ServiceConfigs{Name: "evm-reader", LogLevel: logLevel}
+	err = service.InitServiceTemplate(serviceArgs, &s.evmReader.ServiceTemplate, s.evmReader)
 	s.Require().NoError(err)
 
 	apps := copyApplications(applications)

--- a/internal/evmreader/sealedepochs_test.go
+++ b/internal/evmreader/sealedepochs_test.go
@@ -56,8 +56,8 @@ func (s *SealedEpochsSuite) SetupTest() {
 
 	logLevel, err := config.GetLogLevel()
 	s.Require().NoError(err)
-	serviceArgs := &service.CreateInfo{Name: "evm-reader", Impl: s.evmReader, LogLevel: logLevel}
-	err = service.Create(context.Background(), serviceArgs, &s.evmReader.Service)
+	serviceArgs := &service.ServiceConfigs{Name: "evm-reader", LogLevel: logLevel}
+	err = service.InitServiceTemplate(serviceArgs, &s.evmReader.ServiceTemplate, s.evmReader)
 	s.Require().NoError(err)
 }
 

--- a/internal/evmreader/service.go
+++ b/internal/evmreader/service.go
@@ -20,7 +20,7 @@ import (
 )
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.ServiceConfigs
 
 	Config config.EvmreaderConfig
 
@@ -31,7 +31,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.Service
+	service.ServiceTemplate
 
 	client                              EthClientInterface
 	wsClient                            EthClientInterface
@@ -63,9 +63,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	c.Impl = s
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.InitServiceTemplate(&c.ServiceConfigs, &s.ServiceTemplate, s)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/evmreader/service.go
+++ b/internal/evmreader/service.go
@@ -140,26 +140,20 @@ func (s *Service) Ready() bool {
 	return s.ready.Load()
 }
 
-func (s *Service) Serve() error {
+func (s *Service) OnServe(ctx context.Context) error {
 	s.alive.Store(true)
 	ready := make(chan struct{}, 1)
-	go func() {
-		defer s.alive.Store(false)
-		defer s.ready.Store(false)
-		err := s.Run(s.Context, ready)
-		if err != nil && s.Context.Err() == nil {
-			s.Logger.Error("Run exited with error", "error", err)
-		}
-		s.Cancel()
-	}()
 	go func() {
 		select {
 		case <-ready:
 			s.ready.Store(true)
-		case <-s.Context.Done():
+		case <-ctx.Done():
 		}
 	}()
-	return s.Service.Serve()
+
+	defer s.alive.Store(false)
+	defer s.ready.Store(false)
+	return s.Run(ctx, ready)
 }
 
 func (s *Service) setupPersistentConfig(

--- a/internal/evmreader/service.go
+++ b/internal/evmreader/service.go
@@ -140,19 +140,6 @@ func (s *Service) Ready() bool {
 	return s.ready.Load()
 }
 
-func (s *Service) Reload() []error {
-	return nil
-}
-
-func (s *Service) Stop(bool) []error {
-	s.SetStopping()
-	return nil
-}
-
-func (s *Service) Tick() []error {
-	return []error{}
-}
-
 func (s *Service) Serve() error {
 	s.alive.Store(true)
 	ready := make(chan struct{}, 1)
@@ -173,10 +160,6 @@ func (s *Service) Serve() error {
 		}
 	}()
 	return s.Service.Serve()
-}
-
-func (s *Service) String() string {
-	return s.Name
 }
 
 func (s *Service) setupPersistentConfig(

--- a/internal/evmreader/service.go
+++ b/internal/evmreader/service.go
@@ -56,7 +56,7 @@ type PersistentConfig struct {
 	ChainID            uint64
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 	if err = ctx.Err(); err != nil {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
@@ -126,6 +126,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 			Logger:       s.Logger,
 		},
 	}
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/evmreader/service_config_test.go
+++ b/internal/evmreader/service_config_test.go
@@ -35,7 +35,7 @@ func TestCreateWithNilEthClient(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = Create(context.Background(), &CreateInfo{
-		CreateInfo: service.CreateInfo{Name: "evm-reader", LogLevel: logLevel},
+		ServiceConfigs: service.ServiceConfigs{Name: "evm-reader", LogLevel: logLevel},
 	})
 	require.ErrorContains(t, err, "EthClient on evmreader service Create is nil")
 }

--- a/internal/jsonrpc/service.go
+++ b/internal/jsonrpc/service.go
@@ -102,25 +102,7 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	return s, nil
 }
 
-func (s *Service) Alive() bool {
-	return true
-}
-
-func (s *Service) Ready() bool {
-	return true
-}
-
-func (s *Service) Reload() []error {
-	return nil
-}
-
-func (s *Service) Tick() []error {
-	// No periodic tasks.
-	return nil
-}
-
-func (s *Service) Stop(_ bool) []error {
-	s.SetStopping()
+func (s *Service) OnStop(_ bool) []error {
 	var errs []error
 	s.Logger.Info("Shutting down JSON-RPC HTTP server", "addr", s.server.Addr)
 	ctx, cancel := context.WithTimeout(context.Background(), jsonrpcShutdownTimeout)
@@ -129,10 +111,6 @@ func (s *Service) Stop(_ bool) []error {
 		errs = append(errs, err)
 	}
 	return errs
-}
-
-func (s *Service) String() string {
-	return s.Name
 }
 
 func (s *Service) Serve() error {

--- a/internal/jsonrpc/service.go
+++ b/internal/jsonrpc/service.go
@@ -28,7 +28,7 @@ const jsonrpcShutdownTimeout = 5 * time.Second
 
 // Service implements the IService interface.
 type Service struct {
-	service.Service
+	service.ServiceTemplate
 	repository repository.Repository
 	server     *http.Server
 	admission  *service.SemaphoreAdmission
@@ -40,7 +40,7 @@ type Service struct {
 }
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.ServiceConfigs
 
 	Config config.JsonrpcConfig
 
@@ -54,9 +54,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	c.Impl = s
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.InitServiceTemplate(&c.ServiceConfigs, &s.ServiceTemplate, s)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/jsonrpc/service.go
+++ b/internal/jsonrpc/service.go
@@ -113,7 +113,7 @@ func (s *Service) OnStop(_ bool) []error {
 	return errs
 }
 
-func (s *Service) Serve() error {
+func (s *Service) OnServe(ctx context.Context) error {
 	listener, err := s.listen("tcp", s.server.Addr)
 	if err != nil {
 		return err
@@ -135,26 +135,18 @@ func (s *Service) Serve() error {
 		serverDone <- err
 	}()
 
-	serviceDone := make(chan error, 1)
-	go func() {
-		// Run the shared service loop concurrently because it blocks waiting
-		// for signals/context cancellation while the HTTP server blocks
-		// waiting for connections.
-		serviceDone <- s.Service.Serve()
-	}()
-
 	select {
 	case err := <-serverDone:
 		// The HTTP loop exited first. This is unexpected unless the listener
 		// failed or the server was already closed, so cancel the framework
 		// loop and wait for it to observe the cancellation before returning.
 		s.Cancel()
-		serviceErr := <-serviceDone
+		<-ctx.Done()
 		if err != nil {
 			return err
 		}
-		return serviceErr
-	case err := <-serviceDone:
+		return nil
+	case <-ctx.Done():
 		// The framework loop exited first because it handled a shutdown signal
 		// or context cancellation and called Stop(), which should trigger
 		// s.server.Shutdown(). Wait for the HTTP loop to finish so Serve()
@@ -163,6 +155,6 @@ func (s *Service) Serve() error {
 		if serverErr != nil {
 			return serverErr
 		}
-		return err
+		return nil
 	}
 }

--- a/internal/jsonrpc/service.go
+++ b/internal/jsonrpc/service.go
@@ -140,7 +140,7 @@ func (s *Service) OnServe(ctx context.Context) error {
 		// The HTTP loop exited first. This is unexpected unless the listener
 		// failed or the server was already closed, so cancel the framework
 		// loop and wait for it to observe the cancellation before returning.
-		s.Cancel()
+		s.Stop(true)
 		<-ctx.Done()
 		if err != nil {
 			return err

--- a/internal/jsonrpc/service.go
+++ b/internal/jsonrpc/service.go
@@ -47,7 +47,7 @@ type CreateInfo struct {
 	Repository repository.Repository
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 	if err = ctx.Err(); err != nil {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
@@ -96,6 +96,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 	if s.listen == nil {
 		s.listen = net.Listen
 	}
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/jsonrpc/util_test.go
+++ b/internal/jsonrpc/util_test.go
@@ -115,7 +115,7 @@ func newTestServiceFull(t *testing.T, name string, maxInflight uint64, corsOrigi
 	s, err := Create(ctx, &ci)
 	require.NoError(t, err, "on new test service")
 
-	return s
+	return s.(*Service)
 }
 
 func nameToNumber(in string) uint64 {

--- a/internal/jsonrpc/util_test.go
+++ b/internal/jsonrpc/util_test.go
@@ -101,7 +101,7 @@ func newTestServiceFull(t *testing.T, name string, maxInflight uint64, corsOrigi
 	require.NoError(t, err)
 
 	ci := CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:     name,
 			LogLevel: logLevel,
 			LogColor: true,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -47,7 +47,7 @@ type Service struct {
 	Repository repository.Repository
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 
 	if err = ctx.Err(); err != nil {
@@ -67,6 +67,9 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 		s.Logger.Error(fmt.Sprint(err))
 		return nil, err
 	}
+
+	s.LogConfig(c.Config)
+
 	return s, nil
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -54,6 +54,11 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
 	}
 
+	// setup node and all child services to share the same context.
+	ctx, cancel := context.WithCancel(context.Background())
+	c.CreateInfo.Context = ctx
+	c.CreateInfo.Cancel = cancel
+
 	s := &Service{}
 	c.Impl = s
 
@@ -164,8 +169,8 @@ func newEVMReader(ctx context.Context, c *CreateInfo, s *Service) (service.IServ
 	readerArgs := evmreader.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServiceEvmReader,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceEvmReader, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -189,8 +194,8 @@ func newAdvancer(ctx context.Context, c *CreateInfo, s *Service) (service.IServi
 	advancerArgs := advancer.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServiceAdvancer,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceAdvancer, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -213,8 +218,8 @@ func newValidator(ctx context.Context, c *CreateInfo, s *Service) (service.IServ
 	validatorArgs := validator.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServiceValidator,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceValidator, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -237,8 +242,8 @@ func newClaimer(ctx context.Context, c *CreateInfo, s *Service) (service.IServic
 	claimerArgs := claimer.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServiceClaimer,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceClaimer, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -262,8 +267,8 @@ func newJsonrpc(ctx context.Context, c *CreateInfo, s *Service) (service.IServic
 	jsonrpcArgs := jsonrpc.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServiceJsonrpc,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceJsonrpc, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -285,8 +290,8 @@ func newPrt(ctx context.Context, c *CreateInfo, s *Service) (service.IService, e
 	prtArgs := prt.CreateInfo{
 		CreateInfo: service.CreateInfo{
 			Name:                 config.ServicePrt,
-			Context:              s.Context,
-			Cancel:               s.Cancel,
+			Context:              c.CreateInfo.Context,
+			Cancel:               c.CreateInfo.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServicePrt, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -142,10 +142,7 @@ func (me *Service) Ready() bool {
 	return allReady
 }
 
-func (s *Service) Reload() []error { return nil }
-func (s *Service) Tick() []error   { return nil }
-func (me *Service) Stop(force bool) []error {
-	me.SetStopping()
+func (me *Service) OnStop(force bool) []error {
 	errs := []error{}
 	for _, s := range me.Children {
 		errs = append(errs, s.Stop(force)...)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -29,7 +29,7 @@ type serviceResult struct {
 }
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.ServiceConfigs
 
 	Config config.NodeConfig
 
@@ -41,7 +41,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.Service
+	service.ServiceTemplate
 
 	Children   []service.IService
 	Repository repository.Repository
@@ -56,13 +56,12 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 
 	// setup node and all child services to share the same context.
 	ctx, cancel := context.WithCancel(context.Background())
-	c.CreateInfo.Context = ctx
-	c.CreateInfo.Cancel = cancel
+	c.ServiceConfigs.Context = ctx
+	c.ServiceConfigs.Cancel = cancel
 
 	s := &Service{}
-	c.Impl = s
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.InitServiceTemplate(&c.ServiceConfigs, &s.ServiceTemplate, s)
 	if err != nil {
 		return nil, err
 	}
@@ -167,10 +166,10 @@ func (me *Service) OnServe(ctx context.Context) error {
 
 func newEVMReader(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	readerArgs := evmreader.CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:                 config.ServiceEvmReader,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
+			Context:              c.ServiceConfigs.Context,
+			Cancel:               c.ServiceConfigs.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceEvmReader, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -192,16 +191,17 @@ func newEVMReader(ctx context.Context, c *CreateInfo, s *Service) (service.IServ
 
 func newAdvancer(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	advancerArgs := advancer.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceAdvancer,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceAdvancer, c.Config.LogLevel),
-			LogColor:             c.Config.LogColor,
-			EnableSignalHandling: false,
-			TelemetryCreate:      false,
-			PollInterval:         c.Config.AdvancerPollingInterval,
-			ServeMux:             s.ServeMux,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   c.Config.AdvancerPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceAdvancer,
+				Context:              c.ServiceConfigs.Context,
+				Cancel:               c.ServiceConfigs.Cancel,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceAdvancer, c.Config.LogLevel),
+				LogColor:             c.Config.LogColor,
+				EnableSignalHandling: false,
+				TelemetryCreate:      false,
+			},
 		},
 		Repository: c.Repository,
 		Config:     *c.Config.ToAdvancerConfig(),
@@ -216,16 +216,17 @@ func newAdvancer(ctx context.Context, c *CreateInfo, s *Service) (service.IServi
 
 func newValidator(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	validatorArgs := validator.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceValidator,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceValidator, c.Config.LogLevel),
-			LogColor:             c.Config.LogColor,
-			EnableSignalHandling: false,
-			TelemetryCreate:      false,
-			PollInterval:         c.Config.ValidatorPollingInterval,
-			ServeMux:             s.ServeMux,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   c.Config.ValidatorPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceValidator,
+				Context:              c.ServiceConfigs.Context,
+				Cancel:               c.ServiceConfigs.Cancel,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceValidator, c.Config.LogLevel),
+				LogColor:             c.Config.LogColor,
+				EnableSignalHandling: false,
+				TelemetryCreate:      false,
+			},
 		},
 		Repository: c.Repository,
 		Config:     *c.Config.ToValidatorConfig(),
@@ -240,16 +241,17 @@ func newValidator(ctx context.Context, c *CreateInfo, s *Service) (service.IServ
 
 func newClaimer(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	claimerArgs := claimer.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServiceClaimer,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServiceClaimer, c.Config.LogLevel),
-			LogColor:             c.Config.LogColor,
-			EnableSignalHandling: false,
-			TelemetryCreate:      false,
-			PollInterval:         c.Config.ClaimerPollingInterval,
-			ServeMux:             s.ServeMux,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   c.Config.ClaimerPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServiceClaimer,
+				Context:              c.ServiceConfigs.Context,
+				Cancel:               c.ServiceConfigs.Cancel,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServiceClaimer, c.Config.LogLevel),
+				LogColor:             c.Config.LogColor,
+				EnableSignalHandling: false,
+				TelemetryCreate:      false,
+			},
 		},
 		EthConn:    c.ClaimerClient,
 		Repository: c.Repository,
@@ -265,10 +267,10 @@ func newClaimer(ctx context.Context, c *CreateInfo, s *Service) (service.IServic
 
 func newJsonrpc(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	jsonrpcArgs := jsonrpc.CreateInfo{
-		CreateInfo: service.CreateInfo{
+		ServiceConfigs: service.ServiceConfigs{
 			Name:                 config.ServiceJsonrpc,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
+			Context:              c.ServiceConfigs.Context,
+			Cancel:               c.ServiceConfigs.Cancel,
 			LogLevel:             config.ResolveServiceLogLevel(config.ServiceJsonrpc, c.Config.LogLevel),
 			LogColor:             c.Config.LogColor,
 			EnableSignalHandling: false,
@@ -288,16 +290,17 @@ func newJsonrpc(ctx context.Context, c *CreateInfo, s *Service) (service.IServic
 
 func newPrt(ctx context.Context, c *CreateInfo, s *Service) (service.IService, error) {
 	prtArgs := prt.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:                 config.ServicePrt,
-			Context:              c.CreateInfo.Context,
-			Cancel:               c.CreateInfo.Cancel,
-			LogLevel:             config.ResolveServiceLogLevel(config.ServicePrt, c.Config.LogLevel),
-			LogColor:             c.Config.LogColor,
-			EnableSignalHandling: false,
-			TelemetryCreate:      false,
-			PollInterval:         c.Config.PrtPollingInterval,
-			ServeMux:             s.ServeMux,
+		TickServiceConfigs: service.TickServiceConfigs{
+			PollInterval:   c.Config.PrtPollingInterval,
+			ServiceConfigs: service.ServiceConfigs{
+				Name:                 config.ServicePrt,
+				Context:              c.ServiceConfigs.Context,
+				Cancel:               c.ServiceConfigs.Cancel,
+				LogLevel:             config.ResolveServiceLogLevel(config.ServicePrt, c.Config.LogLevel),
+				LogColor:             c.Config.LogColor,
+				EnableSignalHandling: false,
+				TelemetryCreate:      false,
+			},
 		},
 		EthClient:  c.PrtClient,
 		Repository: c.Repository,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -5,6 +5,7 @@ package node
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/cartesi/rollups-node/pkg/service"
@@ -155,10 +156,25 @@ func (me *Service) OnStop(force bool) []error {
 }
 
 func (me *Service) OnServe(ctx context.Context) error {
-	for _, s := range me.Children {
-		go s.Serve()
+	childrenCount := len(me.Children)
+	errCh := make(chan error, childrenCount)
+	for _, child := range me.Children {
+		child := child
+		go func() { errCh <- child.Serve() }()
 	}
-	<-ctx.Done()
+
+	errs := make([]error, 0)
+	for range childrenCount {
+		err := <-errCh
+		if err != nil && !errors.Is(err, context.Canceled) {
+			me.Stop(true)
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+
 	return nil
 }
 

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -150,11 +150,12 @@ func (me *Service) OnStop(force bool) []error {
 	return errs
 }
 
-func (me *Service) Serve() error {
+func (me *Service) OnServe(ctx context.Context) error {
 	for _, s := range me.Children {
 		go s.Serve()
 	}
-	return me.Service.Serve()
+	<-ctx.Done()
+	return nil
 }
 
 // services creation

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -1,0 +1,173 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cartesi/rollups-node/pkg/service"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type blockingChildImpl struct {
+	service.ServiceTemplate
+	started chan struct{}
+	done    chan struct{}
+	once    sync.Once
+}
+
+func (c *blockingChildImpl) OnServe(ctx context.Context) error {
+	close(c.started)
+	<-ctx.Done()
+	c.once.Do(func() { close(c.done) })
+	return nil
+}
+
+func createBlockingChild(t *testing.T, cfg *service.ServiceConfigs, name string) *blockingChildImpl {
+	t.Helper()
+	childCfg := *cfg
+	childCfg.Name = name
+
+	child := &blockingChildImpl{
+		started: make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+	require.NoError(t, service.InitServiceTemplate(&childCfg, &child.ServiceTemplate, child))
+	return child
+}
+
+type NodeSuite struct {
+	suite.Suite
+}
+
+func TestServe(t *testing.T) {
+	suite.Run(t, new(NodeSuite))
+}
+
+func (s *NodeSuite) TestNodeStopCancelsChildContexts() {
+	ctx, cancel := context.WithCancel(context.Background())
+	parentCfg := service.ServiceConfigs{
+		Name:     "node",
+		LogLevel: slog.LevelError,
+		Context:  ctx,
+		Cancel:   cancel,
+	}
+
+	nodeSvc := &Service{}
+	require.NoError(s.T(), service.InitServiceTemplate(&parentCfg, &nodeSvc.ServiceTemplate, nodeSvc))
+
+	child1 := createBlockingChild(s.T(), &parentCfg, "child-1")
+	child2 := createBlockingChild(s.T(), &parentCfg, "child-2")
+	nodeSvc.Children = []service.IService{child1, child2}
+
+	done := make(chan struct{})
+	go func() {
+		_ = nodeSvc.Serve()
+		close(done)
+	}()
+
+	select {
+	case <-child1.started:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-1 did not start")
+	}
+	select {
+	case <-child2.started:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-2 did not start")
+	}
+
+	nodeSvc.Stop(false)
+
+	select {
+	case <-child1.done:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-1 did not observe ctx.Done()")
+	}
+	select {
+	case <-child2.done:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-2 did not observe ctx.Done()")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		s.Fail("node did not exit after Stop()")
+	}
+}
+
+type errorChildImpl struct {
+	service.ServiceTemplate
+	started chan struct{}
+}
+
+func (c *errorChildImpl) OnServe(ctx context.Context) error {
+	close(c.started)
+	time.Sleep(10 * time.Millisecond)
+	return fmt.Errorf("Oops %s!", c.Name)
+}
+
+func createErrorChild(t *testing.T, cfg *service.ServiceConfigs, name string) *errorChildImpl {
+	t.Helper()
+	childCfg := *cfg
+	childCfg.Name = name
+
+	child := &errorChildImpl{
+		started: make(chan struct{}),
+	}
+	require.NoError(t, service.InitServiceTemplate(&childCfg, &child.ServiceTemplate, child))
+	return child
+}
+
+func (s *NodeSuite) TestNodeReturnChildErrors() {
+
+	ctx, cancel := context.WithCancel(context.Background())
+	parentCfg := service.ServiceConfigs{
+		Name:     "node",
+		LogLevel: slog.LevelError,
+		Context:  ctx,
+		Cancel:   cancel,
+	}
+
+	nodeSvc := &Service{}
+	require.NoError(s.T(), service.InitServiceTemplate(&parentCfg, &nodeSvc.ServiceTemplate, nodeSvc))
+
+	child1 := createErrorChild(s.T(), &parentCfg, "child-1")
+	child2 := createErrorChild(s.T(), &parentCfg, "child-2")
+	nodeSvc.Children = []service.IService{child1, child2}
+
+	done := make(chan error)
+	go func() {
+		err := nodeSvc.Serve()
+		done <- err
+		close(done)
+	}()
+
+	select {
+	case <-child1.started:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-1 did not start")
+	}
+	select {
+	case <-child2.started:
+	case <-time.After(2 * time.Second):
+		s.Fail("child-2 did not start")
+	}
+
+	select {
+	case err := <-done:
+		s.ErrorContains(err, "Oops child-1!")
+		s.ErrorContains(err, "Oops child-2!")
+	case <-time.After(2 * time.Second):
+		s.Fail("node did not exit after child errors")
+	}
+}

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -49,7 +49,7 @@ type PersistentConfig struct {
 	ChainID                uint64
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 	if err = ctx.Err(); err != nil {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
@@ -117,6 +117,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 			return nil, err
 		}
 	}
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -128,14 +128,14 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 // for processed epochs of all running applications.
 func (s *Service) Tick(ctx context.Context) []error {
 	// Check for shutdown before starting work, consistent with the advancer.
-	if s.IsStopping() {
+	if ctx.Err() != nil {
 		return nil
 	}
 
 	apps, _, err := getAllRunningApplications(ctx, s.repository)
 	if err != nil {
 		// Only suppress context errors during shutdown; surface real DB errors.
-		if s.IsStopping() && errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.Canceled) {
 			s.Logger.Warn("Tick interrupted by shutdown", "error", err)
 			return nil
 		}
@@ -151,7 +151,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 		if err := s.validateApplication(ctx, apps[idx]); err != nil {
 			// During shutdown, in-flight L1 requests see context cancellation.
 			// Suppress these to avoid spurious ERR log entries.
-			if s.IsStopping() && errors.Is(err, context.Canceled) {
+			if errors.Is(err, context.Canceled) {
 				s.Logger.Warn("Tick interrupted by shutdown",
 					"application", apps[idx].IApplicationAddress, "error", err)
 				continue

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -123,10 +123,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	return s, nil
 }
 
-func (s *Service) Alive() bool     { return true }
-func (s *Service) Ready() bool     { return true }
-func (s *Service) Reload() []error { return nil }
-
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
 func (s *Service) Tick() []error {
@@ -163,15 +159,6 @@ func (s *Service) Tick() []error {
 		}
 	}
 	return errs
-}
-
-func (s *Service) Stop(_ bool) []error {
-	s.SetStopping()
-	return nil
-}
-
-func (s *Service) String() string {
-	return s.Name
 }
 
 func (s *Service) setupPersistentConfig(

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -21,7 +21,7 @@ import (
 )
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.TickServiceConfigs
 	Config         config.PrtConfig
 	Repository     repository.Repository
 	EthClient      EthClientInterface
@@ -29,7 +29,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.TickService
+	service.TickServiceTemplate
 	repository        prtRepository
 	client            EthClientInterface
 	adapterFactory    AdapterFactory
@@ -56,10 +56,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	s.TickImpl = s
-	c.Impl = s
 
-	err = service.NewTickService(&c.CreateInfo, &s.TickService)
+	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -132,7 +132,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 		return nil
 	}
 
-	apps, _, err := getAllRunningApplications(s.Context, s.repository)
+	apps, _, err := getAllRunningApplications(ctx, s.repository)
 	if err != nil {
 		// Only suppress context errors during shutdown; surface real DB errors.
 		if s.IsStopping() && errors.Is(err, context.Canceled) {
@@ -145,10 +145,10 @@ func (s *Service) Tick(ctx context.Context) []error {
 	// validate each application
 	errs := []error{}
 	for idx := range apps {
-		if s.Context.Err() != nil {
+		if ctx.Err() != nil {
 			return errs
 		}
-		if err := s.validateApplication(s.Context, apps[idx]); err != nil {
+		if err := s.validateApplication(ctx, apps[idx]); err != nil {
 			// During shutdown, in-flight L1 requests see context cancellation.
 			// Suppress these to avoid spurious ERR log entries.
 			if s.IsStopping() && errors.Is(err, context.Canceled) {

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -29,7 +29,7 @@ type CreateInfo struct {
 }
 
 type Service struct {
-	service.Service
+	service.TickService
 	repository        prtRepository
 	client            EthClientInterface
 	adapterFactory    AdapterFactory
@@ -56,9 +56,10 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
+	s.TickImpl = s
 	c.Impl = s
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.NewTickService(&c.CreateInfo, &s.TickService)
 	if err != nil {
 		return nil, err
 	}
@@ -125,7 +126,7 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
-func (s *Service) Tick() []error {
+func (s *Service) Tick(ctx context.Context) []error {
 	// Check for shutdown before starting work, consistent with the advancer.
 	if s.IsStopping() {
 		return nil

--- a/internal/prt/service.go
+++ b/internal/prt/service.go
@@ -124,10 +124,10 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
-func (s *Service) Tick(ctx context.Context) []error {
+func (s *Service) Tick(ctx context.Context) (bool, []error) {
 	// Check for shutdown before starting work, consistent with the advancer.
 	if ctx.Err() != nil {
-		return nil
+		return false, nil
 	}
 
 	apps, _, err := getAllRunningApplications(ctx, s.repository)
@@ -135,16 +135,16 @@ func (s *Service) Tick(ctx context.Context) []error {
 		// Only suppress context errors during shutdown; surface real DB errors.
 		if errors.Is(err, context.Canceled) {
 			s.Logger.Warn("Tick interrupted by shutdown", "error", err)
-			return nil
+			return false, nil
 		}
-		return []error{fmt.Errorf("failed to get running applications. %w", err)}
+		return false, []error{fmt.Errorf("failed to get running applications. %w", err)}
 	}
 
 	// validate each application
 	errs := []error{}
 	for idx := range apps {
 		if ctx.Err() != nil {
-			return errs
+			return false, errs
 		}
 		if err := s.validateApplication(ctx, apps[idx]); err != nil {
 			// During shutdown, in-flight L1 requests see context cancellation.
@@ -157,7 +157,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 			errs = append(errs, err)
 		}
 	}
-	return errs
+	return false, errs
 }
 
 func (s *Service) setupPersistentConfig(

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -22,7 +22,8 @@ import (
 )
 
 type Service struct {
-	service.Service
+	service.TickService
+
 	repository ValidatorRepository
 
 	// cached constants
@@ -45,9 +46,10 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
+	s.TickImpl = s
 	c.Impl = s
 
-	err = service.Create(ctx, &c.CreateInfo, &s.Service)
+	err = service.NewTickService(&c.CreateInfo, &s.TickService)
 	if err != nil {
 		return nil, err
 	}
@@ -67,8 +69,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
-func (s *Service) Tick() []error {
-	apps, _, err := getAllRunningApplications(s.Context, s.repository)
+func (s *Service) Tick(ctx context.Context) []error {
+	apps, _, err := getAllRunningApplications(ctx, s.repository)
 	if err != nil {
 		return []error{fmt.Errorf("failed to get running applications. %w", err)}
 	}
@@ -76,7 +78,7 @@ func (s *Service) Tick() []error {
 	// validate each application
 	errs := []error{}
 	for idx := range apps {
-		if err := s.validateApplication(s.Context, apps[idx]); err != nil {
+		if err := s.validateApplication(ctx, apps[idx]); err != nil {
 			errs = append(errs, err)
 		}
 	}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -65,10 +65,6 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	return s, nil
 }
 
-func (s *Service) Alive() bool     { return true }
-func (s *Service) Ready() bool     { return true }
-func (s *Service) Reload() []error { return nil }
-
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
 func (s *Service) Tick() []error {
@@ -85,14 +81,6 @@ func (s *Service) Tick() []error {
 		}
 	}
 	return errs
-}
-func (s *Service) Stop(_ bool) []error {
-	s.SetStopping()
-	return nil
-}
-
-func (s *Service) String() string {
-	return s.Name
 }
 
 // The maximum height for the Merkle tree of all outputs produced

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Service struct {
-	service.TickService
+	service.TickServiceTemplate
 
 	repository ValidatorRepository
 
@@ -32,7 +32,7 @@ type Service struct {
 }
 
 type CreateInfo struct {
-	service.CreateInfo
+	service.TickServiceConfigs
 
 	Config config.ValidatorConfig
 
@@ -46,10 +46,8 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	}
 
 	s := &Service{}
-	s.TickImpl = s
-	c.Impl = s
 
-	err = service.NewTickService(&c.CreateInfo, &s.TickService)
+	err = service.InitTickServiceTemplate(&c.TickServiceConfigs, &s.TickServiceTemplate, s, s)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -38,7 +38,7 @@ type CreateInfo struct {
 	Repository repository.Repository
 }
 
-func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
+func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 	var err error
 	if err = ctx.Err(); err != nil {
 		return nil, err // This returns context.Canceled or context.DeadlineExceeded.
@@ -59,6 +59,8 @@ func Create(ctx context.Context, c *CreateInfo) (*Service, error) {
 
 	s.pristinePostContext = merkle.CreatePostContext()
 	s.pristineRootHash = s.pristinePostContext[merkle.TREE_DEPTH]
+
+	s.LogConfig(c.Config)
 
 	return s, nil
 }

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -67,10 +67,10 @@ func Create(ctx context.Context, c *CreateInfo) (service.IService, error) {
 
 // Tick executes the Validator main logic of producing claims and/or proofs
 // for processed epochs of all running applications.
-func (s *Service) Tick(ctx context.Context) []error {
+func (s *Service) Tick(ctx context.Context) (bool, []error) {
 	apps, _, err := getAllRunningApplications(ctx, s.repository)
 	if err != nil {
-		return []error{fmt.Errorf("failed to get running applications. %w", err)}
+		return false, []error{fmt.Errorf("failed to get running applications. %w", err)}
 	}
 
 	// validate each application
@@ -80,7 +80,7 @@ func (s *Service) Tick(ctx context.Context) []error {
 			errs = append(errs, err)
 		}
 	}
-	return errs
+	return false, errs
 }
 
 // The maximum height for the Merkle tree of all outputs produced

--- a/internal/validator/validator_test.go
+++ b/internal/validator/validator_test.go
@@ -40,8 +40,8 @@ func (s *ValidatorSuite) SetupSubTest() {
 		pristinePostContext: postContext,
 		pristineRootHash:    postContext[merkle.TREE_DEPTH],
 	}
-	serviceArgs := &service.CreateInfo{Name: "validator", Impl: validator}
-	err := service.Create(context.Background(), serviceArgs, &validator.Service)
+	serviceArgs := &service.ServiceConfigs{Name: "validator"}
+	err := service.InitServiceTemplate(serviceArgs, &validator.ServiceTemplate, validator)
 	s.Require().Nil(err)
 	dummyOutputsMerkleRoot := common.HexToHash("0x0a162946e56158bac0673e6dd3bdfdc1e4a0e7744a120fdb640050c8d7abe1c6")
 	dummyEpochs = []Epoch{

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -10,8 +10,6 @@
 //   - embed a [ServiceTemplate] struct into a new <type>Service struct.
 //   - embed a [Create] call into a new Create<type> function.
 //
-// Check DummyService, SlowService and ListService source code for examples of how to do it.
-//
 // To use a service, call its corresponding Create function with a matching CreateInfo and Service,
 // then fill in the appropriate CreateInfo fields.
 // Here are a few of the available options:

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -6,8 +6,8 @@
 // The runtime information is then stored in the Service.
 //
 // The recommended way to implement a new service is to:
-//   - embed a [CreateInfo] struct into a new Create<type>Info struct.
-//   - embed a [Service] struct into a new <type>Service struct.
+//   - embed a [ServiceConfigs] struct into a new Create<type>Info struct.
+//   - embed a [ServiceTemplate] struct into a new <type>Service struct.
 //   - embed a [Create] call into a new Create<type> function.
 //
 // Check DummyService, SlowService and ListService source code for examples of how to do it.
@@ -74,17 +74,10 @@ const telemetryShutdownTimeout = 5 * time.Second
 
 var (
 	ErrInvalid = fmt.Errorf("Invalid Argument") // invalid argument
+	ErrServiceStopped = fmt.Errorf("Service was stopped")
 )
 
-// ServiceImpl is the interface that concrete services must implement.
-type ServiceImpl interface {
-	Alive() bool
-	Ready() bool
-	OnReload() []error
-	OnStop(bool) []error
-	OnServe(ctx context.Context) error
-}
-
+// Public interface with methods to manipulate the service.
 type IService interface {
 	Alive() bool
 	Ready() bool
@@ -94,40 +87,25 @@ type IService interface {
 	String() string
 }
 
-// CreateInfo stores initialization data for the Create function
-type CreateInfo struct {
-	Name                 string
-	LogLevel             slog.Level
-	LogColor             bool
-	EnableSignalHandling bool
-	TelemetryCreate      bool
-	TelemetryAddress     string
-	PollInterval         time.Duration
-	Impl                 ServiceImpl
-	Logger               *slog.Logger
-	ServeMux             *http.ServeMux
-	Context              context.Context
-	Cancel               context.CancelFunc
+/*
+ * Service template for services that do continuous processing.
+ */
 
-	// EnableReschedule, when true, creates a self-continuation channel.
-	// Services that discover remaining work after a Tick() call
-	// SignalReschedule() to re-tick immediately without waiting for the
-	// timer interval.
-	//
-	// Migration: When the events library (feature/events-library-research)
-	// ships, Serve() will gain an additional EventChannel case for external
-	// cross-service notifications. Reschedule remains complementary:
-	// Reschedule = internal self-continuation ("I have more work"),
-	// EventChannel = external stimulus ("another service produced work").
-	// Both coexist in the select loop alongside the Ticker safety-net.
-	EnableReschedule bool
+// Internal interface with abstract methods called by ServiceTemplate.
+// These methods are not part of the public service interface.
+type LifecycleImpl interface {
+	Alive() bool
+	Ready() bool
+	OnReload() []error
+	OnStop(bool) []error
+	OnServe(ctx context.Context) error
 }
 
-// Service stores runtime information.
-type Service struct {
+// ServiceTemplate stores runtime information.
+type ServiceTemplate struct {
 	Name          string
-	Impl          ServiceImpl
 	Logger        *slog.Logger
+	lifecycleImpl LifecycleImpl
 	context       context.Context
 	cancelContext context.CancelFunc
 	sigHangUp     chan os.Signal // SIGHUP to reload
@@ -141,20 +119,31 @@ type Service struct {
 	stopped atomic.Bool
 }
 
-// Create a service by:
-//   - using values from s if non zero,
-//   - using values from c,
-//   - using default values when applicable
-func Create(ctx context.Context, c *CreateInfo, s *Service) error {
-	if c == nil || c.Impl == nil || s == nil {
+// ServiceConfigs stores configuration for the InitServiceTemplate function
+type ServiceConfigs struct {
+	Name                 string
+	Logger               *slog.Logger
+	LogLevel             slog.Level
+	LogColor             bool
+	Context              context.Context
+	Cancel               context.CancelFunc
+	EnableSignalHandling bool
+	TelemetryCreate      bool
+	TelemetryAddress     string
+	ServeMux             *http.ServeMux  // used only for unit testing
+}
+
+// Initialize the 'ServiceTemplate' structure using values from 'CreateInfo'.
+// 'impl' must be a reference to the concrete service implementation that
+// embeds 'ServiceTemplate'
+func InitServiceTemplate(c *ServiceConfigs, s *ServiceTemplate, impl LifecycleImpl) error {
+	if c == nil || s == nil || impl == nil {
 		return ErrInvalid
 	}
-	if err := ctx.Err(); err != nil {
-		return err // This returns context.Canceled or context.DeadlineExceeded.
-	}
+
+	s.lifecycleImpl = impl
 
 	s.Name = c.Name
-	s.Impl = c.Impl
 	s.Logger = c.Logger
 
 	// log
@@ -210,14 +199,21 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 	return nil
 }
 
-func (s *Service) OnReload() []error { return nil }
-func (s *Service) OnStop(bool) []error { return nil }
-func (s *Service) Alive() bool { return true }
-func (s *Service) Ready() bool { return true }
+// Default implementation of some abstract methods (except `OnServe`).
+// Remove them to force concrete services to provide implementation for them.
+func (s *ServiceTemplate) OnReload() []error { return nil }
+func (s *ServiceTemplate) OnStop(bool) []error { return nil }
+func (s *ServiceTemplate) Alive() bool { return true }
+func (s *ServiceTemplate) Ready() bool { return true }
+func (s *ServiceTemplate) String() string { return s.Name }
 
-func (s *Service) Reload() []error {
+func (s *ServiceTemplate) Reload() []error {
+	if s.stopped.Load() {
+		return []error{ErrServiceStopped}
+	}
+
 	start := time.Now()
-	errs := s.Impl.OnReload()
+	errs := s.lifecycleImpl.OnReload()
 	elapsed := time.Since(start)
 
 	if len(errs) > 0 {
@@ -231,7 +227,7 @@ func (s *Service) Reload() []error {
 	return errs
 }
 
-func (s *Service) Stop(force bool) []error {
+func (s *ServiceTemplate) Stop(force bool) []error {
 	// CAS achieves once-semantics: the second caller returns immediately
 	// (fire-and-forget) rather than blocking like sync.Once. This is safe
 	// because the orchestrator calls Cancel() after Stop() and waits for
@@ -241,7 +237,7 @@ func (s *Service) Stop(force bool) []error {
 	}
 
 	start := time.Now()
-	errs := s.Impl.OnStop(force)
+	errs := s.lifecycleImpl.OnStop(force)
 	if s.telemetry != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetryShutdownTimeout)
 		defer cancel()
@@ -272,17 +268,13 @@ func (s *Service) Stop(force bool) []error {
 	return errs
 }
 
-func (s *Service) Serve() error {
-	// Check for context cancellation before the first tick.
-	select {
-	case <-s.context.Done():
-		s.Stop(true) // Stop logs errors internally.
-		return nil
-	default:
+func (s *ServiceTemplate) Serve() error {
+	if s.stopped.Load() {
+		return ErrServiceStopped
 	}
 
 	go func() {
-		for !s.stopped.Load() {
+		for {
 			select {
 			case <-s.sigHangUp:
 				s.Reload()
@@ -296,20 +288,146 @@ func (s *Service) Serve() error {
 		}
 	}()
 
-	defer s.Stop(false)
+	defer s.Stop(true)
 
-	return s.Impl.OnServe(s.context)
-}
-
-func (s *Service) String() string {
-	return s.Name
+	return s.lifecycleImpl.OnServe(s.context)
 }
 
 // LogConfig logs the service configuration at debug level.
 // Intended for use by standalone service binaries after Create.
-func (s *Service) LogConfig(config any) {
+func (s *ServiceTemplate) LogConfig(config any) {
 	s.Logger.Info("Starting service", "config", config)
 }
+
+/*
+ * Alternative service template that implements the tick-based processing.
+ */
+
+type TickImpl interface {
+	Tick(ctx context.Context) []error
+}
+
+type TickServiceTemplate struct {
+	ServiceTemplate
+	tickImpl   TickImpl
+	ticker     *time.Ticker
+	reschedule chan struct{} // self-continuation signal; see CreateInfo.EnableReschedule
+}
+
+type TickServiceConfigs struct {
+	ServiceConfigs
+	PollInterval time.Duration
+
+	// EnableReschedule, when true, creates a self-continuation channel.
+	// Services that discover remaining work after a Tick() call
+	// SignalReschedule() to re-tick immediately without waiting for the
+	// timer interval.
+	//
+	// Migration: When the events library (feature/events-library-research)
+	// ships, Serve() will gain an additional EventChannel case for external
+	// cross-service notifications. Reschedule remains complementary:
+	// Reschedule = internal self-continuation ("I have more work"),
+	// EventChannel = external stimulus ("another service produced work").
+	// Both coexist in the select loop alongside the Ticker safety-net.
+	EnableReschedule bool
+}
+
+func InitTickServiceTemplate(
+	cfg *TickServiceConfigs,
+	tmpl *TickServiceTemplate,
+	lifecycleImpl LifecycleImpl,
+	tickImpl TickImpl,
+) error {
+	if cfg == nil || tmpl == nil || tickImpl == nil {
+		return ErrInvalid
+	}
+
+	err := InitServiceTemplate(&cfg.ServiceConfigs, &tmpl.ServiceTemplate, lifecycleImpl)
+	if err != nil {
+		return err
+	}
+
+	tmpl.tickImpl = tickImpl
+
+	// ticker
+	if cfg.PollInterval == 0 {
+		cfg.PollInterval = time.Minute
+	}
+	tmpl.ticker = time.NewTicker(cfg.PollInterval)
+
+	// self-rescheduling
+	if cfg.EnableReschedule {
+		tmpl.reschedule = make(chan struct{}, 1)
+	}
+
+	return nil
+}
+
+func (s *TickServiceTemplate) tick(ctx context.Context) []error {
+	start := time.Now()
+	errs := s.tickImpl.Tick(ctx)
+	elapsed := time.Since(start)
+
+	if len(errs) > 0 {
+		s.Logger.Error("Tick",
+			"duration", elapsed,
+			"error", errs)
+	} else {
+		s.Logger.Debug("Tick",
+			"duration", elapsed)
+	}
+	return errs
+}
+
+func (s *TickServiceTemplate) OnStop(bool) []error {
+	s.ticker.Stop()
+	return nil
+}
+
+func (s *TickServiceTemplate) OnServe(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return nil
+	}
+	s.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-s.ticker.C:
+			s.tick(ctx)
+		// 'reschedule' is nil when rescheduling is disabled thus blocking forever,
+		// preserving timer-only behavior.
+		case <-s.reschedule:
+			s.tick(ctx)
+		}
+	}
+}
+
+// SignalReschedule performs a non-blocking send on the reschedule channel.
+// If a signal is already pending, this is a no-op (one wake is sufficient).
+// Does nothing if rescheduling is not enabled.
+// INVARIANT: This method must never block.
+func (s *TickServiceTemplate) SignalReschedule() {
+	select {
+	case s.reschedule <- struct{}{}:
+	default:
+	}
+}
+
+// DrainReschedule consumes and discards a pending reschedule signal, if any.
+// Returns true if a signal was pending. Intended for testing.
+func (s *TickServiceTemplate) DrainReschedule() bool {
+	select {
+	case <-s.reschedule:
+		return true
+	default:
+		return false
+	}
+}
+
+/*
+ * Service Logger
+ */
 
 func NewLogger(level slog.Level, color bool) *slog.Logger {
 	opts := &tint.Options{
@@ -323,12 +441,15 @@ func NewLogger(level slog.Level, color bool) *slog.Logger {
 	return slog.New(handler)
 }
 
-func NewServiceLogger(c *CreateInfo) *slog.Logger {
+func NewServiceLogger(c *ServiceConfigs) *slog.Logger {
 	return NewLogger(c.LogLevel, c.LogColor).With("service", c.Name)
 }
 
-// Telemetry
-func (s *Service) CreateDefaultTelemetry(addr string) (*http.Server, func() error) {
+/*
+ * Service Telemetry
+ */
+
+func (s *ServiceTemplate) CreateDefaultTelemetry(addr string) (*http.Server, func() error) {
 	s.ServeMux.Handle("/readyz", http.HandlerFunc(s.ReadyHandler))
 	s.ServeMux.Handle("/livez", http.HandlerFunc(s.AliveHandler))
 
@@ -354,8 +475,8 @@ func (s *Service) CreateDefaultTelemetry(addr string) (*http.Server, func() erro
 }
 
 // HTTP handler for `/s.Name/readyz` that exposes the value of Ready()
-func (s *Service) ReadyHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.Impl.Ready() {
+func (s *ServiceTemplate) ReadyHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.lifecycleImpl.Ready() {
 		http.Error(w, s.Name+": ready check failed",
 			http.StatusInternalServerError)
 	} else {
@@ -364,110 +485,11 @@ func (s *Service) ReadyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // HTTP handler for `/s.Name/livez` that exposes the value of Alive()
-func (s *Service) AliveHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.Impl.Alive() {
+func (s *ServiceTemplate) AliveHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.lifecycleImpl.Alive() {
 		http.Error(w, s.Name+": alive check failed",
 			http.StatusInternalServerError)
 	} else {
 		fmt.Fprintf(w, "%s: alive\n", s.Name)
-	}
-}
-
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-
-type TickImpl interface {
-	Tick(ctx context.Context) []error
-}
-
-type TickService struct {
-	Service
-	TickImpl
-	ticker     *time.Ticker
-	reschedule chan struct{} // self-continuation signal; see CreateInfo.EnableReschedule
-}
-
-func NewTickService(c *CreateInfo, s *TickService) error {
-	err := Create(context.Background(), c, &s.Service)
-	if err != nil {
-		return err
-	}
-
-	s.Service.Impl = s
-
-	// ticker
-	if c.PollInterval == 0 {
-		c.PollInterval = time.Minute
-	}
-	s.ticker = time.NewTicker(c.PollInterval)
-
-	// self-rescheduling
-	if c.EnableReschedule {
-		s.reschedule = make(chan struct{}, 1)
-	}
-
-	return nil
-}
-
-func (s *TickService) tick(ctx context.Context) []error {
-	start := time.Now()
-	errs := s.Tick(ctx)
-	elapsed := time.Since(start)
-
-	if len(errs) > 0 {
-		s.Logger.Error("Tick",
-			"duration", elapsed,
-			"error", errs)
-	} else {
-		s.Logger.Debug("Tick",
-			"duration", elapsed)
-	}
-	return errs
-}
-
-func (s *TickService) OnStop(bool) []error {
-	s.ticker.Stop()
-	return nil
-}
-
-func (s *TickService) OnServe(ctx context.Context) error {
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
-	s.tick(ctx)
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-s.ticker.C:
-			s.tick(ctx)
-		// 'reschedule' is nil when rescheduling is disabled thus blocking forever,
-		// preserving timer-only behavior.
-		case <-s.reschedule:
-			s.tick(ctx)
-		}
-	}
-}
-
-// SignalReschedule performs a non-blocking send on the reschedule channel.
-// If a signal is already pending, this is a no-op (one wake is sufficient).
-// Does nothing if rescheduling is not enabled.
-// INVARIANT: This method must never block.
-func (s *TickService) SignalReschedule() {
-	select {
-	case s.reschedule <- struct{}{}:
-	default:
-	}
-}
-
-// DrainReschedule consumes and discards a pending reschedule signal, if any.
-// Returns true if a signal was pending. Intended for testing.
-func (s *TickService) DrainReschedule() bool {
-	select {
-	case <-s.reschedule:
-		return true
-	default:
-		return false
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -130,11 +130,11 @@ type Service struct {
 	Logger        *slog.Logger
 	context       context.Context
 	cancelContext context.CancelFunc
-	Sighup        chan os.Signal // SIGHUP to reload
-	SigShutdown   chan os.Signal // SIGINT/SIGTERM to exit gracefully
+	sigHangUp     chan os.Signal // SIGHUP to reload
+	sigShutdown   chan os.Signal // SIGINT/SIGTERM to exit gracefully
 	ServeMux      *http.ServeMux
-	Telemetry     *http.Server
-	TelemetryFunc func() error
+	telemetry     *http.Server
+	telemetryFunc func() error
 
 	// stopped server Stop() run exactly once, even when Stop() is called
 	// multiple times (by the child's Serve() loop and by the parent orchestrator).
@@ -174,13 +174,13 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 
 	// signal handling
 	if c.EnableSignalHandling {
-		if s.Sighup == nil {
-			s.Sighup = make(chan os.Signal, 1)
-			signal.Notify(s.Sighup, syscall.SIGHUP)
+		if s.sigHangUp == nil {
+			s.sigHangUp = make(chan os.Signal, 1)
+			signal.Notify(s.sigHangUp, syscall.SIGHUP)
 		}
-		if s.SigShutdown == nil {
-			s.SigShutdown = make(chan os.Signal, 1)
-			signal.Notify(s.SigShutdown, syscall.SIGINT, syscall.SIGTERM)
+		if s.sigShutdown == nil {
+			s.sigShutdown = make(chan os.Signal, 1)
+			signal.Notify(s.sigShutdown, syscall.SIGINT, syscall.SIGTERM)
 		}
 	}
 
@@ -195,17 +195,17 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 		if c.TelemetryAddress == "" {
 			c.TelemetryAddress = ":8080"
 		}
-		s.Telemetry, s.TelemetryFunc = s.CreateDefaultTelemetry(c.TelemetryAddress)
+		s.telemetry, s.telemetryFunc = s.CreateDefaultTelemetry(c.TelemetryAddress)
 		go func() {
-			if err := s.TelemetryFunc(); err != nil {
+			if err := s.telemetryFunc(); err != nil {
 				s.Logger.Error("Telemetry HTTP server failed", "error", err)
 			}
 		}()
 	}
 
 	s.Logger.Info("Create", "version", version.BuildVersion, "log_level", c.LogLevel, "pid", os.Getpid())
-	if s.Telemetry != nil {
-		s.Logger.Info("Telemetry", "address", s.Telemetry.Addr)
+	if s.telemetry != nil {
+		s.Logger.Info("Telemetry", "address", s.telemetry.Addr)
 	}
 	return nil
 }
@@ -242,18 +242,18 @@ func (s *Service) Stop(force bool) []error {
 
 	start := time.Now()
 	errs := s.Impl.OnStop(force)
-	if s.Telemetry != nil {
+	if s.telemetry != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetryShutdownTimeout)
 		defer cancel()
-		if err := s.Telemetry.Shutdown(shutdownCtx); err != nil {
+		if err := s.telemetry.Shutdown(shutdownCtx); err != nil {
 			errs = append(errs, err)
 		}
 	}
-	if s.SigShutdown != nil {
-		signal.Stop(s.SigShutdown)
+	if s.sigShutdown != nil {
+		signal.Stop(s.sigShutdown)
 	}
-	if s.Sighup != nil {
-		signal.Stop(s.Sighup)
+	if s.sigHangUp != nil {
+		signal.Stop(s.sigHangUp)
 	}
 	elapsed := time.Since(start)
 
@@ -284,9 +284,9 @@ func (s *Service) Serve() error {
 	go func() {
 		for !s.stopped.Load() {
 			select {
-			case <-s.Sighup:
+			case <-s.sigHangUp:
 				s.Reload()
-			case <-s.SigShutdown:
+			case <-s.sigShutdown:
 				s.Stop(false) // Graceful shutdown; errors are logged by Stop.
 				return
 			case <-s.context.Done():

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -114,7 +114,8 @@ type ServiceTemplate struct {
 
 	// stopped server Stop() run exactly once, even when Stop() is called
 	// multiple times (by the child's Serve() loop and by the parent orchestrator).
-	stopped atomic.Bool
+	stopped     atomic.Bool
+	stoppedChan chan struct{}
 }
 
 // ServiceConfigs stores configuration for the InitServiceTemplate function
@@ -138,6 +139,8 @@ func InitServiceTemplate(c *ServiceConfigs, s *ServiceTemplate, impl LifecycleIm
 	if c == nil || s == nil || impl == nil {
 		return ErrInvalid
 	}
+
+	s.stoppedChan = make(chan struct{})
 
 	s.lifecycleImpl = impl
 
@@ -252,6 +255,7 @@ func (s *ServiceTemplate) Stop(force bool) []error {
 	elapsed := time.Since(start)
 
 	s.cancelContext()
+	close(s.stoppedChan)
 
 	if len(errs) > 0 {
 		s.Logger.Error("Stop",
@@ -286,9 +290,12 @@ func (s *ServiceTemplate) Serve() error {
 		}
 	}()
 
-	defer s.Stop(true)
+	err := s.lifecycleImpl.OnServe(s.context)
 
-	return s.lifecycleImpl.OnServe(s.context)
+	go s.Stop(true)
+	<-s.stoppedChan
+
+	return err
 }
 
 // LogConfig logs the service configuration at debug level.

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -304,32 +304,18 @@ func (s *ServiceTemplate) LogConfig(config any) {
  */
 
 type TickImpl interface {
-	Tick(ctx context.Context) []error
+	Tick(ctx context.Context) (bool, []error)
 }
 
 type TickServiceTemplate struct {
 	ServiceTemplate
 	tickImpl   TickImpl
 	ticker     *time.Ticker
-	reschedule chan struct{} // self-continuation signal; see CreateInfo.EnableReschedule
 }
 
 type TickServiceConfigs struct {
 	ServiceConfigs
 	PollInterval time.Duration
-
-	// EnableReschedule, when true, creates a self-continuation channel.
-	// Services that discover remaining work after a Tick() call
-	// SignalReschedule() to re-tick immediately without waiting for the
-	// timer interval.
-	//
-	// Migration: When the events library (feature/events-library-research)
-	// ships, Serve() will gain an additional EventChannel case for external
-	// cross-service notifications. Reschedule remains complementary:
-	// Reschedule = internal self-continuation ("I have more work"),
-	// EventChannel = external stimulus ("another service produced work").
-	// Both coexist in the select loop alongside the Ticker safety-net.
-	EnableReschedule bool
 }
 
 func InitTickServiceTemplate(
@@ -355,28 +341,30 @@ func InitTickServiceTemplate(
 	}
 	tmpl.ticker = time.NewTicker(cfg.PollInterval)
 
-	// self-rescheduling
-	if cfg.EnableReschedule {
-		tmpl.reschedule = make(chan struct{}, 1)
-	}
-
 	return nil
 }
 
-func (s *TickServiceTemplate) tick(ctx context.Context) []error {
+func (s *TickServiceTemplate) tick(ctx context.Context) bool {
+	if ctx.Err() != nil {
+		return false
+	}
 	start := time.Now()
-	errs := s.tickImpl.Tick(ctx)
+	reschedule, errs := s.tickImpl.Tick(ctx)
 	elapsed := time.Since(start)
 
 	if len(errs) > 0 {
 		s.Logger.Error("Tick",
 			"duration", elapsed,
-			"error", errs)
+			"reschedule", reschedule,
+			"error", errs,
+		)
 	} else {
 		s.Logger.Debug("Tick",
-			"duration", elapsed)
+			"duration", elapsed,
+			"reschedule", reschedule,
+		)
 	}
-	return errs
+	return reschedule
 }
 
 func (s *TickServiceTemplate) OnStop(bool) []error {
@@ -388,40 +376,14 @@ func (s *TickServiceTemplate) OnServe(ctx context.Context) error {
 	if ctx.Err() != nil {
 		return nil
 	}
-	s.tick(ctx)
+	for s.tick(ctx) {}
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		case <-s.ticker.C:
-			s.tick(ctx)
-		// 'reschedule' is nil when rescheduling is disabled thus blocking forever,
-		// preserving timer-only behavior.
-		case <-s.reschedule:
-			s.tick(ctx)
+			for s.tick(ctx) {}
 		}
-	}
-}
-
-// SignalReschedule performs a non-blocking send on the reschedule channel.
-// If a signal is already pending, this is a no-op (one wake is sufficient).
-// Does nothing if rescheduling is not enabled.
-// INVARIANT: This method must never block.
-func (s *TickServiceTemplate) SignalReschedule() {
-	select {
-	case s.reschedule <- struct{}{}:
-	default:
-	}
-}
-
-// DrainReschedule consumes and discards a pending reschedule signal, if any.
-// Returns true if a signal was pending. Intended for testing.
-func (s *TickServiceTemplate) DrainReschedule() bool {
-	select {
-	case <-s.reschedule:
-		return true
-	default:
-		return false
 	}
 }
 

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -142,8 +142,8 @@ type Service struct {
 	Name          string
 	Impl          ServiceImpl
 	Logger        *slog.Logger
-	Context       context.Context
-	Cancel        context.CancelFunc
+	context       context.Context
+	cancelContext context.CancelFunc
 	Sighup        chan os.Signal // SIGHUP to reload
 	SigShutdown   chan os.Signal // SIGINT/SIGTERM to exit gracefully
 	ServeMux      *http.ServeMux
@@ -155,7 +155,7 @@ type Service struct {
 	// detect that shutdown is in progress and suppress errors that are
 	// expected during teardown (e.g., context.Canceled from in-flight RPC
 	// calls). This covers the race window between Stop() being called and
-	// ctx.Cancel() propagating.
+	// cancelContext() propagating.
 	stopping atomic.Bool
 
 	// cleanedUp server Stop() run exactly once, even when Stop() is called
@@ -186,18 +186,14 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 	}
 
 	// context and cancelation
-	if s.Context == nil {
-		if c.Context == nil {
-			c.Context = context.Background()
-		}
-		s.Context = c.Context
+	if c.Context == nil {
+		c.Context = context.Background()
 	}
-	if s.Cancel == nil {
-		if c.Cancel == nil {
-			s.Context, c.Cancel = context.WithCancel(c.Context)
-		}
-		s.Cancel = c.Cancel
+	s.context = c.Context
+	if c.Cancel == nil {
+		s.context, c.Cancel = context.WithCancel(c.Context)
 	}
+	s.cancelContext = c.Cancel
 
 	// signal handling
 	if c.EnableSignalHandling {
@@ -300,7 +296,7 @@ func (s *Service) Stop(force bool) []error {
 	elapsed := time.Since(start)
 
 	s.Running.Store(false)
-	s.Cancel()
+	s.cancelContext()
 	if len(errs) > 0 {
 		s.Logger.Error("Stop",
 			"force", force,
@@ -319,7 +315,7 @@ func (s *Service) Serve() error {
 
 	// Check for context cancellation before the first tick.
 	select {
-	case <-s.Context.Done():
+	case <-s.context.Done():
 		s.Stop(true) // Stop logs errors internally.
 		return nil
 	default:
@@ -333,7 +329,7 @@ func (s *Service) Serve() error {
 			case <-s.SigShutdown:
 				s.Stop(false) // Graceful shutdown; errors are logged by Stop.
 				return
-			case <-s.Context.Done():
+			case <-s.context.Done():
 				s.Stop(true) // Stop logs errors internally.
 				return
 			}
@@ -342,7 +338,7 @@ func (s *Service) Serve() error {
 
 	defer s.Stop(false)
 
-	return s.Impl.OnServe(s.Context)
+	return s.Impl.OnServe(s.context)
 }
 
 func (s *Service) String() string {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -94,8 +94,8 @@ type ServiceImpl interface {
 	Alive() bool
 	Ready() bool
 	OnReload() []error
-	Tick() []error
 	OnStop(bool) []error
+	OnServe(ctx context.Context) error
 }
 
 type IService interface {
@@ -142,8 +142,6 @@ type Service struct {
 	Name          string
 	Impl          ServiceImpl
 	Logger        *slog.Logger
-	Ticker        *time.Ticker
-	PollInterval  time.Duration
 	Context       context.Context
 	Cancel        context.CancelFunc
 	Sighup        chan os.Signal // SIGHUP to reload
@@ -151,7 +149,6 @@ type Service struct {
 	ServeMux      *http.ServeMux
 	Telemetry     *http.Server
 	TelemetryFunc func() error
-	reschedule    chan struct{} // self-continuation signal; see CreateInfo.EnableReschedule
 
 	// stopping is set to true at the beginning of Stop(), before Impl.Stop()
 	// is called. Services can check this via IsStopping() from Tick() to
@@ -160,6 +157,10 @@ type Service struct {
 	// calls). This covers the race window between Stop() being called and
 	// ctx.Cancel() propagating.
 	stopping atomic.Bool
+
+	// cleanedUp server Stop() run exactly once, even when Stop() is called
+	// multiple times (by the child's Serve() loop and by the parent orchestrator).
+	cleanedUp atomic.Bool
 }
 
 // Create a service by:
@@ -196,20 +197,6 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 			s.Context, c.Cancel = context.WithCancel(c.Context)
 		}
 		s.Cancel = c.Cancel
-	}
-
-	// ticker
-	if s.Ticker == nil {
-		if c.PollInterval == 0 {
-			c.PollInterval = time.Minute
-		}
-		s.PollInterval = c.PollInterval
-		s.Ticker = time.NewTicker(s.PollInterval)
-	}
-
-	// self-rescheduling
-	if c.EnableReschedule {
-		s.reschedule = make(chan struct{}, 1)
 	}
 
 	// signal handling
@@ -254,7 +241,6 @@ func (s *Service) OnReload() []error { return nil }
 func (s *Service) OnStop(bool) []error { return nil }
 func (s *Service) Alive() bool { return true }
 func (s *Service) Ready() bool { return true }
-func (s *Service) Tick() []error { return nil }
 
 func (s *Service) Reload() []error {
 	start := time.Now()
@@ -267,22 +253,6 @@ func (s *Service) Reload() []error {
 			"error", errs)
 	} else {
 		s.Logger.Info("Reload",
-			"duration", elapsed)
-	}
-	return errs
-}
-
-func (s *Service) tickService() []error {
-	start := time.Now()
-	errs := s.Impl.Tick()
-	elapsed := time.Since(start)
-
-	if len(errs) > 0 {
-		s.Logger.Error("Tick",
-			"duration", elapsed,
-			"error", errs)
-	} else {
-		s.Logger.Debug("Tick",
 			"duration", elapsed)
 	}
 	return errs
@@ -303,6 +273,14 @@ func (s *Service) SetStopping() {
 }
 
 func (s *Service) Stop(force bool) []error {
+	// CAS achieves once-semantics: the second caller returns immediately
+	// (fire-and-forget) rather than blocking like sync.Once. This is safe
+	// because the orchestrator calls Cancel() after Stop() and waits for
+	// the Serve goroutine to exit.
+	if !s.cleanedUp.CompareAndSwap(false, true) {
+		return nil // already stopped
+	}
+
 	s.stopping.Store(true)
 	start := time.Now()
 	errs := s.Impl.OnStop(force)
@@ -336,34 +314,6 @@ func (s *Service) Stop(force bool) []error {
 	return errs
 }
 
-// rescheduleChan returns the reschedule channel, or nil if rescheduling is disabled.
-// A nil channel in a select case blocks forever, preserving timer-only behavior.
-func (s *Service) rescheduleChan() <-chan struct{} {
-	return s.reschedule
-}
-
-// SignalReschedule performs a non-blocking send on the reschedule channel.
-// If a signal is already pending, this is a no-op (one wake is sufficient).
-// Does nothing if rescheduling is not enabled.
-// INVARIANT: This method must never block.
-func (s *Service) SignalReschedule() {
-	select {
-	case s.reschedule <- struct{}{}:
-	default:
-	}
-}
-
-// DrainReschedule consumes and discards a pending reschedule signal, if any.
-// Returns true if a signal was pending. Intended for testing.
-func (s *Service) DrainReschedule() bool {
-	select {
-	case <-s.reschedule:
-		return true
-	default:
-		return false
-	}
-}
-
 func (s *Service) Serve() error {
 	s.Running.Store(true)
 
@@ -375,24 +325,24 @@ func (s *Service) Serve() error {
 	default:
 	}
 
-	s.tickService()
-	for s.Running.Load() {
-		select {
-		case <-s.Sighup:
-			s.Reload()
-		case <-s.SigShutdown:
-			s.Stop(false) // Graceful shutdown; errors are logged by Stop.
-			return nil
-		case <-s.Context.Done():
-			s.Stop(true) // Stop logs errors internally.
-			return nil
-		case <-s.Ticker.C:
-			s.tickService()
-		case <-s.rescheduleChan():
-			s.tickService()
+	go func() {
+		for s.Running.Load() {
+			select {
+			case <-s.Sighup:
+				s.Reload()
+			case <-s.SigShutdown:
+				s.Stop(false) // Graceful shutdown; errors are logged by Stop.
+				return
+			case <-s.Context.Done():
+				s.Stop(true) // Stop logs errors internally.
+				return
+			}
 		}
-	}
-	return nil
+	}()
+
+	defer s.Stop(false)
+
+	return s.Impl.OnServe(s.Context)
 }
 
 func (s *Service) String() string {
@@ -464,5 +414,104 @@ func (s *Service) AliveHandler(w http.ResponseWriter, r *http.Request) {
 			http.StatusInternalServerError)
 	} else {
 		fmt.Fprintf(w, "%s: alive\n", s.Name)
+	}
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+type TickImpl interface {
+	Tick(ctx context.Context) []error
+}
+
+type TickService struct {
+	Service
+	TickImpl
+	ticker     *time.Ticker
+	reschedule chan struct{} // self-continuation signal; see CreateInfo.EnableReschedule
+}
+
+func NewTickService(c *CreateInfo, s *TickService) error {
+	err := Create(context.Background(), c, &s.Service)
+	if err != nil {
+		return err
+	}
+
+	s.Service.Impl = s
+
+	// ticker
+	if c.PollInterval == 0 {
+		c.PollInterval = time.Minute
+	}
+	s.ticker = time.NewTicker(c.PollInterval)
+
+	// self-rescheduling
+	if c.EnableReschedule {
+		s.reschedule = make(chan struct{}, 1)
+	}
+
+	return nil
+}
+
+func (s *TickService) tick(ctx context.Context) []error {
+	start := time.Now()
+	errs := s.Tick(ctx)
+	elapsed := time.Since(start)
+
+	if len(errs) > 0 {
+		s.Logger.Error("Tick",
+			"duration", elapsed,
+			"error", errs)
+	} else {
+		s.Logger.Debug("Tick",
+			"duration", elapsed)
+	}
+	return errs
+}
+
+func (s *TickService) OnStop(bool) []error {
+	s.ticker.Stop()
+	return nil
+}
+
+func (s *TickService) OnServe(ctx context.Context) error {
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	s.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-s.ticker.C:
+			s.tick(ctx)
+		// 'reschedule' is nil when rescheduling is disabled thus blocking forever,
+		// preserving timer-only behavior.
+		case <-s.reschedule:
+			s.tick(ctx)
+		}
+	}
+}
+
+// SignalReschedule performs a non-blocking send on the reschedule channel.
+// If a signal is already pending, this is a no-op (one wake is sufficient).
+// Does nothing if rescheduling is not enabled.
+// INVARIANT: This method must never block.
+func (s *TickService) SignalReschedule() {
+	select {
+	case s.reschedule <- struct{}{}:
+	default:
+	}
+}
+
+// DrainReschedule consumes and discards a pending reschedule signal, if any.
+// Returns true if a signal was pending. Intended for testing.
+func (s *TickService) DrainReschedule() bool {
+	select {
+	case <-s.reschedule:
+		return true
+	default:
+		return false
 	}
 }

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -77,19 +77,6 @@ var (
 )
 
 // ServiceImpl is the interface that concrete services must implement.
-//
-// IMPORTANT: Stop() implementations that shadow Service.Stop() MUST call
-// s.SetStopping() as their first action. This sets the stopping flag so that
-// a concurrent Tick() can detect shutdown-in-progress via IsStopping() and
-// suppress expected teardown errors (e.g., context.Canceled from in-flight
-// RPCs). Without this call, the race window between Stop() tearing down
-// resources and Tick() observing the cancellation produces spurious errors.
-//
-// When Stop() is called through the framework's Service.Stop() dispatch,
-// the flag is set automatically before Impl.Stop() runs. But the node
-// orchestrator calls child.Stop() directly (Go method resolution picks the
-// concrete type's Stop, bypassing Service.Stop), so the impl's SetStopping()
-// is the only thing that sets the flag on that path.
 type ServiceImpl interface {
 	Alive() bool
 	Ready() bool
@@ -149,14 +136,6 @@ type Service struct {
 	ServeMux      *http.ServeMux
 	Telemetry     *http.Server
 	TelemetryFunc func() error
-
-	// stopping is set to true at the beginning of Stop(), before Impl.Stop()
-	// is called. Services can check this via IsStopping() from Tick() to
-	// detect that shutdown is in progress and suppress errors that are
-	// expected during teardown (e.g., context.Canceled from in-flight RPC
-	// calls). This covers the race window between Stop() being called and
-	// cancelContext() propagating.
-	stopping atomic.Bool
 
 	// cleanedUp server Stop() run exactly once, even when Stop() is called
 	// multiple times (by the child's Serve() loop and by the parent orchestrator).
@@ -254,20 +233,6 @@ func (s *Service) Reload() []error {
 	return errs
 }
 
-// IsStopping reports whether Stop() has been called. Services use this in
-// Tick() to detect shutdown-in-progress and suppress expected teardown errors.
-func (s *Service) IsStopping() bool {
-	return s.stopping.Load()
-}
-
-// SetStopping sets the stopping flag. Services whose Stop() method shadows
-// Service.Stop() (i.e., every ServiceImpl) must call this at the top of their
-// Stop so that concurrent Tick goroutines can observe IsStopping() == true
-// before resources are torn down.
-func (s *Service) SetStopping() {
-	s.stopping.Store(true)
-}
-
 func (s *Service) Stop(force bool) []error {
 	// CAS achieves once-semantics: the second caller returns immediately
 	// (fire-and-forget) rather than blocking like sync.Once. This is safe
@@ -277,7 +242,6 @@ func (s *Service) Stop(force bool) []error {
 		return nil // already stopped
 	}
 
-	s.stopping.Store(true)
 	start := time.Now()
 	errs := s.Impl.OnStop(force)
 	if s.Telemetry != nil {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -93,16 +93,15 @@ var (
 type ServiceImpl interface {
 	Alive() bool
 	Ready() bool
-	Reload() []error
+	OnReload() []error
 	Tick() []error
-	Stop(bool) []error
+	OnStop(bool) []error
 }
 
 type IService interface {
 	Alive() bool
 	Ready() bool
 	Reload() []error
-	Tick() []error
 	Stop(bool) []error
 	Serve() error
 	String() string
@@ -168,7 +167,7 @@ type Service struct {
 //   - using values from c,
 //   - using default values when applicable
 func Create(ctx context.Context, c *CreateInfo, s *Service) error {
-	if c == nil || c.Impl == nil || c.Impl == s || s == nil {
+	if c == nil || c.Impl == nil || s == nil {
 		return ErrInvalid
 	}
 	if err := ctx.Err(); err != nil {
@@ -251,17 +250,15 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 	return nil
 }
 
-func (s *Service) Alive() bool {
-	return s.Impl.Alive()
-}
-
-func (s *Service) Ready() bool {
-	return s.Impl.Ready()
-}
+func (s *Service) OnReload() []error { return nil }
+func (s *Service) OnStop(bool) []error { return nil }
+func (s *Service) Alive() bool { return true }
+func (s *Service) Ready() bool { return true }
+func (s *Service) Tick() []error { return nil }
 
 func (s *Service) Reload() []error {
 	start := time.Now()
-	errs := s.Impl.Reload()
+	errs := s.Impl.OnReload()
 	elapsed := time.Since(start)
 
 	if len(errs) > 0 {
@@ -275,7 +272,7 @@ func (s *Service) Reload() []error {
 	return errs
 }
 
-func (s *Service) Tick() []error {
+func (s *Service) tickService() []error {
 	start := time.Now()
 	errs := s.Impl.Tick()
 	elapsed := time.Since(start)
@@ -308,7 +305,7 @@ func (s *Service) SetStopping() {
 func (s *Service) Stop(force bool) []error {
 	s.stopping.Store(true)
 	start := time.Now()
-	errs := s.Impl.Stop(force)
+	errs := s.Impl.OnStop(force)
 	if s.Telemetry != nil {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetryShutdownTimeout)
 		defer cancel()
@@ -378,7 +375,7 @@ func (s *Service) Serve() error {
 	default:
 	}
 
-	s.Tick()
+	s.tickService()
 	for s.Running.Load() {
 		select {
 		case <-s.Sighup:
@@ -390,9 +387,9 @@ func (s *Service) Serve() error {
 			s.Stop(true) // Stop logs errors internally.
 			return nil
 		case <-s.Ticker.C:
-			s.Tick()
+			s.tickService()
 		case <-s.rescheduleChan():
-			s.Tick()
+			s.tickService()
 		}
 	}
 	return nil
@@ -452,7 +449,7 @@ func (s *Service) CreateDefaultTelemetry(addr string) (*http.Server, func() erro
 
 // HTTP handler for `/s.Name/readyz` that exposes the value of Ready()
 func (s *Service) ReadyHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.Ready() {
+	if !s.Impl.Ready() {
 		http.Error(w, s.Name+": ready check failed",
 			http.StatusInternalServerError)
 	} else {
@@ -462,7 +459,7 @@ func (s *Service) ReadyHandler(w http.ResponseWriter, r *http.Request) {
 
 // HTTP handler for `/s.Name/livez` that exposes the value of Alive()
 func (s *Service) AliveHandler(w http.ResponseWriter, r *http.Request) {
-	if !s.Alive() {
+	if !s.Impl.Alive() {
 		http.Error(w, s.Name+": alive check failed",
 			http.StatusInternalServerError)
 	} else {

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -125,7 +125,6 @@ type CreateInfo struct {
 
 // Service stores runtime information.
 type Service struct {
-	Running       atomic.Bool
 	Name          string
 	Impl          ServiceImpl
 	Logger        *slog.Logger
@@ -137,9 +136,9 @@ type Service struct {
 	Telemetry     *http.Server
 	TelemetryFunc func() error
 
-	// cleanedUp server Stop() run exactly once, even when Stop() is called
+	// stopped server Stop() run exactly once, even when Stop() is called
 	// multiple times (by the child's Serve() loop and by the parent orchestrator).
-	cleanedUp atomic.Bool
+	stopped atomic.Bool
 }
 
 // Create a service by:
@@ -154,7 +153,6 @@ func Create(ctx context.Context, c *CreateInfo, s *Service) error {
 		return err // This returns context.Canceled or context.DeadlineExceeded.
 	}
 
-	s.Running.Store(false)
 	s.Name = c.Name
 	s.Impl = c.Impl
 	s.Logger = c.Logger
@@ -238,7 +236,7 @@ func (s *Service) Stop(force bool) []error {
 	// (fire-and-forget) rather than blocking like sync.Once. This is safe
 	// because the orchestrator calls Cancel() after Stop() and waits for
 	// the Serve goroutine to exit.
-	if !s.cleanedUp.CompareAndSwap(false, true) {
+	if !s.stopped.CompareAndSwap(false, true) {
 		return nil // already stopped
 	}
 
@@ -259,8 +257,8 @@ func (s *Service) Stop(force bool) []error {
 	}
 	elapsed := time.Since(start)
 
-	s.Running.Store(false)
 	s.cancelContext()
+
 	if len(errs) > 0 {
 		s.Logger.Error("Stop",
 			"force", force,
@@ -275,8 +273,6 @@ func (s *Service) Stop(force bool) []error {
 }
 
 func (s *Service) Serve() error {
-	s.Running.Store(true)
-
 	// Check for context cancellation before the first tick.
 	select {
 	case <-s.context.Done():
@@ -286,7 +282,7 @@ func (s *Service) Serve() error {
 	}
 
 	go func() {
-		for s.Running.Load() {
+		for !s.stopped.Load() {
 			select {
 			case <-s.Sighup:
 				s.Reload()

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -172,3 +172,130 @@ func (s *ServeSuite) TestServeExitsOnContextCancelledBeforeFirstTick() {
 	// No ticks should have fired since context was already cancelled.
 	s.Equal(int32(0), impl.tickCount.Load())
 }
+
+type delayedCloseImpl struct {
+	ServiceTemplate
+	onServeInitChan chan struct{}
+	onStopInitChan chan struct{}
+}
+
+func (s *delayedCloseImpl) OnStop(bool) []error {
+	<-s.onStopInitChan  // wait signal to initiate stop
+	return nil
+}
+
+func (s *delayedCloseImpl) OnServe(ctx context.Context) error {
+	close(s.onServeInitChan)  // signal service was initiated
+	<-ctx.Done()
+	return nil
+}
+
+func (s *ServeSuite) TestServeExitsAfterStopIsComplete() {
+	svc := &delayedCloseImpl{
+		onServeInitChan: make(chan struct{}),
+		onStopInitChan: make(chan struct{}),
+	}
+
+	// Create the service with a live context, then cancel before Serve().
+	err := InitServiceTemplate(&ServiceConfigs{
+		Name:     "stopOnChanClose",
+		LogLevel: slog.LevelError,
+	}, &svc.ServiceTemplate, svc)
+
+	onServeEndChan := make(chan error)
+	go func() {
+		err = svc.Serve()
+		onServeEndChan <- err  // signal service ended and provide error
+		close(onServeEndChan)
+	}()
+
+	onStopEndChan := make(chan []error)
+	select {
+	case <-svc.onServeInitChan:  // wait service to initiate, so can be stopped.
+		// initiate service shutdown through context cancelation
+		go func() {
+			errs := svc.Stop(true)
+			onStopEndChan <- errs  // signal stop ended and provide the errors
+			close(onStopEndChan)
+		}()
+	case <-time.After(2 * time.Second):
+		s.Fail("Serve() did not start within 2 seconds")
+	}
+
+	// Serve() nor Stop() should not exit just yet.
+	select {
+	case <-onServeEndChan:
+		s.Fail("Serve() exited before 'OnStop' completion")
+	case <-onStopEndChan:
+		s.Fail("Stop() exited before 'OnStop' completion")
+	case <-time.After(100 * time.Millisecond):
+		// OK
+	}
+
+	close(svc.onStopInitChan)  // signal that stop shall initiate and eventually complete
+
+	// Serve() should exit without errors.
+	select {
+	case err := <-onServeEndChan:
+		s.NoError(err)
+	case <-time.After(2 * time.Second):
+		s.Fail("Serve() did not exit within 2 seconds after 'OnStop' concluded")
+	}
+
+	// Stop() should exit without errors.
+	select {
+	case errs := <-onStopEndChan:
+		s.Empty(errs)
+	case <-time.After(2 * time.Second):
+		s.Fail("Stop() did not exit within 2 seconds after 'OnStop' concluded")
+	}
+}
+
+func (s *ServeSuite) TestServeExitsAfterStopIsCompleteOnContextCancelation() {
+	svc := &delayedCloseImpl{
+		onServeInitChan: make(chan struct{}),
+		onStopInitChan: make(chan struct{}),
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Create the service with a live context, then cancel before Serve().
+	err := InitServiceTemplate(&ServiceConfigs{
+		Name:     "stopOnChanClose",
+		LogLevel: slog.LevelError,
+		Context:  ctx,
+		Cancel:   cancel,
+	}, &svc.ServiceTemplate, svc)
+
+	onServeEndChan := make(chan error)
+	go func() {
+		err = svc.Serve()
+		onServeEndChan <- err  // signal service ended and provide error
+		close(onServeEndChan)
+	}()
+
+	select {
+	case <-svc.onServeInitChan:  // wait service to initiate, so can be stopped.
+		cancel()  // initiate service shutdown through context cancelation
+	case <-time.After(2 * time.Second):
+		s.Fail("Serve() did not start within 2 seconds")
+	}
+
+	// Serve() should not exit just yet.
+	select {
+	case <-onServeEndChan:
+		s.Fail("Serve() exited before 'OnStop' completion")
+	case <-time.After(100 * time.Millisecond):
+		// OK
+	}
+
+	close(svc.onStopInitChan)  // signal that stop shall initiate and eventually complete
+
+	// Serve() should exit without errors.
+	select {
+	case err := <-onServeEndChan:
+		s.NoError(err)
+	case <-time.After(2 * time.Second):
+		s.Fail("Serve() did not exit within 2 seconds after 'OnStop' concluded")
+	}
+}

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -16,7 +16,7 @@ import (
 
 // mockImpl is a minimal ServiceImpl for testing the Serve() loop.
 type mockImpl struct {
-	TickService
+	TickServiceTemplate
 	tickCount atomic.Int32
 	onTick    func(n int32) // called on each Tick with the tick count (1-based)
 }
@@ -38,21 +38,21 @@ func createTestService(
 	t *testing.T,
 	impl *mockImpl,
 	enableReschedule bool,
-) (*Service, context.CancelFunc) {
+) (IService, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	impl.TickImpl = impl
-	err := NewTickService(&CreateInfo{
-		Name:             "test",
-		LogLevel:         slog.LevelError,
-		Impl:             impl,
+	err := InitTickServiceTemplate(&TickServiceConfigs{
+		ServiceConfigs: ServiceConfigs{
+			Name:             "test",
+			LogLevel:         slog.LevelError,
+			Context:          ctx,
+			Cancel:           cancel,
+		},
 		PollInterval:     10 * time.Minute, // long: tests control wakeup explicitly
-		Context:          ctx,
-		Cancel:           cancel,
 		EnableReschedule: enableReschedule,
-	}, &impl.TickService)
+	}, &impl.TickServiceTemplate, impl, impl)
 	require.NoError(t, err)
-	return &impl.Service, cancel
+	return impl, cancel
 }
 
 type ServeSuite struct {
@@ -68,21 +68,20 @@ func (s *ServeSuite) TestDisabledReschedulePreservesExistingBehavior() {
 	// Serve() should tick only on timer fires.
 	impl := &mockImpl{}
 	ctx, cancel := context.WithCancel(context.Background())
-	svc := &TickService{}
-	svc.TickImpl = impl
-	err := NewTickService(&CreateInfo{
-		Name:         "test-no-resched",
-		LogLevel:     slog.LevelError,
-		Impl:         impl,
+	err := InitTickServiceTemplate(&TickServiceConfigs{
+		ServiceConfigs: ServiceConfigs{
+			Name:     "test-no-resched",
+			LogLevel: slog.LevelError,
+			Context:  ctx,
+			Cancel:   cancel,
+		},
 		PollInterval: 20 * time.Millisecond,
-		Context:      ctx,
-		Cancel:       cancel,
-	}, svc)
+	}, &impl.TickServiceTemplate, impl, impl)
 	s.Require().NoError(err)
 
 	done := make(chan struct{})
 	go func() {
-		_ = svc.Serve()
+		_ = impl.Serve()
 		close(done)
 	}()
 

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -16,14 +16,11 @@ import (
 
 // mockImpl is a minimal ServiceImpl for testing the Serve() loop.
 type mockImpl struct {
+	Service
 	tickCount atomic.Int32
 	onTick    func(n int32) // called on each Tick with the tick count (1-based)
 }
 
-func (m *mockImpl) Alive() bool       { return true }
-func (m *mockImpl) Ready() bool       { return true }
-func (m *mockImpl) Reload() []error   { return nil }
-func (m *mockImpl) Stop(bool) []error { return nil }
 func (m *mockImpl) Tick() []error {
 	n := m.tickCount.Add(1)
 	if m.onTick != nil {

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -16,12 +16,14 @@ import (
 
 // mockImpl is a minimal ServiceImpl for testing the Serve() loop.
 type mockImpl struct {
-	Service
+	TickService
 	tickCount atomic.Int32
 	onTick    func(n int32) // called on each Tick with the tick count (1-based)
 }
 
-func (m *mockImpl) Tick() []error {
+func (m *mockImpl) OnReload() []error   { return nil }
+func (m *mockImpl) OnStop(bool) []error { return nil }
+func (m *mockImpl) Tick(ctx context.Context) []error {
 	n := m.tickCount.Add(1)
 	if m.onTick != nil {
 		m.onTick(n)
@@ -39,8 +41,8 @@ func createTestService(
 ) (*Service, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
-	s := &Service{}
-	err := Create(ctx, &CreateInfo{
+	impl.TickImpl = impl
+	err := NewTickService(&CreateInfo{
 		Name:             "test",
 		LogLevel:         slog.LevelError,
 		Impl:             impl,
@@ -48,9 +50,9 @@ func createTestService(
 		Context:          ctx,
 		Cancel:           cancel,
 		EnableReschedule: enableReschedule,
-	}, s)
+	}, &impl.TickService)
 	require.NoError(t, err)
-	return s, cancel
+	return &impl.Service, cancel
 }
 
 type ServeSuite struct {
@@ -66,8 +68,9 @@ func (s *ServeSuite) TestDisabledReschedulePreservesExistingBehavior() {
 	// Serve() should tick only on timer fires.
 	impl := &mockImpl{}
 	ctx, cancel := context.WithCancel(context.Background())
-	svc := &Service{}
-	err := Create(ctx, &CreateInfo{
+	svc := &TickService{}
+	svc.TickImpl = impl
+	err := NewTickService(&CreateInfo{
 		Name:         "test-no-resched",
 		LogLevel:     slog.LevelError,
 		Impl:         impl,
@@ -99,13 +102,13 @@ func (s *ServeSuite) TestDisabledReschedulePreservesExistingBehavior() {
 func (s *ServeSuite) TestRescheduleTriggersImmediateRetick() {
 	// When SignalReschedule() is called from Tick(), Serve() should call
 	// Tick() again immediately without waiting for the timer.
-	var svc *Service
-	impl := &mockImpl{
+	var impl *mockImpl
+	impl = &mockImpl{
 		onTick: func(n int32) {
 			// Signal reschedule on ticks 1 and 2 (the initial tick
 			// and the first rescheduled tick). Stop on tick 3.
 			if n <= 2 {
-				svc.SignalReschedule()
+				impl.SignalReschedule()
 			}
 		},
 	}
@@ -133,7 +136,6 @@ func (s *ServeSuite) TestRescheduleTriggersImmediateRetick() {
 func (s *ServeSuite) TestRescheduleCoalesces() {
 	// Multiple signals while Tick() is running should result in at most
 	// one extra tick, not one per signal.
-	var svc *Service
 	tickStarted := make(chan struct{})
 	tickProceed := make(chan struct{})
 
@@ -162,7 +164,7 @@ func (s *ServeSuite) TestRescheduleCoalesces() {
 
 	// Send multiple signals while tick is blocked. Only one fits in the buffer.
 	for range 10 {
-		svc.SignalReschedule()
+		impl.SignalReschedule()
 	}
 
 	// Let the first tick complete.
@@ -182,10 +184,10 @@ func (s *ServeSuite) TestRescheduleCoalesces() {
 func (s *ServeSuite) TestContextCancellationExitsPromptly() {
 	// When context is cancelled with a reschedule signal pending,
 	// Serve() should exit promptly.
-	var svc *Service
-	impl := &mockImpl{
+	var impl *mockImpl
+	impl = &mockImpl{
 		onTick: func(_ int32) {
-			svc.SignalReschedule()
+			impl.SignalReschedule()
 		},
 	}
 
@@ -225,37 +227,37 @@ func (s *ServeSuite) TestServeExitsOnContextCancelledBeforeFirstTick() {
 
 func (s *ServeSuite) TestRescheduleEnabledCreatesChannel() {
 	impl := &mockImpl{}
-	svc, cancel := createTestService(s.T(), impl, true)
+	_, cancel := createTestService(s.T(), impl, true)
 	defer cancel()
 
-	s.NotNil(svc.reschedule, "reschedule channel should be created when enabled")
+	s.NotNil(impl.reschedule, "reschedule channel should be created when enabled")
 }
 
 func (s *ServeSuite) TestRescheduleDisabledLeavesNilChannel() {
 	impl := &mockImpl{}
-	svc, cancel := createTestService(s.T(), impl, false)
+	_, cancel := createTestService(s.T(), impl, false)
 	defer cancel()
 
-	s.Nil(svc.reschedule, "reschedule channel should be nil when disabled")
+	s.Nil(impl.reschedule, "reschedule channel should be nil when disabled")
 }
 
 func (s *ServeSuite) TestSignalRescheduleNoopWhenDisabled() {
 	impl := &mockImpl{}
-	svc, cancel := createTestService(s.T(), impl, false)
+	_, cancel := createTestService(s.T(), impl, false)
 	defer cancel()
 
 	// Should not panic on nil channel.
-	s.NotPanics(func() { svc.SignalReschedule() })
+	s.NotPanics(func() { impl.SignalReschedule() })
 }
 
 func (s *ServeSuite) TestDrainReschedule() {
 	impl := &mockImpl{}
-	svc, cancel := createTestService(s.T(), impl, true)
+	_, cancel := createTestService(s.T(), impl, true)
 	defer cancel()
 
-	s.False(svc.DrainReschedule(), "should be empty initially")
+	s.False(impl.DrainReschedule(), "should be empty initially")
 
-	svc.SignalReschedule()
-	s.True(svc.DrainReschedule(), "should drain pending signal")
-	s.False(svc.DrainReschedule(), "should be empty after drain")
+	impl.SignalReschedule()
+	s.True(impl.DrainReschedule(), "should drain pending signal")
+	s.False(impl.DrainReschedule(), "should be empty after drain")
 }

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -18,17 +18,18 @@ import (
 type mockImpl struct {
 	TickServiceTemplate
 	tickCount atomic.Int32
-	onTick    func(n int32) // called on each Tick with the tick count (1-based)
+	onTick    func(n int32) bool // called on each Tick with the tick count (1-based)
 }
 
 func (m *mockImpl) OnReload() []error   { return nil }
 func (m *mockImpl) OnStop(bool) []error { return nil }
-func (m *mockImpl) Tick(ctx context.Context) []error {
+func (m *mockImpl) Tick(ctx context.Context) (bool, []error) {
 	n := m.tickCount.Add(1)
+	reschedule := false
 	if m.onTick != nil {
-		m.onTick(n)
+		reschedule = m.onTick(n)
 	}
-	return nil
+	return reschedule, nil
 }
 
 // createTestService creates a Service for testing with the given mock and
@@ -37,7 +38,6 @@ func (m *mockImpl) Tick(ctx context.Context) []error {
 func createTestService(
 	t *testing.T,
 	impl *mockImpl,
-	enableReschedule bool,
 ) (IService, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -49,7 +49,6 @@ func createTestService(
 			Cancel:           cancel,
 		},
 		PollInterval:     10 * time.Minute, // long: tests control wakeup explicitly
-		EnableReschedule: enableReschedule,
 	}, &impl.TickServiceTemplate, impl, impl)
 	require.NoError(t, err)
 	return impl, cancel
@@ -103,16 +102,14 @@ func (s *ServeSuite) TestRescheduleTriggersImmediateRetick() {
 	// Tick() again immediately without waiting for the timer.
 	var impl *mockImpl
 	impl = &mockImpl{
-		onTick: func(n int32) {
+		onTick: func(n int32) bool {
 			// Signal reschedule on ticks 1 and 2 (the initial tick
 			// and the first rescheduled tick). Stop on tick 3.
-			if n <= 2 {
-				impl.SignalReschedule()
-			}
+			return n <= 2
 		},
 	}
 
-	svc, cancel := createTestService(s.T(), impl, true)
+	svc, cancel := createTestService(s.T(), impl)
 	defer cancel()
 
 	done := make(chan struct{})
@@ -132,65 +129,17 @@ func (s *ServeSuite) TestRescheduleTriggersImmediateRetick() {
 		"should have at least 3 ticks: initial + 2 rescheduled")
 }
 
-func (s *ServeSuite) TestRescheduleCoalesces() {
-	// Multiple signals while Tick() is running should result in at most
-	// one extra tick, not one per signal.
-	tickStarted := make(chan struct{})
-	tickProceed := make(chan struct{})
-
-	impl := &mockImpl{
-		onTick: func(n int32) {
-			if n == 1 {
-				// Signal that the first tick is running.
-				close(tickStarted)
-				// Block the first tick until the test is ready.
-				<-tickProceed
-			}
-		},
-	}
-
-	svc, cancel := createTestService(s.T(), impl, true)
-	defer cancel()
-
-	done := make(chan struct{})
-	go func() {
-		_ = svc.Serve()
-		close(done)
-	}()
-
-	// Wait for the first tick to start.
-	<-tickStarted
-
-	// Send multiple signals while tick is blocked. Only one fits in the buffer.
-	for range 10 {
-		impl.SignalReschedule()
-	}
-
-	// Let the first tick complete.
-	close(tickProceed)
-
-	// Wait for the rescheduled tick to fire, then shut down.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-	<-done
-
-	// Should be exactly 2 ticks: the initial one + one rescheduled (coalesced).
-	ticks := impl.tickCount.Load()
-	s.Equal(int32(2), ticks,
-		"should have exactly 2 ticks: initial + 1 coalesced reschedule")
-}
-
 func (s *ServeSuite) TestContextCancellationExitsPromptly() {
 	// When context is cancelled with a reschedule signal pending,
 	// Serve() should exit promptly.
 	var impl *mockImpl
 	impl = &mockImpl{
-		onTick: func(_ int32) {
-			impl.SignalReschedule()
+		onTick: func(_ int32) bool {
+			return true
 		},
 	}
 
-	svc, cancel := createTestService(s.T(), impl, true)
+	svc, cancel := createTestService(s.T(), impl)
 
 	done := make(chan struct{})
 	go func() {
@@ -215,48 +164,11 @@ func (s *ServeSuite) TestServeExitsOnContextCancelledBeforeFirstTick() {
 	impl := &mockImpl{}
 
 	// Create the service with a live context, then cancel before Serve().
-	svc, cancel := createTestService(s.T(), impl, false)
+	svc, cancel := createTestService(s.T(), impl)
 	cancel()
 
 	err := svc.Serve()
 	s.NoError(err)
 	// No ticks should have fired since context was already cancelled.
 	s.Equal(int32(0), impl.tickCount.Load())
-}
-
-func (s *ServeSuite) TestRescheduleEnabledCreatesChannel() {
-	impl := &mockImpl{}
-	_, cancel := createTestService(s.T(), impl, true)
-	defer cancel()
-
-	s.NotNil(impl.reschedule, "reschedule channel should be created when enabled")
-}
-
-func (s *ServeSuite) TestRescheduleDisabledLeavesNilChannel() {
-	impl := &mockImpl{}
-	_, cancel := createTestService(s.T(), impl, false)
-	defer cancel()
-
-	s.Nil(impl.reschedule, "reschedule channel should be nil when disabled")
-}
-
-func (s *ServeSuite) TestSignalRescheduleNoopWhenDisabled() {
-	impl := &mockImpl{}
-	_, cancel := createTestService(s.T(), impl, false)
-	defer cancel()
-
-	// Should not panic on nil channel.
-	s.NotPanics(func() { impl.SignalReschedule() })
-}
-
-func (s *ServeSuite) TestDrainReschedule() {
-	impl := &mockImpl{}
-	_, cancel := createTestService(s.T(), impl, true)
-	defer cancel()
-
-	s.False(impl.DrainReschedule(), "should be empty initially")
-
-	impl.SignalReschedule()
-	s.True(impl.DrainReschedule(), "should drain pending signal")
-	s.False(impl.DrainReschedule(), "should be empty after drain")
 }

--- a/pkg/service/telemetry_test.go
+++ b/pkg/service/telemetry_test.go
@@ -15,13 +15,13 @@ import (
 
 // newTelemetryTestService returns a *Service ready to have CreateDefaultTelemetry
 // called on it. It wires a ServeMux, a mockImpl, and a discard logger.
-func newTelemetryTestService() *Service {
+func newTelemetryTestService() *ServiceTemplate {
 	impl := &mockImpl{}
-	return &Service{
-		Name:     "test",
-		Logger:   discardLogger(),
-		ServeMux: http.NewServeMux(),
-		Impl:     impl,
+	return &ServiceTemplate{
+		Name:          "test",
+		Logger:        discardLogger(),
+		ServeMux:      http.NewServeMux(),
+		lifecycleImpl: impl,
 	}
 }
 
@@ -98,18 +98,18 @@ func TestCreateDefaultTelemetry_PanicRecovered(t *testing.T) {
 	require.NotContains(t, rr.Body.String(), "kaboom")
 }
 
-type falseLifecycleImpl struct{ Service }
+type falseLifecycleImpl struct{ ServiceTemplate }
 
 func (*falseLifecycleImpl) Alive() bool                   { return false }
 func (*falseLifecycleImpl) Ready() bool                   { return false }
 func (*falseLifecycleImpl) OnServe(context.Context) error { return nil }
 
 func TestCreateDefaultTelemetry_Returns500WhenLifecycleFails(t *testing.T) {
-	service := &Service{
-		Name:     "test",
-		Logger:   discardLogger(),
-		ServeMux: http.NewServeMux(),
-		Impl:     &falseLifecycleImpl{},
+	service := &ServiceTemplate{
+		Name:          "test",
+		Logger:        discardLogger(),
+		ServeMux:      http.NewServeMux(),
+		lifecycleImpl: &falseLifecycleImpl{},
 	}
 
 	srv, _ := service.CreateDefaultTelemetry(":0")

--- a/pkg/service/telemetry_test.go
+++ b/pkg/service/telemetry_test.go
@@ -4,6 +4,7 @@
 package service
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -99,9 +100,9 @@ func TestCreateDefaultTelemetry_PanicRecovered(t *testing.T) {
 
 type falseLifecycleImpl struct{ Service }
 
-func (*falseLifecycleImpl) Alive() bool                  { return false }
-func (*falseLifecycleImpl) Ready() bool                  { return false }
-func (*falseLifecycleImpl) Tick() []error                { return nil }
+func (*falseLifecycleImpl) Alive() bool                   { return false }
+func (*falseLifecycleImpl) Ready() bool                   { return false }
+func (*falseLifecycleImpl) OnServe(context.Context) error { return nil }
 
 func TestCreateDefaultTelemetry_Returns500WhenLifecycleFails(t *testing.T) {
 	service := &Service{

--- a/pkg/service/telemetry_test.go
+++ b/pkg/service/telemetry_test.go
@@ -96,3 +96,26 @@ func TestCreateDefaultTelemetry_PanicRecovered(t *testing.T) {
 	require.Contains(t, rr.Body.String(), "Internal server error")
 	require.NotContains(t, rr.Body.String(), "kaboom")
 }
+
+type falseLifecycleImpl struct{ Service }
+
+func (*falseLifecycleImpl) Alive() bool                  { return false }
+func (*falseLifecycleImpl) Ready() bool                  { return false }
+func (*falseLifecycleImpl) Tick() []error                { return nil }
+
+func TestCreateDefaultTelemetry_Returns500WhenLifecycleFails(t *testing.T) {
+	service := &Service{
+		Name:     "test",
+		Logger:   discardLogger(),
+		ServeMux: http.NewServeMux(),
+		Impl:     &falseLifecycleImpl{},
+	}
+
+	srv, _ := service.CreateDefaultTelemetry(":0")
+
+	for _, path := range []string{"/readyz", "/livez"} {
+		rr := httptest.NewRecorder()
+		srv.Handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		require.Equal(t, http.StatusInternalServerError, rr.Code, "path=%s", path)
+	}
+}

--- a/test/integration/snapshot_policy_test.go
+++ b/test/integration/snapshot_policy_test.go
@@ -256,9 +256,25 @@ func (s *SnapshotPolicySuite) runSnapshotPolicyTest(cfg snapshotPolicyConfig) {
 	s.T().Logf("=== Snapshot %s test complete ===", policyStr)
 }
 
+var (
+	// PRT settlement mines hundreds of blocks rapidly, which can cause
+	// transient BlockOutOfRangeError in the EVM reader.
+	blockOutOrRangeErrorPattern ExpectedLog = ExpectedLog{
+		Pattern: regexp.MustCompile(`BlockOutOfRangeError`),
+		Level:   LevelError,
+		Reason:  "transient Anvil error during rapid block mining in PRT settlement",
+	}
+	contextCanceledPattern ExpectedLog = ExpectedLog{
+		Pattern: regexp.MustCompile(`context canceled`),
+		Level:   LevelError,
+		Reason:  "ongoing I/O operations are expected to fail with this error when node restarts",
+	}
+)
+
 // TestSnapshotPolicyEveryInput tests the EVERY_INPUT snapshot policy
 // with Authority consensus.
 func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryInput() {
+	s.SetExpectedLogs(s.T(), contextCanceledPattern)
 	s.runSnapshotPolicyTest(snapshotPolicyConfig{
 		Policy: model.SnapshotPolicy_EveryInput,
 	})
@@ -267,6 +283,7 @@ func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryInput() {
 // TestSnapshotPolicyEveryEpoch tests the EVERY_EPOCH snapshot policy
 // with Authority consensus.
 func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryEpoch() {
+	s.SetExpectedLogs(s.T(), contextCanceledPattern)
 	s.runSnapshotPolicyTest(snapshotPolicyConfig{
 		Policy: model.SnapshotPolicy_EveryEpoch,
 	})
@@ -275,13 +292,7 @@ func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryEpoch() {
 // TestSnapshotPolicyEveryInputPrt tests the EVERY_INPUT snapshot policy
 // with PRT (Dave) consensus.
 func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryInputPrt() {
-	// PRT settlement mines hundreds of blocks rapidly, which can cause
-	// transient BlockOutOfRangeError in the EVM reader.
-	s.SetExpectedLogs(s.T(), ExpectedLog{
-		Pattern: regexp.MustCompile(`BlockOutOfRangeError`),
-		Level:   LevelError,
-		Reason:  "transient Anvil error during rapid block mining in PRT settlement",
-	})
+	s.SetExpectedLogs(s.T(), blockOutOrRangeErrorPattern, contextCanceledPattern)
 
 	endpoint := envOrDefault(
 		"CARTESI_BLOCKCHAIN_HTTP_ENDPOINT", "http://localhost:8545")
@@ -305,13 +316,7 @@ func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryInputPrt() {
 // TestSnapshotPolicyEveryEpochPrt tests the EVERY_EPOCH snapshot policy
 // with PRT (Dave) consensus.
 func (s *SnapshotPolicySuite) TestSnapshotPolicyEveryEpochPrt() {
-	// PRT settlement mines hundreds of blocks rapidly, which can cause
-	// transient BlockOutOfRangeError in the EVM reader.
-	s.SetExpectedLogs(s.T(), ExpectedLog{
-		Pattern: regexp.MustCompile(`BlockOutOfRangeError`),
-		Level:   LevelError,
-		Reason:  "transient Anvil error during rapid block mining in PRT settlement",
-	})
+	s.SetExpectedLogs(s.T(), blockOutOrRangeErrorPattern, contextCanceledPattern)
 
 	endpoint := envOrDefault(
 		"CARTESI_BLOCKCHAIN_HTTP_ENDPOINT", "http://localhost:8545")

--- a/test/validator/validator_test.go
+++ b/test/validator/validator_test.go
@@ -132,7 +132,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPristineClaim() {
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick()
+		errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), epoch.Index)
@@ -254,7 +254,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPreviousClaim() {
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick()
+		errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), secondEpoch.Index)
@@ -336,7 +336,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick()
+		errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), epoch.Index)
@@ -489,7 +489,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick()
+		errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedSecondEpoch, err := s.repository.GetEpoch(

--- a/test/validator/validator_test.go
+++ b/test/validator/validator_test.go
@@ -134,7 +134,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPristineClaim() {
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick(s.ctx)
+		_, errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), epoch.Index)
@@ -256,7 +256,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsPreviousClaim() {
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick(s.ctx)
+		_, errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), secondEpoch.Index)
@@ -338,7 +338,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick(s.ctx)
+		_, errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedEpoch, err := s.repository.GetEpoch(s.ctx, app.IApplicationAddress.String(), epoch.Index)
@@ -491,7 +491,7 @@ func (s *ValidatorRepositoryIntegrationSuite) TestItReturnsANewClaimAndProofs() 
 		err = s.repository.StoreAdvanceResult(s.ctx, 1, &advanceResult)
 		s.Require().Nil(err)
 
-		errs := s.validator.Tick(s.ctx)
+		_, errs := s.validator.Tick(s.ctx)
 		s.Require().Equal(0, len(errs))
 
 		updatedSecondEpoch, err := s.repository.GetEpoch(

--- a/test/validator/validator_test.go
+++ b/test/validator/validator_test.go
@@ -64,7 +64,8 @@ func (s *ValidatorRepositoryIntegrationSuite) SetupSubTest() {
 		},
 		Repository: s.repository,
 	}
-	s.validator, err = validator.Create(context.Background(), &serviceArgs)
+	srv, err := validator.Create(context.Background(), &serviceArgs)
+	s.validator = srv.(*validator.Service)
 	s.Require().Nil(err)
 }
 

--- a/test/validator/validator_test.go
+++ b/test/validator/validator_test.go
@@ -58,9 +58,11 @@ func (s *ValidatorRepositoryIntegrationSuite) SetupSubTest() {
 	s.Require().Nil(err)
 
 	serviceArgs := validator.CreateInfo{
-		CreateInfo: service.CreateInfo{
-			Name:     "validator",
-			LogLevel: slog.LevelDebug,
+		TickServiceConfigs: service.TickServiceConfigs{
+			ServiceConfigs: service.ServiceConfigs{
+				Name:     "validator",
+				LogLevel: slog.LevelDebug,
+			},
 		},
 		Repository: s.repository,
 	}


### PR DESCRIPTION
# Issues Addressed

- Propagate errors from services through the service framework.
- Provide better support for services that do not perform periodic batch processing (tick-based), like the ones that provide a HTTP interface (e.g. Advancer, JSON-RPC) or consume external events like a WebSocket (i.e. EVM Reader).
- Avoid multiple stages during service shutdown (Running, Stopping, and Stopped).
- Avoid method shadowing of service framework methods.

# Still Open Issues (left for a future PR)

- There are two ways to stop services: either calling `Stop(force bool)` or by cancelling the context explicitly provided to be used by the service. The former is used to synchronize the shutdown of multiple services running together.
- Extend the support for services oriented to periodic batch processing (tick-based) to also support for services oriented to provide HTTP interface, and also services that consume external events like a WebSocket interface.
- Provide better support to organize the code as independent services running under a single process. Examples include the Node running as a single process, or the Advancer HTTP API running with and Inspector, and Telemetry API in a single process.

# Overview of Changes

Package `pkg/service` provides the service runtime used across the node. It owns lifecycle concerns such as logging, signal handling, telemetry, and shutdown coordination.

The solution seems to try to follow the [Template Method design pattern](https://refactoring.guru/design-patterns/template-method) where a base class implements methods that provide those basic features (template methods defined by interface `IService`) but also calls additional methods that are provided by the subclass to implement some service specific behavior (abstract methods defined by interface `ServiceImpl`).

```go
package service

type ServiceImpl interface {
  Alive() bool
  Ready() bool
  Reload() []error
  Stop(bool) []error

  Tick() []error
}

type IService interface {
  Alive() bool
  Ready() bool
  Reload() []error
  Stop(bool) []error

  Serve() error
  String() string
}

type Service struct {
  Name string
  ...
  Impl ServiceImpl
}
func (s *Service) Alive() bool { return s.Impl.Alive() }
func (s *Service) Ready() bool { return s.Impl.Ready() }
func (s *Service) Reload() []error { ... return s.Impl.Reload() }
func (s *Service) Stop(force bool) []error { ... return s.Impl.Stop(force) }
func (s *Service) Serve() []error { return for { s.Impl.Tick() ... } }
func (s *Service) String() string { return s.Name }

////////////////////////////////////////////////////////////////////////////////

package custom_service

type Service struct {
  service.Service
  ...
}
func Create() *Service {
  s := &Service{Name: "Custom Service"}
  s.Impl = s  /* same as 's.Service.Impl = s' */
  return s
}
func (s *Service) Alive() bool { return true }
func (s *Service) Ready() bool { return true }
func (s *Service) Reload() []error { return nil }
func (s *Service) Stop(force bool) []error { return nil }
func (s *Service) Tick() []error { ... return nil }
```

In Go, it is common to use struct embedding to emulate class inheritance of other languages. However, Go does not provide a standard way for a embedded struct (base class) like `service.Service` to access its embedding struct (subclass) `custom_service.Service`. Therefore it is always necessary to explicitly provide a reference that allows the template method to access the actual implementation of the abstract method it needs to call (see the description of one approach [here](https://adrianwit.medium.com/abstract-class-reinvented-with-go-4a7326525034)). This explicit reference is provided as field `service.Service.Impl`.

Such approach for Template Methods using struct embedding with explicit auto-reference has the following advantages:

1. Since both template and abstract method implementations are accessible in the embedding struct (subclass), abstract methods can easily access the API of the base class. For instance, access the `Logger` from the base class or call `Cancel` to terminate the service's context and cause the service to stop (it would be better to be able to call `Stop` but it is shadowed due to a particular problem of the current implementation).
2. By using the instance to the embedding struct (subclass) as the service object implementing `IService` for the clients, the embedding struct (subclass) can override any of its public method by shadowing the "inherited" implementation. For instance, some services redefine the `Server` method to do continuous processing instead of the tick-based periodic processing supported by the service framework.

# Problems

1. Using the same method name for a template method and the abstract method that it invokes causes some confusion when adopting the approach of struct embedding because the abstract method shadows the template method. Therefore clients using the objects returned by factory function `custom_service.Create()` will execute the stripped down abstract method instead of the full-featured template method. In principle, we could solve this by returning the embedded `service.Service` instead of the `custom_service.Service` object, but this would prevent shadowing altogether, which is an issue as described by the next problem.

2. Since `service.Service` only supports services that perform smalls processing batches periodically (ticks), some custom services define an implementation of `Serve` that shadows the one from `service.Service` to start Goroutines for continuous tasks. Therefore, we currently must return `custom_service.Service` to allow to shadowing of some methods.

# Solution

Adopt different method names for abstract methods to avoid unintentional method shadowing. It also makes clear that calling `Stop` on `custom_service.Service` will not execute `custom_service.Service.Stop` as the former will be named differently.

Unlike methods `Reload`, `Stop`, and `Serve`, methods `Alive` and `Ready` do not implement a common basic behavior and only delegate entirely to the custom service. For this reason, we will not implement them as a pair of template and abstract methods, and just let the concrete services to shadow them when necessary to define a custom behavior.

We will also implement a standard behavior for most abstract methods which are currently implemented by most services.

We will also provide two alternative service templates:
- `ServiceTemplate` for services that do continuous processing.
- `TickServiceTemplate` for services that do processing in periodic batches (tick-based).

Finally, since the `impl` self-reference is a specific hack necessary in Go to implement the Template Method design pattern, we removed this field from the service initialization structure (current `ConfigInfo`) to avoid making them too visible in the code, and try to confine this setup of the self-references to the factory functions that create and initialize services.

```go
package service

// Public interface with methods to manipulate the service.
type IService interface {
  Alive() bool
  Ready() bool
  Reload() []error
  Stop(bool) []error
  Serve() error
  String() string
}

/*
 * Template for services that do continuous processing.
 */

// Internal interface with abstract methods called by the template methods.
// These methods are not part of the public service API.
type LifecycleImpl interface {
  OnReload() []error
  OnStop(bool) []error
  DoServe() []error
}

type ServiceTemplate struct {
  lifecycle LifecycleImpl
  Name string
  ...
}

type ServiceConfigs struct {
  Name string
  ...
}

func InitTemplate(
  cfg *ServiceConfigs,
  tmpl *ServiceTemplate,
  impl LifecycleImpl,
) {
  /* assume impl.ServiceTemplate == tmpl */
  tmpl.lifecycle = impl  // set explicit auto-reference used by template methods
  tmpl.Name = cfg.Name
  ...
}

// Default implementation of some abstract methods (except `Tick`).
// Remove them to force concrete services to provide implementation for them.
func (s *ServiceTemplate) OnReload() []error { return nil }
func (s *ServiceTemplate) OnStop(bool) []error { return nil }
func (s *ServiceTemplate) Alive() bool { return true }
func (s *ServiceTemplate) Ready() bool { return true }
func (s *ServiceTemplate) String() string { return s.Name }

// Template methods implementing basic behavior.
func (s *ServiceTemplate) Reload() []error { ... return s.lifecycle.OnReload() }
func (s *ServiceTemplate) Stop(force bool) []error { ... return s.lifecycle.OnStop(force) }
func (s *ServiceTemplate) Serve() []error { ... return s.lifecycle.DoServe() }

/*
 * Alternative template that implements the tick-based processing.
 */

// Internal interface with abstract methods called by the template methods.
// These methods are not part of the public service API.
type TickImpl interface {
  Tick() []error
}

type TickServiceTemplate struct {
  ServiceTemplate
  tickImpl TickImpl
  ticker   *time.Ticker
  ...
}

type TickServiceConfigs struct {
  ServiceConfigs
  PollInterval     time.Duration
  EnableReschedule bool
}

func InitTickTemplate(
  cfg *TickServiceConfigs,
  tmpl *TickServiceTemplate,
  svcImpl LifecycleImpl,
  tickImpl TickImpl,
) {
  /* assume tickImpl.TickServiceTemplate == t */
  tmpl.tickImpl = tickImpl  // set explicit auto-reference used by template methods
  InitTemplate(cfg.ServiceConfigs, tmpl.ServiceTemplate, svcImpl)
  ...
}

// Internal API with methods provided for use in implementation of concrete services.
func (s *TickServiceTemplate) SignalReschedule() { ... }
func (s *TickServiceTemplate) DrainReschedule() bool { ... }  // used only for unit testing

// Default implementation of abstract method used by `ServiceTemplate`.
func (s *TickServiceTemplate) DoServe() []error { ... for { ... s.impl.Tick() ... } ... }

////////////////////////////////////////////////////////////////////////////////

package custom_service

type CustomService struct {
  service.TickServiceTemplate
  ...
}

type CustomConfigs struct {
  service.TickServiceConfigs
  ...
}

func NewCustomService(cfg *CustomConfigs) service.IService {
  s := &CustomService{}
  service.InitTickTemplate(cfg.TickServiceConfigs, s.TickServiceTemplate, s, s)
  return s
}

// Override public methods by shadowing.
func (s *CustomService) Alive() bool { ... }
func (s *CustomService) Ready() bool { ... }

// Override default implementation of abstract methods used by the `ServiceTemplate`.
func (s *CustomService) OnReload() []error { ... }
func (s *CustomService) OnStop(force bool) []error { ... }
func (s *CustomService) DoServe() []error { ... return s.TickServiceTemplate.DoServe() }

// Implement abstract methods used by the `TickServiceTemplate`.
func (s *CustomService) Tick() []error { ... }
```
