### PR TITLE
feature(emulator): bump emulator (v0.21.0), rootfs (v0.18.0), linux (6.5.13-ctsi-2-v0.21.0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 
 # syntax=docker.io/docker/dockerfile:1
 
-ARG EMULATOR_VERSION=0.20.0
+ARG EMULATOR_VERSION=0.21.0
 
 # Build directories.
 ARG GO_BUILD_PATH=/build/cartesi/go
@@ -29,8 +29,8 @@ RUN <<EOF
     ARCH=$(dpkg --print-architecture)
     wget -O /tmp/cartesi-machine-emulator.deb "https://github.com/cartesi/machine-emulator/releases/download/v${EMULATOR_VERSION}/machine-emulator_${ARCH}.deb"
     case "$ARCH" in
-        amd64) echo "46b2f37b889091df3b89a8909467935f8dd4a1426eeb0491b6a346a12f0c341c  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
-        arm64) echo "27ea10571335ad174b75388e7de54a3d3434bd607554d8c0bdf6abca47ceae0d  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
+        amd64) echo "5f13034f43454c340062c677146daabe77c587cee1bd60342c95b8ad8f1463a3  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
+        arm64) echo "866f0bde2db53b9b8e6a6eac85e5ad4116338379fa25cdfcc5e4bf835f948bb1  /tmp/cartesi-machine-emulator.deb" | sha256sum --check ;;
         *) echo "unsupported architecture: $ARCH"; exit 1 ;;
     esac
     apt-get install -y --no-install-recommends /tmp/cartesi-machine-emulator.deb

--- a/Makefile
+++ b/Makefile
@@ -414,13 +414,13 @@ withdraw-wallet: cartesi-rollups-cli ## Send a test withdrawal request from the 
 
 # Temporary test dependencies target while we are not using distribution packages
 DOWNLOADS_DIR = test/downloads
-CARTESI_TEST_MACHINE_IMAGES = $(DOWNLOADS_DIR)/linux.bin
+CARTESI_TEST_MACHINE_IMAGES = $(DOWNLOADS_DIR)/linux.bin $(DOWNLOADS_DIR)/rootfs.ext2
 $(CARTESI_TEST_MACHINE_IMAGES):
 	@mkdir -p $(DOWNLOADS_DIR)
 	@wget -nc -i test/dependencies -P $(DOWNLOADS_DIR)
 	@shasum -ca 256 test/dependencies.sha256
 	@cd $(DOWNLOADS_DIR) && ln -s rootfs-tools.ext2 rootfs.ext2
-	@cd $(DOWNLOADS_DIR) && ln -s linux-6.5.13-ctsi-1-v0.20.0.bin linux.bin
+	@cd $(DOWNLOADS_DIR) && ln -s linux-6.5.13-ctsi-2-v0.21.0.bin linux.bin
 
 download-test-dependencies: | $(CARTESI_TEST_MACHINE_IMAGES)
 

--- a/cmd/cartesi-rollups-machine-tool/main.go
+++ b/cmd/cartesi-rollups-machine-tool/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -165,7 +166,7 @@ func replayInputsBatch(ctx context.Context, opts replayOptions, tmp string, inpu
 
 	args := []string{
 		"--quiet",
-		"--no-rollback",
+		"--no-revert",
 		"--load=" + opts.Template,
 		fmt.Sprintf("--cmio-advance-state=input:%s,input_index_begin:0,input_index_end:%d",
 			filepath.Join(tmp, "input-%i.bin"), len(inputs)),
@@ -374,7 +375,7 @@ func generateMachineProof(
 
 	args := []string{
 		"--quiet",
-		"--no-rollback",
+		"--no-revert",
 		"--load=" + snapshot,
 		fmt.Sprintf("--initial-proof=address:0x%x,log2_size:%d,filename:%s", address, log2Size, tmpPath),
 		"--",
@@ -392,6 +393,23 @@ func generateMachineProof(
 	if err := json.Unmarshal(raw, &proof); err != nil {
 		return nil, fmt.Errorf("parse machine proof: %w", err)
 	}
+
+	// convert the file hashes from base64 to hex
+	proof.RootHash, err = base64ToHex(proof.RootHash)
+	if err != nil {
+		return nil, err
+	}
+	proof.TargetHash, err = base64ToHex(proof.TargetHash)
+	if err != nil {
+		return nil, err
+	}
+	for i := range proof.SiblingHashes {
+		proof.SiblingHashes[i], err = base64ToHex(proof.SiblingHashes[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &proof, nil
 }
 
@@ -477,4 +495,15 @@ func ensure0x(s string) string {
 
 func strip0x(s string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+}
+
+func base64ToHex(s string) (string, error) {
+	raw, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", fmt.Errorf("expected %q to be a hash in base64. %w", s, err)
+	}
+	if len(raw) != common.HashLength {
+		return "", fmt.Errorf("expected %q to decode to %d bytes, got %d", s, common.HashLength, len(raw))
+	}
+	return common.BytesToHash(raw).Hex(), nil
 }

--- a/cmd/cartesi-rollups-machine-tool/replay_dave.lua
+++ b/cmd/cartesi-rollups-machine-tool/replay_dave.lua
@@ -3,8 +3,6 @@
 
 local cartesi = require("cartesi")
 
-local checkpoint_address = 0xfe0
-
 local function usage(message)
     if message then io.stderr:write(message, "\n") end
     io.stderr:write(
@@ -75,16 +73,15 @@ end
 
 local function advance_one(machine, input_path, input_number)
     local checkpoint = machine:get_root_hash()
-    machine:write_memory(checkpoint_address, checkpoint)
-    machine:send_cmio_response(cartesi.CMIO_YIELD_REASON_ADVANCE_STATE, read_all(input_path))
+    machine:send_cmio_response(cartesi.HTIF_YIELD_REASON_ADVANCE_STATE, read_all(input_path), checkpoint)
     run_until_manual_yield(machine)
 
     local _, reason, data = machine:receive_cmio_request()
-    if reason == cartesi.CMIO_YIELD_MANUAL_REASON_RX_REJECTED then
+    if reason == cartesi.HTIF_YIELD_MANUAL_REASON_RX_REJECTED then
         error(string.format("Dave replay input %d was rejected", input_number))
-    elseif reason == cartesi.CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION then
+    elseif reason == cartesi.HTIF_YIELD_MANUAL_REASON_TX_EXCEPTION then
         error(string.format("Dave replay input %d raised an exception", input_number))
-    elseif reason ~= cartesi.CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED then
+    elseif reason ~= cartesi.HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED then
         error(string.format("Dave replay input %d ended with unexpected yield reason %s", input_number, tostring(reason)))
     end
     if #data ~= 32 then

--- a/control.template
+++ b/control.template
@@ -5,7 +5,7 @@ Homepage: https://docs.cartesi.io/cartesi-rollups/
 Architecture: ARG_ARCH
 Maintainer: Node Reference Unit <https://discord.com/channels/600597137524391947/1110564973115097179>
 Provides: cartesi-rollups-node
-Depends: cartesi-machine-emulator (>= 0.20.0), cartesi-machine-emulator (<< 0.21.0)
+Depends: cartesi-machine-emulator (>= 0.21.0), cartesi-machine-emulator (<< 0.22.0)
 Section: net
 Priority: optional
 Multi-Arch: no

--- a/internal/manager/instance.go
+++ b/internal/manager/instance.go
@@ -299,16 +299,8 @@ func (m *MachineInstanceImpl) Advance(ctx context.Context, input []byte, epochIn
 	advanceCtx, cancel := context.WithTimeout(ctx, m.advanceTimeout)
 	defer cancel()
 
-	if computeHashes {
-		// write the checkpoint hash before processing
-		err = fork.WriteCheckpointHash(advanceCtx, prevMachineHash)
-		if err != nil {
-			return nil, errors.Join(err, fork.Close())
-		}
-	}
-
 	// Process the input
-	advanceResp, err := fork.Advance(advanceCtx, input, computeHashes)
+	advanceResp, err := fork.Advance(advanceCtx, input, prevMachineHash, computeHashes)
 	status, err := toInputStatus(advanceResp.Accepted, err)
 	if err != nil {
 		return nil, errors.Join(err, fork.Close())

--- a/internal/manager/instance_test.go
+++ b/internal/manager/instance_test.go
@@ -507,9 +507,6 @@ func (s *MachineInstanceSuite) TestAdvance() {
 		require := s.Require()
 		inner, fork, machine := s.setupAdvance()
 
-		// Set up WriteCheckpointHash to succeed
-		fork.CheckpointHashError = nil
-
 		res, err := machine.Advance(context.Background(), []byte{}, 0, 5, true)
 		require.Nil(err)
 		require.NotNil(res)
@@ -521,20 +518,6 @@ func (s *MachineInstanceSuite) TestAdvance() {
 
 		// Verify the inner runtime was closed (accept path)
 		_ = inner
-	})
-
-	s.Run("CollectHashesWriteCheckpointError", func() {
-		require := s.Require()
-		_, fork, machine := s.setupAdvance()
-
-		errCheckpoint := errors.New("checkpoint write error")
-		fork.CheckpointHashError = errCheckpoint
-
-		res, err := machine.Advance(context.Background(), []byte{}, 0, 5, true)
-		require.Error(err)
-		require.Nil(res)
-		require.ErrorIs(err, errCheckpoint)
-		require.Equal(uint64(5), machine.processedInputs.Load())
 	})
 
 	s.Run("SequentialAdvances", func() {
@@ -1475,8 +1458,6 @@ type MockRollupsMachine struct {
 	HashReturn machine.Hash
 	HashError  error
 
-	CheckpointHashError error
-
 	AdvanceAcceptedReturn  bool
 	AdvanceOutputsReturn   []machine.Output
 	AdvanceReportsReturn   []machine.Report
@@ -1516,11 +1497,7 @@ func (m *MockRollupsMachine) OutputsHashProof(_ context.Context) ([]machine.Hash
 	return m.OutputsHashProofReturn, m.OutputsHashProofError
 }
 
-func (m *MockRollupsMachine) WriteCheckpointHash(_ context.Context, _ machine.Hash) error {
-	return m.CheckpointHashError
-}
-
-func (m *MockRollupsMachine) Advance(_ context.Context, _ []byte, _ bool) (*machine.AdvanceResponse, error) {
+func (m *MockRollupsMachine) Advance(_ context.Context, _ []byte, _ machine.Hash, _ bool) (*machine.AdvanceResponse, error) {
 	return &machine.AdvanceResponse{
 		Accepted:        m.AdvanceAcceptedReturn,
 		Outputs:         m.AdvanceOutputsReturn,

--- a/internal/manager/instance_test.go
+++ b/internal/manager/instance_test.go
@@ -27,6 +27,14 @@ func TestMachineInstance(t *testing.T) {
 
 type MachineInstanceSuite struct{ suite.Suite }
 
+func (s *MachineInstanceSuite) TestMcycleOverflowRemainsIncomplete() {
+	require := s.Require()
+
+	status, err := toInputStatus(false, machine.ErrReachedLimitMcycle)
+	require.ErrorIs(err, machine.ErrReachedLimitMcycle)
+	require.Empty(status)
+}
+
 // MockMachineRuntimeFactory implements MachineRuntimeFactory for testing
 type MockMachineRuntimeFactory struct {
 	RuntimeToReturn machine.Machine

--- a/pkg/emulator/emulator.go
+++ b/pkg/emulator/emulator.go
@@ -8,7 +8,7 @@ package emulator
 
 // #cgo LDFLAGS: -lcartesi -lcartesi_jsonrpc
 // #include <stdlib.h>
-// #include "cartesi-machine/jsonrpc-machine-c-api.h"
+// #include "cartesi-machine/cm-jsonrpc.h"
 import "C"
 
 import (

--- a/pkg/emulator/machine.go
+++ b/pkg/emulator/machine.go
@@ -8,7 +8,18 @@ package emulator
 
 // #include <stdlib.h>
 // #include <string.h>
-// #include "cartesi-machine/machine-c-api.h"
+// #include "cartesi-machine/cm.h"
+//
+// static inline cm_error go_cm_send_cmio_response(
+//     cm_machine *m,
+//     uint16_t reason,
+//     const uint8_t *data,
+//     uint64_t length,
+//     const uint8_t *revert_root_hash)
+// {
+//     return cm_send_cmio_response(
+//         m, reason, data, length, (const cm_hash *) revert_root_hash);
+// }
 import "C"
 
 import (
@@ -383,16 +394,22 @@ func (m *Machine) CollectMCycleRootHashes(mcycleEnd, mcyclePeriod, mcyclePhase u
 }
 
 // collect_uarch_cycle_root_hashes
-func (m *Machine) CollectUarchCycleRootHashes(mcycleEnd uint64, log2BundleMcycleCount int32) ([]byte, error) {
+func (m *Machine) CollectUarchCycleRootHashes(mcycleEnd uint64, log2BundleUarchCycleCount int32, revertUarchTail string) ([]byte, error) {
 	var err error
 	var result []byte
 
 	m.callCAPI(func() {
 		var cResult *C.char
+		var revertUarchTailC *C.char
+		if revertUarchTail != "" {
+			revertUarchTailC = C.CString(revertUarchTail)
+			defer C.free(unsafe.Pointer(revertUarchTailC))
+		}
 		err = newError(C.cm_collect_uarch_cycle_root_hashes(
 			m.ptr,
 			C.uint64_t(mcycleEnd),
-			C.int32_t(log2BundleMcycleCount),
+			C.int32_t(log2BundleUarchCycleCount),
+			revertUarchTailC,
 			&cResult))
 		result = []byte(C.GoString(cResult))
 	})
@@ -404,7 +421,7 @@ func (m *Machine) CollectUarchCycleRootHashes(mcycleEnd uint64, log2BundleMcycle
 }
 
 // send_cmio_response
-func (m *Machine) SendCmioResponse(reason uint16, data []byte) error {
+func (m *Machine) SendCmioResponse(reason uint16, data []byte, revertRootHash *Hash) error {
 	var err error
 
 	m.callCAPI(func() {
@@ -413,9 +430,13 @@ func (m *Machine) SendCmioResponse(reason uint16, data []byte) error {
 		if sizeData > 0 {
 			ptrData = (*C.uint8_t)(unsafe.Pointer(&data[0]))
 		}
-
-		err = newError(C.cm_send_cmio_response(
+		var ptrHash *C.uint8_t
+		if revertRootHash != nil {
+			ptrHash = (*C.uint8_t)(unsafe.Pointer(revertRootHash))
+		}
+		err = newError(C.go_cm_send_cmio_response(
 			m.ptr,
+			ptrHash,
 			C.uint16_t(reason),
 			ptrData,
 			sizeData,

--- a/pkg/emulator/machine.go
+++ b/pkg/emulator/machine.go
@@ -23,6 +23,7 @@ package emulator
 import "C"
 
 import (
+	"encoding/json"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -32,6 +33,12 @@ const HashSize = C.sizeof_cm_hash
 
 // Common type aliases
 type Hash = [HashSize]byte
+
+// RevertUarchTail is the emulator-owned JSON array of base64-encoded state
+// hashes for the reset-delimited uarch period corresponding to a revert root.
+// It remains opaque so collector output can be passed back without decoding and
+// re-encoding every hash.
+type RevertUarchTail json.RawMessage
 
 // -----------------------------------------------------------------------------
 // Machine Methods
@@ -365,24 +372,30 @@ func (m *Machine) Run(mcycleEnd uint64) (BreakReason, error) {
 }
 
 // collect_mcycle_root_hashes
-func (m *Machine) CollectMCycleRootHashes(mcycleEnd, mcyclePeriod, mcyclePhase uint64, log2BundleMcycleCount int32, previousBackTree string) ([]byte, error) {
+func (m *Machine) CollectMCycleRootHashes(
+	mcycleEnd,
+	log2McyclePeriod,
+	mcyclePhase uint64,
+	log2BundleMcycleCount int32,
+	previousPartialBundle json.RawMessage,
+) ([]byte, error) {
 	var err error
 	var result []byte
 
 	m.callCAPI(func() {
 		var cResult *C.char
-		var previousBackTreeC *C.char
-		if previousBackTree != "" {
-			previousBackTreeC = C.CString(previousBackTree)
-			defer C.free(unsafe.Pointer(previousBackTreeC))
+		var previousPartialBundleC *C.char
+		if len(previousPartialBundle) > 0 {
+			previousPartialBundleC = C.CString(string(previousPartialBundle))
+			defer C.free(unsafe.Pointer(previousPartialBundleC))
 		}
 		err = newError(C.cm_collect_mcycle_root_hashes(
 			m.ptr,
 			C.uint64_t(mcycleEnd),
-			C.uint64_t(mcyclePeriod),
+			C.uint64_t(log2McyclePeriod),
 			C.uint64_t(mcyclePhase),
 			C.int32_t(log2BundleMcycleCount),
-			previousBackTreeC,
+			previousPartialBundleC,
 			&cResult))
 		result = []byte(C.GoString(cResult))
 	})
@@ -394,15 +407,19 @@ func (m *Machine) CollectMCycleRootHashes(mcycleEnd, mcyclePeriod, mcyclePhase u
 }
 
 // collect_uarch_cycle_root_hashes
-func (m *Machine) CollectUarchCycleRootHashes(mcycleEnd uint64, log2BundleUarchCycleCount int32, revertUarchTail string) ([]byte, error) {
+func (m *Machine) CollectUarchCycleRootHashes(
+	mcycleEnd uint64,
+	log2BundleUarchCycleCount int32,
+	revertUarchTail RevertUarchTail,
+) ([]byte, error) {
 	var err error
 	var result []byte
 
 	m.callCAPI(func() {
 		var cResult *C.char
 		var revertUarchTailC *C.char
-		if revertUarchTail != "" {
-			revertUarchTailC = C.CString(revertUarchTail)
+		if len(revertUarchTail) > 0 {
+			revertUarchTailC = C.CString(string(revertUarchTail))
 			defer C.free(unsafe.Pointer(revertUarchTailC))
 		}
 		err = newError(C.cm_collect_uarch_cycle_root_hashes(
@@ -436,10 +453,10 @@ func (m *Machine) SendCmioResponse(reason uint16, data []byte, revertRootHash *H
 		}
 		err = newError(C.go_cm_send_cmio_response(
 			m.ptr,
-			ptrHash,
 			C.uint16_t(reason),
 			ptrData,
 			sizeData,
+			ptrHash,
 		))
 	})
 

--- a/pkg/emulator/machine.go
+++ b/pkg/emulator/machine.go
@@ -397,7 +397,9 @@ func (m *Machine) CollectMCycleRootHashes(
 			C.int32_t(log2BundleMcycleCount),
 			previousPartialBundleC,
 			&cResult))
-		result = []byte(C.GoString(cResult))
+		if err == nil {
+			result = []byte(C.GoString(cResult))
+		}
 	})
 	if err != nil {
 		return nil, err
@@ -428,7 +430,9 @@ func (m *Machine) CollectUarchCycleRootHashes(
 			C.int32_t(log2BundleUarchCycleCount),
 			revertUarchTailC,
 			&cResult))
-		result = []byte(C.GoString(cResult))
+		if err == nil {
+			result = []byte(C.GoString(cResult))
+		}
 	})
 
 	if err != nil {

--- a/pkg/emulator/machine_test.go
+++ b/pkg/emulator/machine_test.go
@@ -1,0 +1,147 @@
+// (c) Cartesi and individual authors (see AUTHORS)
+// SPDX-License-Identifier: Apache-2.0 (see LICENSE)
+
+package emulator
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mcycleRootHashesResult struct {
+	Hashes        []string        `json:"hashes"`
+	MCyclePhase   uint64          `json:"mcycle_phase"`
+	BreakReason   string          `json:"break_reason"`
+	PartialBundle json.RawMessage `json:"partial_bundle,omitempty"`
+}
+
+func createLoopMachine(t *testing.T) *Machine {
+	t.Helper()
+
+	const ramLength = 4096
+	image := make([]byte, ramLength)
+	// jal x0, 0 loops forever while allowing mcycle to advance predictably.
+	binary.LittleEndian.PutUint32(image, 0x0000006f)
+	imagePath := filepath.Join(t.TempDir(), "loop.bin")
+	require.NoError(t, os.WriteFile(imagePath, image, 0o600))
+
+	config, err := json.Marshal(map[string]any{
+		"ram": map[string]any{
+			"length": ramLength,
+			"backing_store": map[string]any{
+				"data_filename": imagePath,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	machine, err := CreateMachine(string(config), "", "")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, machine.Destroy())
+		machine.Delete()
+	})
+	return machine
+}
+
+func collectMCycleRootHashes(
+	t *testing.T,
+	machine *Machine,
+	target,
+	log2Period,
+	phase uint64,
+	log2Bundle int32,
+	partialBundle json.RawMessage,
+) mcycleRootHashesResult {
+	t.Helper()
+
+	rawResult, err := machine.CollectMCycleRootHashes(target, log2Period, phase, log2Bundle, partialBundle)
+	require.NoError(t, err)
+	var result mcycleRootHashesResult
+	require.NoError(t, json.Unmarshal(rawResult, &result))
+	return result
+}
+
+func TestCollectMCycleRootHashes_PartitionedBundlingMatchesOneShot(t *testing.T) {
+	const (
+		mcycleStart = uint64(1)
+		mcycleEnd   = uint64(65)
+		log2Period  = uint64(2)
+		log2Bundle  = int32(2)
+	)
+	targets := []uint64{2, 7, 19, 34, mcycleEnd}
+
+	oneShotMachine := createLoopMachine(t)
+	partitionedMachine := createLoopMachine(t)
+	for _, machine := range []*Machine{oneShotMachine, partitionedMachine} {
+		breakReason, err := machine.Run(mcycleStart)
+		require.NoError(t, err)
+		require.Equal(t, BreakReasonReachedTargetMcycle, breakReason)
+	}
+
+	oneShot := collectMCycleRootHashes(
+		t,
+		oneShotMachine,
+		mcycleEnd,
+		log2Period,
+		mcycleStart%(uint64(1)<<log2Period),
+		log2Bundle,
+		nil,
+	)
+
+	partitioned := mcycleRootHashesResult{
+		MCyclePhase: mcycleStart % (uint64(1) << log2Period),
+	}
+	sawPartialBundle := false
+	for _, target := range targets {
+		result := collectMCycleRootHashes(
+			t,
+			partitionedMachine,
+			target,
+			log2Period,
+			partitioned.MCyclePhase,
+			log2Bundle,
+			partitioned.PartialBundle,
+		)
+		partitioned.Hashes = append(partitioned.Hashes, result.Hashes...)
+		partitioned.MCyclePhase = result.MCyclePhase
+		partitioned.BreakReason = result.BreakReason
+		partitioned.PartialBundle = result.PartialBundle
+		sawPartialBundle = sawPartialBundle || len(result.PartialBundle) > 0
+	}
+
+	require.True(t, sawPartialBundle, "test partitions must exercise partial-bundle continuation")
+	require.Equal(t, oneShot, partitioned)
+
+	oneShotRoot, err := oneShotMachine.GetRootHash()
+	require.NoError(t, err)
+	partitionedRoot, err := partitionedMachine.GetRootHash()
+	require.NoError(t, err)
+	require.Equal(t, oneShotRoot, partitionedRoot)
+}
+
+func TestCollectUarchCycleRootHashes_AcceptsOpaqueRevertTail(t *testing.T) {
+	machine := createLoopMachine(t)
+	zeroHash := Hash{}
+	encodedZeroHash := base64.StdEncoding.EncodeToString(zeroHash[:])
+	tail, err := json.Marshal([]string{encodedZeroHash, encodedZeroHash})
+	require.NoError(t, err)
+
+	rawResult, err := machine.CollectUarchCycleRootHashes(1, 0, RevertUarchTail(tail))
+	require.NoError(t, err)
+
+	var result struct {
+		Hashes      []string `json:"hashes"`
+		BreakReason string   `json:"break_reason"`
+	}
+	require.NoError(t, json.Unmarshal(rawResult, &result))
+	require.NotEmpty(t, result.Hashes)
+	require.Equal(t, "reached_target_mcycle", result.BreakReason)
+}

--- a/pkg/emulator/remote.go
+++ b/pkg/emulator/remote.go
@@ -7,7 +7,7 @@
 package emulator
 
 // #include <stdlib.h>
-// #include "cartesi-machine/jsonrpc-machine-c-api.h"
+// #include "cartesi-machine/cm-jsonrpc.h"
 import "C"
 
 import (

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -7,7 +7,7 @@
 package emulator
 
 // #include <stdlib.h>
-// #include "cartesi-machine/jsonrpc-machine-c-api.h"
+// #include "cartesi-machine/cm-jsonrpc.h"
 import "C"
 import "fmt"
 
@@ -18,18 +18,18 @@ import "fmt"
 type ErrorCode int32
 
 const (
-	ErrCodeOk                ErrorCode = C.CM_ERROR_OK
-	ErrCodeInvalidArgument   ErrorCode = C.CM_ERROR_INVALID_ARGUMENT
-	ErrCodeDomainError       ErrorCode = C.CM_ERROR_DOMAIN_ERROR
-	ErrCodeLengthError       ErrorCode = C.CM_ERROR_LENGTH_ERROR
-	ErrCodeOutOfRange        ErrorCode = C.CM_ERROR_OUT_OF_RANGE
-	ErrCodeLogicError        ErrorCode = C.CM_ERROR_LOGIC_ERROR
-	ErrCodeRuntimeError      ErrorCode = C.CM_ERROR_RUNTIME_ERROR
-	ErrCodeRangeError        ErrorCode = C.CM_ERROR_RANGE_ERROR
-	ErrCodeOverflowError     ErrorCode = C.CM_ERROR_OVERFLOW_ERROR
-	ErrCodeUnderflowError    ErrorCode = C.CM_ERROR_UNDERFLOW_ERROR
-	ErrCodeRegexError        ErrorCode = C.CM_ERROR_REGEX_ERROR
-	ErrCodeSystemError       ErrorCode = C.CM_ERROR_SYSTEM_ERROR
+	ErrCodeOk              ErrorCode = C.CM_ERROR_OK
+	ErrCodeInvalidArgument ErrorCode = C.CM_ERROR_INVALID_ARGUMENT
+	ErrCodeDomainError     ErrorCode = C.CM_ERROR_DOMAIN_ERROR
+	ErrCodeLengthError     ErrorCode = C.CM_ERROR_LENGTH_ERROR
+	ErrCodeOutOfRange      ErrorCode = C.CM_ERROR_OUT_OF_RANGE
+	ErrCodeLogicError      ErrorCode = C.CM_ERROR_LOGIC_ERROR
+	ErrCodeRuntimeError    ErrorCode = C.CM_ERROR_RUNTIME_ERROR
+	ErrCodeRangeError      ErrorCode = C.CM_ERROR_RANGE_ERROR
+	ErrCodeOverflowError   ErrorCode = C.CM_ERROR_OVERFLOW_ERROR
+	ErrCodeUnderflowError  ErrorCode = C.CM_ERROR_UNDERFLOW_ERROR
+	//ErrCodeRegexError        ErrorCode = C.CM_ERROR_REGEX_ERROR
+	//ErrCodeSystemError       ErrorCode = C.CM_ERROR_SYSTEM_ERROR
 	ErrCodeBadTypeid         ErrorCode = C.CM_ERROR_BAD_TYPEID
 	ErrCodeBadCast           ErrorCode = C.CM_ERROR_BAD_CAST
 	ErrCodeBadAnyCast        ErrorCode = C.CM_ERROR_BAD_ANY_CAST
@@ -123,23 +123,23 @@ type (
 
 const (
 	// type
-	YieldAutomatic CmioYieldCommand = C.CM_CMIO_YIELD_COMMAND_AUTOMATIC
-	YieldManual    CmioYieldCommand = C.CM_CMIO_YIELD_COMMAND_MANUAL
+	YieldAutomatic CmioYieldCommand = C.CM_HTIF_YIELD_CMD_AUTOMATIC
+	YieldManual    CmioYieldCommand = C.CM_HTIF_YIELD_CMD_MANUAL
 
 	// NOTE: these values do not form an enum (e.g., automatic-progress == manual-accepted).
 
 	// reason - request
-	AutomaticYieldReasonProgress CmioYieldReason = C.CM_CMIO_YIELD_AUTOMATIC_REASON_PROGRESS
-	AutomaticYieldReasonOutput   CmioYieldReason = C.CM_CMIO_YIELD_AUTOMATIC_REASON_TX_OUTPUT
-	AutomaticYieldReasonReport   CmioYieldReason = C.CM_CMIO_YIELD_AUTOMATIC_REASON_TX_REPORT
+	AutomaticYieldReasonProgress CmioYieldReason = C.CM_HTIF_YIELD_AUTOMATIC_REASON_PROGRESS
+	AutomaticYieldReasonOutput   CmioYieldReason = C.CM_HTIF_YIELD_AUTOMATIC_REASON_TX_OUTPUT
+	AutomaticYieldReasonReport   CmioYieldReason = C.CM_HTIF_YIELD_AUTOMATIC_REASON_TX_REPORT
 
-	ManualYieldReasonAccepted  CmioYieldReason = C.CM_CMIO_YIELD_MANUAL_REASON_RX_ACCEPTED
-	ManualYieldReasonRejected  CmioYieldReason = C.CM_CMIO_YIELD_MANUAL_REASON_RX_REJECTED
-	ManualYieldReasonException CmioYieldReason = C.CM_CMIO_YIELD_MANUAL_REASON_TX_EXCEPTION
+	ManualYieldReasonAccepted  CmioYieldReason = C.CM_HTIF_YIELD_MANUAL_REASON_RX_ACCEPTED
+	ManualYieldReasonRejected  CmioYieldReason = C.CM_HTIF_YIELD_MANUAL_REASON_RX_REJECTED
+	ManualYieldReasonException CmioYieldReason = C.CM_HTIF_YIELD_MANUAL_REASON_TX_EXCEPTION
 
 	// reason - reply
-	YieldReasonAdvanceState CmioYieldReason = C.CM_CMIO_YIELD_REASON_ADVANCE_STATE
-	YieldReasonInspectState CmioYieldReason = C.CM_CMIO_YIELD_REASON_INSPECT_STATE
+	YieldReasonAdvanceState CmioYieldReason = C.CM_HTIF_YIELD_REASON_ADVANCE_STATE
+	YieldReasonInspectState CmioYieldReason = C.CM_HTIF_YIELD_REASON_INSPECT_STATE
 )
 
 // cm_reg addresses/CSRs
@@ -257,41 +257,41 @@ const (
 	REG_HTIF_ICONSOLE  RegID = C.CM_REG_HTIF_ICONSOLE
 	REG_HTIF_IYIELD    RegID = C.CM_REG_HTIF_IYIELD
 	// Microarchitecture registers
-	REG_UARCH_X0        RegID = C.CM_REG_UARCH_X0
-	REG_UARCH_X1        RegID = C.CM_REG_UARCH_X1
-	REG_UARCH_X2        RegID = C.CM_REG_UARCH_X2
-	REG_UARCH_X3        RegID = C.CM_REG_UARCH_X3
-	REG_UARCH_X4        RegID = C.CM_REG_UARCH_X4
-	REG_UARCH_X5        RegID = C.CM_REG_UARCH_X5
-	REG_UARCH_X6        RegID = C.CM_REG_UARCH_X6
-	REG_UARCH_X7        RegID = C.CM_REG_UARCH_X7
-	REG_UARCH_X8        RegID = C.CM_REG_UARCH_X8
-	REG_UARCH_X9        RegID = C.CM_REG_UARCH_X9
-	REG_UARCH_X10       RegID = C.CM_REG_UARCH_X10
-	REG_UARCH_X11       RegID = C.CM_REG_UARCH_X11
-	REG_UARCH_X12       RegID = C.CM_REG_UARCH_X12
-	REG_UARCH_X13       RegID = C.CM_REG_UARCH_X13
-	REG_UARCH_X14       RegID = C.CM_REG_UARCH_X14
-	REG_UARCH_X15       RegID = C.CM_REG_UARCH_X15
-	REG_UARCH_X16       RegID = C.CM_REG_UARCH_X16
-	REG_UARCH_X17       RegID = C.CM_REG_UARCH_X17
-	REG_UARCH_X18       RegID = C.CM_REG_UARCH_X18
-	REG_UARCH_X19       RegID = C.CM_REG_UARCH_X19
-	REG_UARCH_X20       RegID = C.CM_REG_UARCH_X20
-	REG_UARCH_X21       RegID = C.CM_REG_UARCH_X21
-	REG_UARCH_X22       RegID = C.CM_REG_UARCH_X22
-	REG_UARCH_X23       RegID = C.CM_REG_UARCH_X23
-	REG_UARCH_X24       RegID = C.CM_REG_UARCH_X24
-	REG_UARCH_X25       RegID = C.CM_REG_UARCH_X25
-	REG_UARCH_X26       RegID = C.CM_REG_UARCH_X26
-	REG_UARCH_X27       RegID = C.CM_REG_UARCH_X27
-	REG_UARCH_X28       RegID = C.CM_REG_UARCH_X28
-	REG_UARCH_X29       RegID = C.CM_REG_UARCH_X29
-	REG_UARCH_X30       RegID = C.CM_REG_UARCH_X30
-	REG_UARCH_X31       RegID = C.CM_REG_UARCH_X31
-	REG_UARCH_PC        RegID = C.CM_REG_UARCH_PC
-	REG_UARCH_CYCLE     RegID = C.CM_REG_UARCH_CYCLE
-	REG_UARCH_HALT_FLAG RegID = C.CM_REG_UARCH_HALT_FLAG
+	REG_UARCH_X0    RegID = C.CM_REG_UARCH_X0
+	REG_UARCH_X1    RegID = C.CM_REG_UARCH_X1
+	REG_UARCH_X2    RegID = C.CM_REG_UARCH_X2
+	REG_UARCH_X3    RegID = C.CM_REG_UARCH_X3
+	REG_UARCH_X4    RegID = C.CM_REG_UARCH_X4
+	REG_UARCH_X5    RegID = C.CM_REG_UARCH_X5
+	REG_UARCH_X6    RegID = C.CM_REG_UARCH_X6
+	REG_UARCH_X7    RegID = C.CM_REG_UARCH_X7
+	REG_UARCH_X8    RegID = C.CM_REG_UARCH_X8
+	REG_UARCH_X9    RegID = C.CM_REG_UARCH_X9
+	REG_UARCH_X10   RegID = C.CM_REG_UARCH_X10
+	REG_UARCH_X11   RegID = C.CM_REG_UARCH_X11
+	REG_UARCH_X12   RegID = C.CM_REG_UARCH_X12
+	REG_UARCH_X13   RegID = C.CM_REG_UARCH_X13
+	REG_UARCH_X14   RegID = C.CM_REG_UARCH_X14
+	REG_UARCH_X15   RegID = C.CM_REG_UARCH_X15
+	REG_UARCH_X16   RegID = C.CM_REG_UARCH_X16
+	REG_UARCH_X17   RegID = C.CM_REG_UARCH_X17
+	REG_UARCH_X18   RegID = C.CM_REG_UARCH_X18
+	REG_UARCH_X19   RegID = C.CM_REG_UARCH_X19
+	REG_UARCH_X20   RegID = C.CM_REG_UARCH_X20
+	REG_UARCH_X21   RegID = C.CM_REG_UARCH_X21
+	REG_UARCH_X22   RegID = C.CM_REG_UARCH_X22
+	REG_UARCH_X23   RegID = C.CM_REG_UARCH_X23
+	REG_UARCH_X24   RegID = C.CM_REG_UARCH_X24
+	REG_UARCH_X25   RegID = C.CM_REG_UARCH_X25
+	REG_UARCH_X26   RegID = C.CM_REG_UARCH_X26
+	REG_UARCH_X27   RegID = C.CM_REG_UARCH_X27
+	REG_UARCH_X28   RegID = C.CM_REG_UARCH_X28
+	REG_UARCH_X29   RegID = C.CM_REG_UARCH_X29
+	REG_UARCH_X30   RegID = C.CM_REG_UARCH_X30
+	REG_UARCH_X31   RegID = C.CM_REG_UARCH_X31
+	REG_UARCH_PC    RegID = C.CM_REG_UARCH_PC
+	REG_UARCH_CYCLE RegID = C.CM_REG_UARCH_CYCLE
+	REG_UARCH_HALT  RegID = C.CM_REG_UARCH_HALT
 	// Views of registers
 	REG_HTIF_TOHOST_DEV      RegID = C.CM_REG_HTIF_TOHOST_DEV
 	REG_HTIF_TOHOST_CMD      RegID = C.CM_REG_HTIF_TOHOST_CMD

--- a/pkg/emulator/types.go
+++ b/pkg/emulator/types.go
@@ -84,6 +84,7 @@ const (
 	BreakReasonReachedTargetMcycle  BreakReason = C.CM_BREAK_REASON_REACHED_TARGET_MCYCLE
 	BreakReasonConsoleOutput        BreakReason = C.CM_BREAK_REASON_CONSOLE_OUTPUT
 	BreakReasonConsoleInput         BreakReason = C.CM_BREAK_REASON_CONSOLE_INPUT
+	BreakReasonMcycleOverflow       BreakReason = C.CM_BREAK_REASON_MCYCLE_OVERFLOW
 )
 
 func (reason BreakReason) String() (s string) {
@@ -100,6 +101,8 @@ func (reason BreakReason) String() (s string) {
 		s = "yielded softly"
 	case BreakReasonReachedTargetMcycle:
 		s = "reached target mcycle"
+	case BreakReasonMcycleOverflow:
+		s = "mcycle overflow"
 	default:
 		return "invalid break reason"
 	}

--- a/pkg/machine/backend.go
+++ b/pkg/machine/backend.go
@@ -17,15 +17,16 @@ const (
 	YieldedAutomatically BreakReason = 0x3
 	YieldedSoftly        BreakReason = 0x4
 	ReachedTargetMcycle  BreakReason = 0x5
+	McycleOverflow       BreakReason = 0x8
 )
 
 type HashCollectorState struct {
-	Period     uint64
-	Phase      uint64
-	MaxHashes  uint64
-	BundleLog2 int32
-	Hashes     []Hash
-	BackTree   json.RawMessage
+	Period        uint64
+	Phase         uint64
+	MaxHashes     uint64
+	BundleLog2    int32
+	Hashes        []Hash
+	PartialBundle json.RawMessage
 }
 
 // This Backend interface covers the methods used from the emulator / remote machine server.
@@ -35,6 +36,9 @@ type Backend interface {
 	Store(directory string, timeout time.Duration) error
 
 	Run(mcycleEnd uint64, timeout time.Duration) (BreakReason, error)
+	// RunAndCollectRootHashes may advance the backend before returning an error.
+	// Callers must discard the backend after an error instead of retrying it with
+	// the previous HashCollectorState.
 	RunAndCollectRootHashes(mcycleEnd uint64, state *HashCollectorState, timeout time.Duration,
 	) (reason BreakReason, err error)
 

--- a/pkg/machine/backend.go
+++ b/pkg/machine/backend.go
@@ -41,7 +41,7 @@ type Backend interface {
 	IsAtManualYield(timeout time.Duration) (bool, error)
 	ReadMCycle(timeout time.Duration) (uint64, error)
 
-	SendCmioResponse(reason uint16, data []byte, timeout time.Duration) error
+	SendCmioResponse(reason uint16, data []byte, revertRootHash *Hash, timeout time.Duration) error
 	ReceiveCmioRequest(timeout time.Duration) (cmd uint8, reason uint16, data []byte, err error)
 
 	WriteMemory(address uint64, data []byte, timeout time.Duration) error

--- a/pkg/machine/backend_test.go
+++ b/pkg/machine/backend_test.go
@@ -40,8 +40,15 @@ func (m *MockBackend) ReadMCycle(timeout time.Duration) (uint64, error) {
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *MockBackend) SendCmioResponse(reason uint16, data []byte, timeout time.Duration) error {
-	args := m.Called(reason, data, timeout)
+func (m *MockBackend) SendCmioResponse(reason uint16, data []byte, revertRootHash *Hash, timeout time.Duration) error {
+	args := mock.Arguments{}
+	if requestType(reason) == AdvanceStateRequest {
+		// match hash by value on advance
+		args = m.Called(reason, data, *revertRootHash, timeout)
+	} else if requestType(reason) == InspectStateRequest {
+		// nil on inspect
+		args = m.Called(reason, data, nil, timeout)
+	}
 	return args.Error(0)
 }
 
@@ -105,7 +112,7 @@ func randomFakeHash() Hash {
 // SetupAccepted configures the mock for a successful advance/inspect operation
 func (m *MockBackend) SetupAccepted(reqType requestType) {
 	hash := randomFakeHash()
-	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
 	m.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(YieldedManually, nil)
 	m.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), nil)
 	m.On("ReceiveCmioRequest", mock.AnythingOfType("time.Duration")).Return(
@@ -116,7 +123,7 @@ func (m *MockBackend) SetupAccepted(reqType requestType) {
 // SetupRejected configures the mock for a rejected advance/inspect operation
 func (m *MockBackend) SetupRejected(reqType requestType) {
 	hash := randomFakeHash()
-	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
 	m.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(YieldedManually, nil)
 	m.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), nil)
 	m.On("ReceiveCmioRequest", mock.AnythingOfType("time.Duration")).Return(
@@ -126,7 +133,7 @@ func (m *MockBackend) SetupRejected(reqType requestType) {
 
 // SetupException configures the mock for an exception during advance/inspect
 func (m *MockBackend) SetupException(reqType requestType) {
-	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	m.On("SendCmioResponse", uint16(reqType), mock.Anything, mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
 	m.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(YieldedManually, nil)
 	m.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), nil)
 	m.On("ReceiveCmioRequest", mock.AnythingOfType("time.Duration")).Return(

--- a/pkg/machine/implementation.go
+++ b/pkg/machine/implementation.go
@@ -526,6 +526,8 @@ func (m *machineImpl) runIncrementInterval(ctx context.Context,
 		return nil, currentCycle, nil // returns with no yield type
 	case ReachedTargetMcycle:
 		return nil, currentCycle, ErrReachedTargetMcycle
+	case McycleOverflow:
+		return nil, currentCycle, ErrReachedLimitMcycle
 	case Halted:
 		return nil, currentCycle, ErrHalted
 	case Failed:

--- a/pkg/machine/implementation.go
+++ b/pkg/machine/implementation.go
@@ -50,7 +50,6 @@ const (
 const maxOutputs = 65536 // 2^16
 const maxReports = 65536 // 2^16
 
-const CheckpointAddress uint64 = 0xfe0 // value from machine api: CM_AR_SHADOW_REVERT_ROOT_HASH_START
 const TxBufferAddress uint64 = 0x60800000
 const HashLog2Size = 5 // 32 bytes
 
@@ -165,23 +164,10 @@ func (m *machineImpl) OutputsHashProof(ctx context.Context) ([]Hash, error) {
 	return siblings, nil
 }
 
-func (m *machineImpl) WriteCheckpointHash(ctx context.Context, hash Hash) error {
-	if err := checkContext(ctx); err != nil {
-		return err
-	}
-
-	err := m.backend.WriteMemory(CheckpointAddress, hash[:], m.params.FastDeadline)
-	if err != nil {
-		err := fmt.Errorf("could not write checkpoint hash in to machine memory: %w", err)
-		return errors.Join(ErrMachineInternal, err)
-	}
-	return nil
-}
-
 // Advance sends an input to the machine and processes it
-func (m *machineImpl) Advance(ctx context.Context, input []byte, computeHashes bool) (*AdvanceResponse, error) {
+func (m *machineImpl) Advance(ctx context.Context, input []byte, checkpointHash Hash, computeHashes bool) (*AdvanceResponse, error) {
 	// TODO: return the exception reason
-	accepted, outputs, reports, hashes, remaining, data, err := m.process(ctx, input, AdvanceStateRequest, computeHashes)
+	accepted, outputs, reports, hashes, remaining, data, err := m.process(ctx, input, AdvanceStateRequest, &checkpointHash, computeHashes)
 	if err != nil {
 		return &AdvanceResponse{
 			Accepted:        accepted,
@@ -212,7 +198,8 @@ func (m *machineImpl) Advance(ctx context.Context, input []byte, computeHashes b
 // Inspect sends a query to the machine and returns the results
 func (m *machineImpl) Inspect(ctx context.Context, query []byte) (bool, []Report, error) {
 	// TODO: return the exception reason
-	accepted, _, reports, _, _, _, err := m.process(ctx, query, InspectStateRequest, false)
+	// For inspect-state requests, revert_root_hash is not checked and can be NULL/empty
+	accepted, _, reports, _, _, _, err := m.process(ctx, query, InspectStateRequest, nil, false)
 	return accepted, reports, err
 }
 
@@ -343,10 +330,12 @@ func (m *machineImpl) readMCycle(ctx context.Context) (uint64, error) {
 //
 // It expects the machine to be ready to receive requests before execution,
 // and leaves the machine in a state ready to receive requests after an execution with no errors.
+// checkpointHash is nil for inspects.
 func (m *machineImpl) process(
 	ctx context.Context,
 	request []byte,
 	reqType requestType,
+	checkpointHash *Hash,
 	computeHashes bool,
 ) (bool, []Output, []Report, []Hash, uint64, []byte, error) {
 	if err := checkContext(ctx); err != nil {
@@ -357,7 +346,7 @@ func (m *machineImpl) process(
 		return false, nil, nil, nil, 0, nil, ErrPayloadLengthLimitExceeded
 	}
 
-	err := m.backend.SendCmioResponse(uint16(reqType), request, m.params.FastDeadline)
+	err := m.backend.SendCmioResponse(uint16(reqType), request, checkpointHash, m.params.FastDeadline)
 	if err != nil {
 		return false, nil, nil, nil, 0, nil, err
 	}

--- a/pkg/machine/implementation_test.go
+++ b/pkg/machine/implementation_test.go
@@ -249,56 +249,11 @@ func (s *ImplementationSuite) TestOutputsHashProof() {
 	require.ErrorIs(err, ErrCanceled)
 }
 
-// Test WriteCheckpointHash method
-func (s *ImplementationSuite) TestWriteCheckpointHash() {
-	require := s.Require()
-	ctx := context.Background()
-
-	// Test successful write
-	mockBackend := NewMockBackend()
-	hash := randomFakeHash()
-	mockBackend.On("WriteMemory", CheckpointAddress, hash[:], mock.AnythingOfType("time.Duration")).
-		Return(nil)
-	machine := &machineImpl{
-		backend: mockBackend,
-		logger:  s.logger,
-		params: model.ExecutionParameters{
-			FastDeadline: time.Second * 5,
-		},
-	}
-
-	err := machine.WriteCheckpointHash(ctx, hash)
-	require.NoError(err)
-	mockBackend.AssertExpectations(s.T())
-
-	// Test write with backend error
-	mockBackend2 := NewMockBackend()
-	mockBackend2.On("WriteMemory", CheckpointAddress, hash[:], mock.AnythingOfType("time.Duration")).
-		Return(errors.New("write failed"))
-	machine2 := &machineImpl{
-		backend: mockBackend2,
-		logger:  s.logger,
-		params: model.ExecutionParameters{
-			FastDeadline: time.Second * 5,
-		},
-	}
-	err = machine2.WriteCheckpointHash(ctx, hash)
-	require.Error(err)
-	require.ErrorIs(err, ErrMachineInternal)
-	require.Contains(err.Error(), "could not write checkpoint hash")
-	mockBackend2.AssertExpectations(s.T())
-
-	// Test write with canceled context
-	canceledCtx, cancel := context.WithCancel(ctx)
-	cancel()
-	err = machine.WriteCheckpointHash(canceledCtx, hash)
-	require.ErrorIs(err, ErrCanceled)
-}
-
 // Test Advance method
 func (s *ImplementationSuite) TestAdvance() {
 	require := s.Require()
 	ctx := context.Background()
+	expectedHash := randomFakeHash()
 
 	// Test successful advance (accepted)
 	mockBackend := NewMockBackend()
@@ -317,7 +272,7 @@ func (s *ImplementationSuite) TestAdvance() {
 	}
 
 	input := []byte("test input")
-	resp, err := machine.Advance(ctx, input, false)
+	resp, err := machine.Advance(ctx, input, expectedHash, false)
 	require.NoError(err)
 	require.True(resp.Accepted)
 	require.Empty(resp.Outputs)
@@ -339,7 +294,7 @@ func (s *ImplementationSuite) TestAdvance() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	resp, err = machine2.Advance(ctx, input, false)
+	resp, err = machine2.Advance(ctx, input, expectedHash, false)
 	require.NoError(err)
 	require.False(resp.Accepted)
 	require.Empty(resp.Outputs)
@@ -361,7 +316,7 @@ func (s *ImplementationSuite) TestAdvance() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	resp, err = machine3.Advance(ctx, input, false)
+	resp, err = machine3.Advance(ctx, input, expectedHash, false)
 	require.ErrorIs(err, ErrException)
 	require.False(resp.Accepted)
 	require.Equal(Hash{}, resp.OutputsHash)
@@ -382,14 +337,14 @@ func (s *ImplementationSuite) TestAdvance() {
 		},
 	}
 	largeInput := make([]byte, 10)
-	_, err = machine4.Advance(ctx, largeInput, false)
+	_, err = machine4.Advance(ctx, largeInput, expectedHash, false)
 	require.ErrorIs(err, ErrPayloadLengthLimitExceeded)
 	mockBackend4.AssertExpectations(s.T())
 
 	// Test advance with invalid hash length
 	mockBackend5 := NewMockBackend()
 	mockBackend5.On("CmioRxBufferSize").Return(uint64(1024))
-	mockBackend5.On("SendCmioResponse", uint16(AdvanceStateRequest), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	mockBackend5.On("SendCmioResponse", uint16(AdvanceStateRequest), mock.Anything, expectedHash, mock.AnythingOfType("time.Duration")).Return(nil)
 	mockBackend5.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), nil)
 	mockBackend5.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(YieldedManually, nil)
 	mockBackend5.On("ReceiveCmioRequest", mock.AnythingOfType("time.Duration")).Return(
@@ -405,7 +360,7 @@ func (s *ImplementationSuite) TestAdvance() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	_, err = machine5.Advance(ctx, input, false)
+	_, err = machine5.Advance(ctx, input, expectedHash, false)
 	require.Error(err)
 	require.ErrorIs(err, ErrHashLength)
 	mockBackend5.AssertExpectations(s.T())
@@ -994,11 +949,12 @@ func (s *ImplementationSuite) TestStep() {
 func (s *ImplementationSuite) TestProcess() {
 	require := s.Require()
 	ctx := context.Background()
+	expectedHash := randomFakeHash()
 
 	// Test successful process
 	mockBackend := NewMockBackend()
 	mockBackend.On("CmioRxBufferSize").Return(uint64(1024))
-	mockBackend.On("SendCmioResponse", mock.AnythingOfType("uint16"), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	mockBackend.On("SendCmioResponse", mock.AnythingOfType("uint16"), mock.Anything, expectedHash, mock.AnythingOfType("time.Duration")).Return(nil)
 	mockBackend.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), nil)
 	mockBackend.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(YieldedManually, nil)
 	mockBackend.On("ReceiveCmioRequest", mock.AnythingOfType("time.Duration")).Return(
@@ -1017,7 +973,7 @@ func (s *ImplementationSuite) TestProcess() {
 	}
 
 	input := []byte("test input")
-	accepted, outputs, reports, _, _, data, err := machine.process(ctx, input, AdvanceStateRequest, false)
+	accepted, outputs, reports, _, _, data, err := machine.process(ctx, input, AdvanceStateRequest, &expectedHash, false)
 	require.NoError(err)
 	require.True(accepted)
 	require.Empty(outputs)
@@ -1039,7 +995,7 @@ func (s *ImplementationSuite) TestProcess() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	_, _, _, _, _, _, err = machine2.process(ctx, input, AdvanceStateRequest, false)
+	_, _, _, _, _, _, err = machine2.process(ctx, input, AdvanceStateRequest, &expectedHash, false)
 	require.ErrorIs(err, ErrPayloadLengthLimitExceeded)
 	mockBackend2.AssertExpectations(s.T())
 
@@ -1049,6 +1005,7 @@ func (s *ImplementationSuite) TestProcess() {
 	mockBackend3.On("SendCmioResponse",
 		mock.AnythingOfType("uint16"),
 		mock.Anything,
+		expectedHash,
 		mock.AnythingOfType("time.Duration"),
 	).Return(errors.New("send failed"))
 	machine3 := &machineImpl{
@@ -1062,7 +1019,7 @@ func (s *ImplementationSuite) TestProcess() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	_, _, _, _, _, _, err = machine3.process(ctx, input, AdvanceStateRequest, false)
+	_, _, _, _, _, _, err = machine3.process(ctx, input, AdvanceStateRequest, &expectedHash, false)
 	require.Error(err)
 	require.Contains(err.Error(), "send failed")
 	mockBackend3.AssertExpectations(s.T())
@@ -1070,7 +1027,7 @@ func (s *ImplementationSuite) TestProcess() {
 	// Test process with run error
 	mockBackend4 := NewMockBackend()
 	mockBackend4.On("CmioRxBufferSize").Return(uint64(1024))
-	mockBackend4.On("SendCmioResponse", mock.AnythingOfType("uint16"), mock.Anything, mock.AnythingOfType("time.Duration")).Return(nil)
+	mockBackend4.On("SendCmioResponse", mock.AnythingOfType("uint16"), mock.Anything, expectedHash, mock.AnythingOfType("time.Duration")).Return(nil)
 	mockBackend4.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(0), errors.New("read cycle failed"))
 	machine4 := &machineImpl{
 		backend: mockBackend4,
@@ -1083,7 +1040,7 @@ func (s *ImplementationSuite) TestProcess() {
 			AdvanceMaxDeadline: time.Second * 10,
 		},
 	}
-	_, _, _, _, _, _, err = machine4.process(ctx, input, AdvanceStateRequest, false)
+	_, _, _, _, _, _, err = machine4.process(ctx, input, AdvanceStateRequest, &expectedHash, false)
 	require.Error(err)
 	require.Contains(err.Error(), "read cycle failed")
 	mockBackend4.AssertExpectations(s.T())

--- a/pkg/machine/implementation_test.go
+++ b/pkg/machine/implementation_test.go
@@ -902,6 +902,23 @@ func (s *ImplementationSuite) TestStep() {
 	require.Equal(uint64(1000), cycle)
 	mockBackend4.AssertExpectations(s.T())
 
+	// Test runIncrementInterval with mcycle overflow
+	mockBackendOverflow := NewMockBackend()
+	mockBackendOverflow.On(
+		"Run",
+		mock.AnythingOfType("uint64"),
+		mock.AnythingOfType("time.Duration"),
+	).Return(McycleOverflow, nil)
+	mockBackendOverflow.On("ReadMCycle", mock.AnythingOfType("time.Duration")).Return(uint64(999), nil)
+	machine.backend = mockBackendOverflow
+
+	yieldType, cycle, err = machine.runIncrementInterval(ctx, 100, 1000, nil, time.Second)
+	require.ErrorIs(err, ErrReachedLimitMcycle)
+	require.NotErrorIs(err, ErrMachineInternal)
+	require.Nil(yieldType)
+	require.Equal(uint64(999), cycle)
+	mockBackendOverflow.AssertExpectations(s.T())
+
 	// Test runIncrementInterval with halted
 	mockBackend5 := NewMockBackend()
 	mockBackend5.On("Run", mock.AnythingOfType("uint64"), mock.AnythingOfType("time.Duration")).Return(Halted, nil)

--- a/pkg/machine/libcartesi.go
+++ b/pkg/machine/libcartesi.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/bits"
 	"time"
 
 	"github.com/cartesi/rollups-node/pkg/emulator"
@@ -28,6 +29,13 @@ type RemoteMachineInterface interface {
 	Delete()
 	ForkServer() (*emulator.RemoteMachine, string, uint32, error)
 	ShutdownServer() error
+	CollectMCycleRootHashes(
+		mcycleEnd,
+		log2McyclePeriod,
+		mcyclePhase uint64,
+		log2BundleMcycleCount int32,
+		previousPartialBundle json.RawMessage,
+	) ([]byte, error)
 }
 
 type proofJson struct {
@@ -230,124 +238,92 @@ func (e *LibCartesiBackend) CmioRxBufferSize() uint64 {
 	return 1 << emulator.CmioRxBufferLog2Size
 }
 
+func decodeBreakReason(s string) (BreakReason, error) {
+	switch s {
+	case "yielded_automatically":
+		return YieldedAutomatically, nil
+	case "yielded_manually":
+		return YieldedManually, nil
+	case "yielded_softly":
+		return YieldedSoftly, nil
+	case "reached_target_mcycle":
+		return ReachedTargetMcycle, nil
+	case "mcycle_overflow":
+		return McycleOverflow, nil
+	case "halted":
+		return Halted, nil
+	case "failed":
+		return Failed, nil
+	default:
+		return Failed, fmt.Errorf("unknown break reason %q", s)
+	}
+}
+
 func (e *LibCartesiBackend) RunAndCollectRootHashes(
 	mcycleEnd uint64,
 	state *HashCollectorState,
 	timeout time.Duration,
 ) (reason BreakReason, err error) {
+
 	if state == nil {
 		return Failed, errors.New("nil state")
 	}
 	if state.Period == 0 {
-		return Failed, errors.New("State.Period must be > 0")
+		return Failed, errors.New("state period must be greater than zero")
+	}
+	log2Period := uint64(bits.Len64(state.Period) - 1)
+	if uint64(1)<<log2Period != state.Period {
+		return Failed, fmt.Errorf("period must be a power of 2, got %v", state.Period)
+	}
+	if state.Phase >= state.Period {
+		return Failed, fmt.Errorf("phase must be less than period, got phase %v and period %v", state.Phase, state.Period)
+	}
+	if err := e.inner.SetTimeout(timeout.Milliseconds()); err != nil {
+		return Failed, fmt.Errorf("failed to set operation timeout: %w", err)
 	}
 
-	// Set up timeout management: calculate absolute deadline if timeout is specified
-	var deadline time.Time
-	hasDeadline := timeout > 0
-	if hasDeadline {
-		deadline = time.Now().Add(timeout)
-	}
-	remaining := func() time.Duration {
-		if !hasDeadline {
-			return 0
-		}
-		d := time.Until(deadline)
-		if d <= 0 {
-			return time.Nanosecond
-		}
-		return d
-	}
-	checkDeadline := func() error {
-		if hasDeadline && time.Now().After(deadline) {
-			return errors.New("runWithRootHashes: deadline exceeded")
-		}
-		return nil
-	}
-
-	if err := checkDeadline(); err != nil {
-		return Failed, err
-	}
-	cur, err := e.ReadMCycle(remaining())
+	rawResult, err := e.inner.CollectMCycleRootHashes(
+		mcycleEnd,
+		log2Period,
+		state.Phase,
+		state.BundleLog2,
+		state.PartialBundle,
+	)
 	if err != nil {
 		return Failed, err
 	}
+	result := struct {
+		RootHashes    []string        `json:"hashes"`
+		MCyclePhase   uint64          `json:"mcycle_phase"`
+		BreakReason   string          `json:"break_reason"`
+		PartialBundle json.RawMessage `json:"partial_bundle,omitempty"`
+	}{}
+	err = json.Unmarshal(rawResult, &result)
+	if err != nil {
+		return Failed, fmt.Errorf("failed to unmarshal CollectMCycleRootHashes result: %w", err)
+	}
+	reason, err = decodeBreakReason(result.BreakReason)
+	if err != nil {
+		return Failed, fmt.Errorf("invalid CollectMCycleRootHashes result: %w", err)
+	}
+	if result.MCyclePhase >= state.Period {
+		return Failed, fmt.Errorf(
+			"invalid CollectMCycleRootHashes result: phase %v must be less than period %v",
+			result.MCyclePhase,
+			state.Period,
+		)
+	}
 
-	collected := (uint64)(0)
-
-	for {
-		if err := checkDeadline(); err != nil {
-			return Failed, err
-		}
-		if cur >= mcycleEnd {
-			// No more cycles to execute
-			return ReachedTargetMcycle, nil
-		}
-
-		// Calculate the next collection point: distance to the next multiple of the period
-		// This ensures we collect hashes at regular intervals aligned with the period
-		var step uint64
-		if r := state.Phase % state.Period; r == 0 {
-			step = state.Period
-		} else {
-			step = state.Period - r
-		}
-
-		nextHashCycle := cur + step
-		target := min(nextHashCycle, mcycleEnd)
-
-		// Run the machine until target cycle or until it yields/halts
-		br, err := e.Run(target, remaining())
-		if err != nil {
-			return Failed, err
-		}
-
-		// Check where we stopped after the run
-		if err := checkDeadline(); err != nil {
-			return Failed, err
-		}
-		pos, err := e.ReadMCycle(remaining())
-		if err != nil {
-			return Failed, err
-		}
-
-		advanced := pos - cur
-		state.Phase = (state.Phase + advanced) % state.Period
-		cur = pos
-
-		// Only collect hash if we reached the exact boundary (pos == nextHashCycle)
-		// This ensures "hash after each complete period", matching the C API behavior
-		// and avoiding duplicate collections if the machine stops early due to yields
-		if pos == nextHashCycle {
-			if err := checkDeadline(); err != nil {
-				return Failed, err
-			}
-			h, err := e.GetRootHash(remaining())
-			if err != nil {
-				return Failed, err
-			}
-
-			state.Hashes = append(state.Hashes, h)
-
-			collected++
-			if state.MaxHashes > 0 && collected >= state.MaxHashes {
-				return YieldedSoftly, nil
-			}
-		}
-
-		switch br {
-		case ReachedTargetMcycle:
-			if cur >= mcycleEnd {
-				return ReachedTargetMcycle, nil
-			}
-		case YieldedManually:
-			return br, nil
-		case YieldedAutomatically, YieldedSoftly, Halted:
-			return br, nil
-		case Failed:
-			return Failed, errors.New("run failed")
-		default:
-			return Failed, errors.New("unknown break reason")
+	decodedHashes := make([]Hash, len(result.RootHashes))
+	for i, base64Hash := range result.RootHashes {
+		if err := decodeB64To32(&decodedHashes[i], base64Hash); err != nil {
+			return Failed, fmt.Errorf("invalid collected hash at index %v: %w", i, err)
 		}
 	}
+
+	state.Hashes = append(state.Hashes, decodedHashes...)
+	state.Phase = result.MCyclePhase
+	state.PartialBundle = result.PartialBundle
+
+	return reason, nil
 }

--- a/pkg/machine/libcartesi.go
+++ b/pkg/machine/libcartesi.go
@@ -21,7 +21,7 @@ type RemoteMachineInterface interface {
 	GetRootHash() (emulator.Hash, error)
 	GetProof(address uint64, log2size int32) (string, error)
 	ReadReg(reg emulator.RegID) (uint64, error)
-	SendCmioResponse(reason uint16, data []byte) error
+	SendCmioResponse(reason uint16, data []byte, revertRootHash *emulator.Hash) error
 	ReceiveCmioRequest() (uint8, uint16, []byte, error)
 	WriteMemory(address uint64, data []byte) error
 	Store(directory string) error
@@ -167,11 +167,11 @@ func (e *LibCartesiBackend) ReadMCycle(timeout time.Duration) (uint64, error) {
 	return cycle, nil
 }
 
-func (e *LibCartesiBackend) SendCmioResponse(reason uint16, data []byte, timeout time.Duration) error {
+func (e *LibCartesiBackend) SendCmioResponse(reason uint16, data []byte, revertRootHash *Hash, timeout time.Duration) error {
 	if err := e.inner.SetTimeout(timeout.Milliseconds()); err != nil {
 		return fmt.Errorf("failed to set operation timeout: %w", err)
 	}
-	return e.inner.SendCmioResponse(reason, data)
+	return e.inner.SendCmioResponse(reason, data, revertRootHash)
 }
 
 func (e *LibCartesiBackend) ReceiveCmioRequest(timeout time.Duration) (uint8, uint16, []byte, error) {

--- a/pkg/machine/libcartesi_test.go
+++ b/pkg/machine/libcartesi_test.go
@@ -4,6 +4,8 @@
 package machine
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -92,6 +94,234 @@ func (s *LibCartesiSuite) TestRun() {
 	_, err = s.backend.Run(1000, 5*time.Second)
 	require.Error(err)
 	require.Contains(err.Error(), "run error")
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunMcycleOverflow() {
+	require := s.Require()
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On("Run", uint64(1000)).Return(emulator.BreakReasonMcycleOverflow, nil)
+
+	breakReason, err := s.backend.Run(1000, 5*time.Second)
+	require.NoError(err)
+	require.Equal(McycleOverflow, breakReason)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesMcycleOverflow() {
+	require := s.Require()
+	state := &HashCollectorState{Period: 1}
+	result := []byte(`{"hashes":[],"mcycle_phase":0,"break_reason":"mcycle_overflow"}`)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(0),
+		uint64(0),
+		int32(0),
+		json.RawMessage(nil),
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.NoError(err)
+	require.Equal(McycleOverflow, breakReason)
+	require.Nil(state.PartialBundle)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesContinuesPartialBundle() {
+	require := s.Require()
+	previousPartialBundle := json.RawMessage(
+		`{"log2_max_leaves":2,"hash_function":"keccak256","leaf_count":1,"context":["AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]}`,
+	)
+	nextPartialBundle := json.RawMessage(
+		`{"log2_max_leaves":2,"hash_function":"keccak256","leaf_count":2,"context":["AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]}`,
+	)
+	previousHash := Hash{0x11}
+	collectedHash := Hash{0x22}
+	state := &HashCollectorState{
+		Period:        4,
+		Phase:         3,
+		BundleLog2:    2,
+		Hashes:        []Hash{previousHash},
+		PartialBundle: previousPartialBundle,
+	}
+	result, err := json.Marshal(struct {
+		Hashes        []string        `json:"hashes"`
+		MCyclePhase   uint64          `json:"mcycle_phase"`
+		BreakReason   string          `json:"break_reason"`
+		PartialBundle json.RawMessage `json:"partial_bundle"`
+	}{
+		Hashes:        []string{base64.StdEncoding.EncodeToString(collectedHash[:])},
+		MCyclePhase:   1,
+		BreakReason:   "reached_target_mcycle",
+		PartialBundle: nextPartialBundle,
+	})
+	require.NoError(err)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(2),
+		uint64(3),
+		int32(2),
+		previousPartialBundle,
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.NoError(err)
+	require.Equal(ReachedTargetMcycle, breakReason)
+	require.Equal(uint64(1), state.Phase)
+	require.Equal([]Hash{previousHash, collectedHash}, state.Hashes)
+	require.Equal(nextPartialBundle, state.PartialBundle)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesClearsPartialBundleAtFixedPoint() {
+	require := s.Require()
+	previousPartialBundle := json.RawMessage(
+		`{"log2_max_leaves":2,"hash_function":"keccak256","leaf_count":3,"context":["AwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]}`,
+	)
+	state := &HashCollectorState{
+		Period:        4,
+		Phase:         2,
+		BundleLog2:    2,
+		PartialBundle: previousPartialBundle,
+	}
+	result := []byte(`{"hashes":[],"mcycle_phase":2,"break_reason":"halted"}`)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(2),
+		uint64(2),
+		int32(2),
+		previousPartialBundle,
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.NoError(err)
+	require.Equal(Halted, breakReason)
+	require.Nil(state.PartialBundle)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesInvalidHashLeavesStateUnchanged() {
+	require := s.Require()
+	previousPartialBundle := json.RawMessage(
+		`{"log2_max_leaves":2,"hash_function":"keccak256","leaf_count":1,"context":["AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]}`,
+	)
+	nextPartialBundle := json.RawMessage(
+		`{"log2_max_leaves":2,"hash_function":"keccak256","leaf_count":2,"context":["AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="]}`,
+	)
+	previousHash := Hash{0x11}
+	validHash := Hash{0x22}
+	state := &HashCollectorState{
+		Period:        4,
+		Phase:         3,
+		BundleLog2:    2,
+		Hashes:        []Hash{previousHash},
+		PartialBundle: previousPartialBundle,
+	}
+	originalState := *state
+	originalState.Hashes = append([]Hash(nil), state.Hashes...)
+	originalState.PartialBundle = append(json.RawMessage(nil), state.PartialBundle...)
+	result, err := json.Marshal(struct {
+		Hashes        []string        `json:"hashes"`
+		MCyclePhase   uint64          `json:"mcycle_phase"`
+		BreakReason   string          `json:"break_reason"`
+		PartialBundle json.RawMessage `json:"partial_bundle"`
+	}{
+		Hashes: []string{
+			base64.StdEncoding.EncodeToString(validHash[:]),
+			"not-base64",
+		},
+		MCyclePhase:   1,
+		BreakReason:   "reached_target_mcycle",
+		PartialBundle: nextPartialBundle,
+	})
+	require.NoError(err)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(2),
+		uint64(3),
+		int32(2),
+		previousPartialBundle,
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.Error(err)
+	require.Equal(Failed, breakReason)
+	require.Equal(originalState, *state)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesInvalidBreakReasonLeavesStateUnchanged() {
+	require := s.Require()
+	previousHash := Hash{0x11}
+	state := &HashCollectorState{
+		Period: 4,
+		Phase:  3,
+		Hashes: []Hash{previousHash},
+	}
+	originalState := *state
+	originalState.Hashes = append([]Hash(nil), state.Hashes...)
+	result := []byte(`{"hashes":[],"mcycle_phase":1,"break_reason":"future_reason"}`)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(2),
+		uint64(3),
+		int32(0),
+		json.RawMessage(nil),
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.ErrorContains(err, "unknown break reason")
+	require.Equal(Failed, breakReason)
+	require.Equal(originalState, *state)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesInvalidResultPhaseLeavesStateUnchanged() {
+	require := s.Require()
+	state := &HashCollectorState{Period: 4, Phase: 3}
+	originalState := *state
+	result := []byte(`{"hashes":[],"mcycle_phase":4,"break_reason":"reached_target_mcycle"}`)
+
+	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
+	s.mockRemoteMachine.On(
+		"CollectMCycleRootHashes",
+		uint64(1000),
+		uint64(2),
+		uint64(3),
+		int32(0),
+		json.RawMessage(nil),
+	).Return(result, nil)
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.ErrorContains(err, "phase 4 must be less than period 4")
+	require.Equal(Failed, breakReason)
+	require.Equal(originalState, *state)
+	s.mockRemoteMachine.AssertExpectations(s.T())
+}
+
+func (s *LibCartesiSuite) TestRunAndCollectRootHashesRejectsInvalidInputPhase() {
+	require := s.Require()
+	state := &HashCollectorState{Period: 4, Phase: 4}
+
+	breakReason, err := s.backend.RunAndCollectRootHashes(1000, state, 5*time.Second)
+	require.ErrorContains(err, "phase must be less than period")
+	require.Equal(Failed, breakReason)
 	s.mockRemoteMachine.AssertExpectations(s.T())
 }
 
@@ -485,4 +715,15 @@ func (m *MockRemoteMachine) ForkServer() (*emulator.RemoteMachine, string, uint3
 func (m *MockRemoteMachine) ShutdownServer() error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *MockRemoteMachine) CollectMCycleRootHashes(
+	mcycleEnd,
+	log2McyclePeriod,
+	mcyclePhase uint64,
+	log2BundleMcycleCount int32,
+	previousPartialBundle json.RawMessage,
+) ([]byte, error) {
+	args := m.Called(mcycleEnd, log2McyclePeriod, mcyclePhase, log2BundleMcycleCount, previousPartialBundle)
+	return args.Get(0).([]byte), args.Error(1)
 }

--- a/pkg/machine/libcartesi_test.go
+++ b/pkg/machine/libcartesi_test.go
@@ -214,12 +214,13 @@ func (s *LibCartesiSuite) TestSendCmioResponse() {
 	require := s.Require()
 
 	data := []byte("test data")
+	expectedHash := randomFakeHash()
 
 	// Test successful send
 	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
-	s.mockRemoteMachine.On("SendCmioResponse", uint16(1), data).Return(nil)
+	s.mockRemoteMachine.On("SendCmioResponse", uint16(1), data, &expectedHash).Return(nil)
 
-	err := s.backend.SendCmioResponse(1, data, 5*time.Second)
+	err := s.backend.SendCmioResponse(1, data, &expectedHash, 5*time.Second)
 	require.NoError(err)
 	s.mockRemoteMachine.AssertExpectations(s.T())
 
@@ -228,7 +229,7 @@ func (s *LibCartesiSuite) TestSendCmioResponse() {
 	s.backend = &LibCartesiBackend{inner: s.mockRemoteMachine}
 	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(errors.New("timeout error"))
 
-	err = s.backend.SendCmioResponse(1, data, 5*time.Second)
+	err = s.backend.SendCmioResponse(1, data, &expectedHash, 5*time.Second)
 	require.Error(err)
 	require.Contains(err.Error(), "failed to set operation timeout")
 	s.mockRemoteMachine.AssertExpectations(s.T())
@@ -237,9 +238,9 @@ func (s *LibCartesiSuite) TestSendCmioResponse() {
 	s.mockRemoteMachine = new(MockRemoteMachine)
 	s.backend = &LibCartesiBackend{inner: s.mockRemoteMachine}
 	s.mockRemoteMachine.On("SetTimeout", int64(5000)).Return(nil)
-	s.mockRemoteMachine.On("SendCmioResponse", uint16(1), data).Return(errors.New("send error"))
+	s.mockRemoteMachine.On("SendCmioResponse", uint16(1), data, &expectedHash).Return(errors.New("send error"))
 
-	err = s.backend.SendCmioResponse(1, data, 5*time.Second)
+	err = s.backend.SendCmioResponse(1, data, &expectedHash, 5*time.Second)
 	require.Error(err)
 	require.Contains(err.Error(), "send error")
 	s.mockRemoteMachine.AssertExpectations(s.T())
@@ -449,8 +450,8 @@ func (m *MockRemoteMachine) ReadReg(reg emulator.RegID) (uint64, error) {
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *MockRemoteMachine) SendCmioResponse(reason uint16, data []byte) error {
-	args := m.Called(reason, data)
+func (m *MockRemoteMachine) SendCmioResponse(reason uint16, data []byte, revertRootHash *Hash) error {
+	args := m.Called(reason, data, revertRootHash)
 	return args.Error(0)
 }
 

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -67,15 +67,15 @@ type Machine interface {
 	OutputsHash(ctx context.Context) (Hash, error)
 	// OutputsHashProof returns the proof that the outputs merkle root hash is stored in the cmio tx buffer.
 	OutputsHashProof(ctx context.Context) ([]Hash, error)
-	// WriteCheckpointHash writes the given checkpoint hash to the machine memory.
-	WriteCheckpointHash(ctx context.Context, hash Hash) error
 
 	// Advance sends an input to the machine.
+	// The checkpointHash is the machine's root hash before processing the input,
+	// sent along with the request so the machine can revert to it if needed.
 	// It always returns a non-nil AdvanceResponse, even on error paths.
 	// The response contains whether the request was accepted,
 	// the corresponding outputs, reports, and the hash of the outputs.
 	// In case the request is not accepted, the response does not contain outputs.
-	Advance(ctx context.Context, input []byte, computeHashes bool) (*AdvanceResponse, error)
+	Advance(ctx context.Context, input []byte, checkpointHash Hash, computeHashes bool) (*AdvanceResponse, error)
 
 	// Inspect sends a query to the machine.
 	// It returns a boolean indicating whether or not the request was accepted

--- a/pkg/machine/machine_test.go
+++ b/pkg/machine/machine_test.go
@@ -233,7 +233,7 @@ func (s *MachineSuite) TestMachineInterface() {
 	require.Equal(Hash{6, 7, 8, 9, 10}, outputsHash)
 
 	// Test Advance
-	advanceResp, err := machine.Advance(ctx, []byte("input"), false)
+	advanceResp, err := machine.Advance(ctx, []byte("input"), Hash{}, false)
 	require.NoError(err)
 	require.True(advanceResp.Accepted)
 	require.Len(advanceResp.Outputs, 2)
@@ -298,7 +298,7 @@ func (s *MachineSuite) TestMachineInterfaceErrors() {
 	require.Contains(err.Error(), "outputs hash error")
 
 	// Test Advance error
-	_, err = machine.Advance(ctx, []byte("input"), false)
+	_, err = machine.Advance(ctx, []byte("input"), Hash{}, false)
 	require.Error(err)
 	require.Contains(err.Error(), "advance error")
 
@@ -331,8 +331,6 @@ type MockMachine struct {
 
 	OutputsHashProofReturn []Hash
 	OutputsHashProofError  error
-
-	CheckpointHashError error
 
 	AdvanceAcceptedReturn  bool
 	AdvanceOutputsReturn   []Output
@@ -369,11 +367,7 @@ func (m *MockMachine) OutputsHashProof(_ context.Context) ([]Hash, error) {
 	return m.OutputsHashProofReturn, m.OutputsHashProofError
 }
 
-func (m *MockMachine) WriteCheckpointHash(_ context.Context, _ Hash) error {
-	return m.CheckpointHashError
-}
-
-func (m *MockMachine) Advance(_ context.Context, _ []byte, _ bool) (*AdvanceResponse, error) {
+func (m *MockMachine) Advance(_ context.Context, _ []byte, _ Hash, _ bool) (*AdvanceResponse, error) {
 	return &AdvanceResponse{
 		Accepted:        m.AdvanceAcceptedReturn,
 		Outputs:         m.AdvanceOutputsReturn,
@@ -384,9 +378,7 @@ func (m *MockMachine) Advance(_ context.Context, _ []byte, _ bool) (*AdvanceResp
 	}, m.AdvanceError
 }
 
-func (m *MockMachine) Inspect(_ context.Context,
-	_ []byte,
-) (bool, []Report, error) {
+func (m *MockMachine) Inspect(_ context.Context, _ []byte) (bool, []Report, error) {
 	return m.InspectAcceptedReturn, m.InspectReportsReturn, m.InspectError
 }
 

--- a/test/dependencies
+++ b/test/dependencies
@@ -1,2 +1,2 @@
-https://github.com/cartesi/image-kernel/releases/download/v0.20.0/linux-6.5.13-ctsi-1-v0.20.0.bin
-https://github.com/cartesi/machine-guest-tools/releases/download/v0.17.2/rootfs-tools.ext2
+https://github.com/cartesi/machine-linux-image/releases/download/v0.21.0/linux-6.5.13-ctsi-2-v0.21.0.bin
+https://github.com/cartesi/machine-guest-tools/releases/download/v0.18.0/rootfs-tools.ext2

--- a/test/dependencies.sha256
+++ b/test/dependencies.sha256
@@ -1,2 +1,2 @@
-65dd100ff6204346ac2f50f772721358b5c1451450ceb39a154542ee27b4c947  test/downloads/linux-6.5.13-ctsi-1-v0.20.0.bin
-675a49e3c9bada29f25d5b559707b34553b94280c03f44ccb8203c2cf453b541  test/downloads/rootfs-tools.ext2
+5c900060da2db2bfa84cd39cd9cd722988c83c42225f3cac55f2d3157e48f32f  test/downloads/linux-6.5.13-ctsi-2-v0.21.0.bin
+6c159937485c99f695021c4f2ea2a57bdadcf4e4bce8e71af5bee3bb9552802e  test/downloads/rootfs-tools.ext2


### PR DESCRIPTION
Changes:
- header files got renamed
- defines renamed: `CM_CMIO_*` -> `CM_HTIF_*`; `UARCH_HALT_FLAG` -> `UARCH_HALT`
- SendCmioResponse got a new parameter: `revertRootHash`. Checkpoint is now done "automatically" from it.
- Need final versions of dependencies: emulator, rootfs and linux.

bumps:
- machine-emulator: 0.21.0
- machine-guest-tools: 0.18.0
- linux: 6.5.13-ctsi-2-v0.21.0